### PR TITLE
fix(gpu): type websocket error callbacks

### DIFF
--- a/src/server/api/plugins/gpu-terminal.ts
+++ b/src/server/api/plugins/gpu-terminal.ts
@@ -75,7 +75,7 @@ export const gpuTerminalApiPlugin: FastifyPluginAsync = async (app) => {
         forwardFromBrowser(sessionId, readTerminalMessage(raw));
       });
       socket.on('close', () => closeSession(sessionId, 'browser-disconnected'));
-      socket.on('error', (err) => {
+      socket.on('error', (err: Error) => {
         log.warn('browser ws error', { sessionId, error: err.message });
         closeSession(sessionId, 'browser-error');
       });
@@ -119,7 +119,7 @@ export const gpuTerminalApiPlugin: FastifyPluginAsync = async (app) => {
         forwardFromAgent(sessionId, readTerminalMessage(raw));
       });
       socket.on('close', () => closeSession(sessionId, 'agent-disconnected'));
-      socket.on('error', (err) => {
+      socket.on('error', (err: Error) => {
         log.warn('agent ws error', { sessionId, error: err.message });
         closeSession(sessionId, 'agent-error');
       });


### PR DESCRIPTION
## Summary
- type the GPU terminal websocket error callbacks explicitly so Next/Docker builds do not fail on implicit `any`
- address the production deploy failure seen immediately after tagging `v1.2.3`
- keep the earlier websocket payload typing fix intact and complete the remaining callback typing in the same file

## Validation
- rm -rf .next && npm run build

## Notes
- production tag `v1.2.3` failed in GitHub Actions because of an implicit `any` on the websocket `error` callback in `src/server/api/plugins/gpu-terminal.ts`