### PR TITLE
chore(ci): align docker build with lockfile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,9 @@ jobs:
       - name: Build
         run: npm run build
 
+      - name: Docker builder parity
+        run: docker build --target builder .
+
       - name: Build docs
         run: npm run docs:build
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM node:22 AS deps
 WORKDIR /app
 ENV NEXT_TELEMETRY_DISABLED=1
 COPY package.json package-lock.json* npm-shrinkwrap.json* ./
-RUN npm install --no-audit --no-fund
+RUN npm ci --no-audit --no-fund
 
 # --------------------- builder stage ---------------------
 FROM node:22 AS builder

--- a/src/server/api/plugins/gpu-terminal.ts
+++ b/src/server/api/plugins/gpu-terminal.ts
@@ -75,7 +75,7 @@ export const gpuTerminalApiPlugin: FastifyPluginAsync = async (app) => {
         forwardFromBrowser(sessionId, readTerminalMessage(raw));
       });
       socket.on('close', () => closeSession(sessionId, 'browser-disconnected'));
-      socket.on('error', (err) => {
+      socket.on('error', (err: Error) => {
         log.warn('browser ws error', { sessionId, error: err.message });
         closeSession(sessionId, 'browser-error');
       });
@@ -119,7 +119,7 @@ export const gpuTerminalApiPlugin: FastifyPluginAsync = async (app) => {
         forwardFromAgent(sessionId, readTerminalMessage(raw));
       });
       socket.on('close', () => closeSession(sessionId, 'agent-disconnected'));
-      socket.on('error', (err) => {
+      socket.on('error', (err: Error) => {
         log.warn('agent ws error', { sessionId, error: err.message });
         closeSession(sessionId, 'agent-error');
       });


### PR DESCRIPTION
## Summary
- switch the deploy Dockerfile deps stage from `npm install` to `npm ci` so container builds follow the committed lockfile exactly
- add a PR CI parity step with `docker build --target builder .` so the same builder path used by deploy is exercised before merge and tagging
- standardize the build path to catch local-vs-container dependency drift before production tags are cut

## Validation
- rm -rf .next && npm run build
- npx prettier --check .github/workflows/ci.yml

## Notes
- local Docker daemon was unavailable on this machine, so the new parity path could not be executed locally here
- the point of this PR is to make GitHub PR CI run that exact Docker builder path for us before merge