### PR TITLE
fix(gpu): type terminal websocket payloads

### DIFF
--- a/src/server/api/plugins/gpu-terminal.ts
+++ b/src/server/api/plugins/gpu-terminal.ts
@@ -29,6 +29,20 @@ import {
 import { TokenManager } from '@/lib/license/token-manager';
 
 const log = createLogger('api:gpu-terminal');
+type TerminalMessagePayload = string | Buffer | ArrayBuffer | Buffer[];
+
+function readTerminalMessage(raw: TerminalMessagePayload): string {
+  if (typeof raw === 'string') {
+    return raw;
+  }
+  if (Array.isArray(raw)) {
+    return Buffer.concat(raw).toString('utf8');
+  }
+  if (Buffer.isBuffer(raw)) {
+    return raw.toString('utf8');
+  }
+  return Buffer.from(raw).toString('utf8');
+}
 
 export const gpuTerminalApiPlugin: FastifyPluginAsync = async (app) => {
   await app.register(websocket);
@@ -57,8 +71,8 @@ export const gpuTerminalApiPlugin: FastifyPluginAsync = async (app) => {
         return;
       }
 
-      socket.on('message', (raw) => {
-        forwardFromBrowser(sessionId, raw.toString('utf8'));
+      socket.on('message', (raw: TerminalMessagePayload) => {
+        forwardFromBrowser(sessionId, readTerminalMessage(raw));
       });
       socket.on('close', () => closeSession(sessionId, 'browser-disconnected'));
       socket.on('error', (err) => {
@@ -101,8 +115,8 @@ export const gpuTerminalApiPlugin: FastifyPluginAsync = async (app) => {
         return;
       }
 
-      socket.on('message', (raw) => {
-        forwardFromAgent(sessionId, raw.toString('utf8'));
+      socket.on('message', (raw: TerminalMessagePayload) => {
+        forwardFromAgent(sessionId, readTerminalMessage(raw));
       });
       socket.on('close', () => closeSession(sessionId, 'agent-disconnected'));
       socket.on('error', (err) => {


### PR DESCRIPTION
## Summary
- type the GPU terminal websocket message payload explicitly so Next/Docker builds do not fail on an implicit `any`
- normalize websocket payloads through a small helper instead of relying on ad hoc `toString` calls
- address the production deploy failure seen immediately after tagging `v1.2.2`

## Validation
- rm -rf .next && npm run build

## Notes
- local Docker daemon was unavailable, so the matching builder-stage validation could not be run locally
- production tag `v1.2.2` failed in GitHub Actions because of this exact type error in `src/server/api/plugins/gpu-terminal.ts`