### PR TITLE
fix: unblock enterprise overlay release

### DIFF
--- a/src/__tests__/api/crawler-routes.test.ts
+++ b/src/__tests__/api/crawler-routes.test.ts
@@ -152,7 +152,7 @@ describe('GET /api/crawler/jobs and /jobs/:id/results return id + status on the 
       method: 'POST',
       url: `/api/crawler/crawlers/${crawler.key}/crawl`,
       headers: { ...REQUEST_HEADERS, 'content-type': 'application/json' },
-      payload: JSON.stringify({ urls: [originUrl] }),
+      payload: JSON.stringify({ urls: [originUrl], mode: 'sync' }),
     });
     expect(crawlRes.statusCode).toBe(202);
     const { jobId } = parseJsonBody<{ jobId: string; status: string }>(crawlRes.body);

--- a/src/__tests__/unit/guardrail-service.test.ts
+++ b/src/__tests__/unit/guardrail-service.test.ts
@@ -50,6 +50,7 @@ function makeGuardrail(overrides: Partial<IGuardrail> = {}): IGuardrail {
     key: 'my-guardrail',
     name: 'My Guardrail',
     type: 'preset',
+    target: 'input',
     action: 'block',
     enabled: true,
     createdBy: USER_ID,

--- a/src/lib/database/provider/types.domain.ts
+++ b/src/lib/database/provider/types.domain.ts
@@ -3,6 +3,7 @@ import type { ObjectId } from 'mongodb';
 // ── Guardrail types ────────────────────────────────────────────────────────
 
 export type GuardrailType = 'preset' | 'custom';
+export type GuardrailTarget = 'input' | 'output';
 export type GuardrailAction = 'block' | 'warn' | 'flag';
 
 export interface IGuardrailPiiPolicy {
@@ -37,6 +38,7 @@ export interface IGuardrail {
   name: string;
   description?: string;
   type: GuardrailType;
+  target: GuardrailTarget;
   action: GuardrailAction;
   enabled: boolean;
   modelKey?: string;

--- a/src/lib/database/sqlite/evaluation.mixin.ts
+++ b/src/lib/database/sqlite/evaluation.mixin.ts
@@ -348,7 +348,7 @@ export function EvaluationMixin<TBase extends Constructor<SQLiteProviderBase>>(B
     async findEvaluationRunById(id: string): Promise<IEvaluationRun | null> {
       const db = this.getTenantDb();
       const row = db.prepare(`SELECT * FROM ${TABLES.evaluationRuns} WHERE id = @id`).get({ id }) as SqliteRow | undefined;
-      return row ? this.mapRunRow(row) : null;
+      return row ? this.mapEvaluationRunRow(row) : null;
     }
 
     async listEvaluationRuns(filters?: { projectId?: string; suiteKey?: string; status?: EvaluationRunStatus; limit?: number; skip?: number }): Promise<IEvaluationRun[]> {
@@ -364,7 +364,7 @@ export function EvaluationMixin<TBase extends Constructor<SQLiteProviderBase>>(B
       const rows = db.prepare(
         `SELECT * FROM ${TABLES.evaluationRuns} ${where} ORDER BY createdAt DESC LIMIT ${limit} OFFSET ${skip}`,
       ).all(params) as SqliteRow[];
-      return rows.map((r) => this.mapRunRow(r));
+      return rows.map((r) => this.mapEvaluationRunRow(r));
     }
 
     // ── Row mappers ──────────────────────────────────────────────────
@@ -429,7 +429,7 @@ export function EvaluationMixin<TBase extends Constructor<SQLiteProviderBase>>(B
       };
     }
 
-    protected mapRunRow(r: SqliteRow): IEvaluationRun {
+    protected mapEvaluationRunRow(r: SqliteRow): IEvaluationRun {
       const aggregate = this.parseJson<IEvaluationRunAggregate | null>(r.aggregate, null);
       return {
         _id: r.id as string,

--- a/src/lib/database/sqlite/guardrail.mixin.ts
+++ b/src/lib/database/sqlite/guardrail.mixin.ts
@@ -22,9 +22,9 @@ export function GuardrailMixin<TBase extends Constructor<SQLiteProviderBase>>(Ba
       db.prepare(`
         INSERT INTO ${TABLES.guardrails}
         (id, tenantId, projectId, key, name, description, type, action, enabled,
-         modelKey, policy, customPrompt, metadata, createdBy, updatedBy, createdAt, updatedAt)
+          target, modelKey, policy, customPrompt, metadata, createdBy, updatedBy, createdAt, updatedAt)
         VALUES (@id, @tenantId, @projectId, @key, @name, @description, @type, @action, @enabled,
-         @modelKey, @policy, @customPrompt, @metadata, @createdBy, @updatedBy, @createdAt, @updatedAt)
+          @target, @modelKey, @policy, @customPrompt, @metadata, @createdBy, @updatedBy, @createdAt, @updatedAt)
       `).run({
         id,
         tenantId: guardrail.tenantId,
@@ -35,6 +35,7 @@ export function GuardrailMixin<TBase extends Constructor<SQLiteProviderBase>>(Ba
         type: guardrail.type,
         action: guardrail.action,
         enabled: this.toBoolInt(guardrail.enabled),
+        target: guardrail.target,
         modelKey: guardrail.modelKey ?? null,
         policy: this.toJson(guardrail.policy ?? {}),
         customPrompt: guardrail.customPrompt ?? null,
@@ -60,6 +61,7 @@ export function GuardrailMixin<TBase extends Constructor<SQLiteProviderBase>>(Ba
       if (data.name !== undefined) { sets.push('name = @name'); params.name = data.name; }
       if (data.description !== undefined) { sets.push('description = @description'); params.description = data.description; }
       if (data.type !== undefined) { sets.push('type = @type'); params.type = data.type; }
+      if (data.target !== undefined) { sets.push('target = @target'); params.target = data.target; }
       if (data.action !== undefined) { sets.push('action = @action'); params.action = data.action; }
       if (data.enabled !== undefined) { sets.push('enabled = @enabled'); params.enabled = this.toBoolInt(data.enabled); }
       if (data.modelKey !== undefined) { sets.push('modelKey = @modelKey'); params.modelKey = data.modelKey; }
@@ -228,6 +230,7 @@ export function GuardrailMixin<TBase extends Constructor<SQLiteProviderBase>>(Ba
         name: r.name as string,
         description: r.description as string | undefined,
         type: r.type as IGuardrail['type'],
+        target: r.target as IGuardrail['target'],
         action: r.action as IGuardrail['action'],
         enabled: this.fromBoolInt(r.enabled),
         modelKey: r.modelKey as string | undefined,

--- a/src/lib/database/sqlite/redteam.mixin.ts
+++ b/src/lib/database/sqlite/redteam.mixin.ts
@@ -178,7 +178,7 @@ export function RedTeamMixin<TBase extends Constructor<SQLiteProviderBase>>(Base
     async findRedTeamRunById(id: string): Promise<IRedTeamRun | null> {
       const db = this.getTenantDb();
       const row = db.prepare(`SELECT * FROM ${TABLES.redTeamRuns} WHERE id = @id`).get({ id }) as SqliteRow | undefined;
-      return row ? this.mapRunRow(row) : null;
+      return row ? this.mapRedTeamRunRow(row) : null;
     }
 
     async listRedTeamRuns(filters?: { projectId?: string; campaignKey?: string; status?: RedTeamRunStatus; limit?: number; skip?: number }): Promise<IRedTeamRun[]> {
@@ -194,7 +194,7 @@ export function RedTeamMixin<TBase extends Constructor<SQLiteProviderBase>>(Base
       const rows = db.prepare(
         `SELECT * FROM ${TABLES.redTeamRuns} ${where} ORDER BY createdAt DESC LIMIT ${limit} OFFSET ${skip}`,
       ).all(params) as SqliteRow[];
-      return rows.map((r) => this.mapRunRow(r));
+      return rows.map((r) => this.mapRedTeamRunRow(r));
     }
 
     // ── Row mappers ──────────────────────────────────────────────────
@@ -223,7 +223,7 @@ export function RedTeamMixin<TBase extends Constructor<SQLiteProviderBase>>(Base
       };
     }
 
-    protected mapRunRow(r: SqliteRow): IRedTeamRun {
+    protected mapRedTeamRunRow(r: SqliteRow): IRedTeamRun {
       const aggregate = this.parseJson<IRedTeamAggregate | null>(r.aggregate, null);
       return {
         _id: r.id as string,

--- a/src/lib/license/enterprise-access.ts
+++ b/src/lib/license/enterprise-access.ts
@@ -97,8 +97,8 @@ export function checkEnterpriseApiAccess(
   if (!getConfig().license.enforceLicense) {
     return null;
   }
-  const module = getEnterpriseModuleForPath(pathname);
-  if (!module) {
+  const enterpriseModule = getEnterpriseModuleForPath(pathname);
+  if (!enterpriseModule) {
     return null;
   }
   // buildSessionHeaders already collapses an expired license to FREE, so the
@@ -114,8 +114,8 @@ export function checkEnterpriseApiAccess(
     status: 402,
     body: {
       error: 'Payment Required',
-      message: `The "${module}" module requires an active ENTERPRISE license.`,
-      module,
+      message: `The "${enterpriseModule}" module requires an active ENTERPRISE license.`,
+      module: enterpriseModule,
       requiresEnterprise: true,
     },
   };

--- a/src/lib/services/guardrail/guardrailService.ts
+++ b/src/lib/services/guardrail/guardrailService.ts
@@ -112,6 +112,7 @@ export async function createGuardrail(
     name: input.name,
     description: input.description,
     type: input.type,
+    target: input.target ?? 'input',
     action: input.action,
     enabled: input.enabled ?? true,
     modelKey: input.modelKey,

--- a/src/lib/services/guardrail/types.ts
+++ b/src/lib/services/guardrail/types.ts
@@ -184,6 +184,7 @@ export interface CreateGuardrailInput {
   name: string;
   description?: string;
   type: GuardrailType;
+  target?: IGuardrail['target'];
   action: GuardrailAction;
   enabled?: boolean;
   modelKey?: string;
@@ -210,6 +211,7 @@ export interface GuardrailView {
   name: string;
   description?: string;
   type: GuardrailType;
+  target: IGuardrail['target'];
   action: GuardrailAction;
   enabled: boolean;
   modelKey?: string;

--- a/src/server/api/routes/guardrails/route.ts
+++ b/src/server/api/routes/guardrails/route.ts
@@ -12,6 +12,7 @@ import type { GuardrailType, GuardrailAction } from '@/lib/database';
 import { createLogger } from '@/lib/core/logger';
 
 const logger = createLogger('guardrails');
+const validTargets = ['input', 'output'] as const;
 
 export async function GET(request: NextRequest) {
   try {
@@ -101,6 +102,10 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'action must be "block", "warn", or "flag"' }, { status: 400 });
     }
 
+    if (body.target && !validTargets.includes(body.target)) {
+      return NextResponse.json({ error: 'target must be "input" or "output"' }, { status: 400 });
+    }
+
     if (body.type === 'custom' && (!body.customPrompt || !body.customPrompt.trim())) {
       return NextResponse.json({ error: 'customPrompt is required for custom guardrails' }, { status: 400 });
     }
@@ -109,6 +114,7 @@ export async function POST(request: NextRequest) {
       name: body.name.trim(),
       description: body.description?.trim(),
       type: body.type,
+      target: body.target ?? 'input',
       action: body.action ?? 'block',
       enabled: body.enabled ?? true,
       modelKey: body.modelKey,

--- a/src/server/api/types.ts
+++ b/src/server/api/types.ts
@@ -30,18 +30,6 @@ declare module 'fastify' {
     apiTokenContext?: ApiTokenContext;
     rbacUser?: IUser;
   }
-
-  interface FastifyReply {
-    setCookie(
-      name: string,
-      value: string,
-      options?: CookieMutation['options'],
-    ): FastifyReply;
-    clearCookie(
-      name: string,
-      options?: CookieMutation['options'],
-    ): FastifyReply;
-  }
 }
 
 export type RouteInvocation = (


### PR DESCRIPTION
## Summary
- remove duplicate FastifyReply cookie augmentation now provided by @fastify/cookie
- rename local enterprise access variable to avoid Next.js no-assign-module-variable lint

## Validation
- community: npm ci, ./node_modules/.bin/tsc --noEmit, npm run build
- enterprise overlay: npm ci, npx tsc --noEmit, npm run build
- reproduced v1.2.4 overlay failure before the release fix