### PR TITLE
fix(build): mark ldapts as a server-external package

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -26,6 +26,10 @@ const nextConfig: NextConfig = {
     'pg',
     '@orama/orama',
     'mongodb',
+    // Server-only LDAP client (enterprise LDAP integration). Node-only deps;
+    // keep it out of the Next.js bundle so `next build` doesn't try to resolve
+    // it (it is imported only by the enterprise overlay's auth plugin).
+    'ldapts',
   ],
   turbopack: {
     root: path.resolve(process.cwd(), '..'),


### PR DESCRIPTION
## Why
The enterprise build (`overlay-apply` + `next build`) failed with **`Module not found: Can't resolve 'ldapts'`** — Next.js tried to bundle the LDAP client.

## Fix
`ldapts` is a **server-only Node module** (imported only by the enterprise overlay's auth plugin/authenticator), so add it to `serverExternalPackages` alongside the other server-only drivers (`mongodb`, `pg`, `ioredis`, vector SDKs, …).

## Verification
Enterprise `next build` (overlay tree) now **compiles successfully (exit 0)**, zero `Module not found` errors.

Follow-up to #149 / console-ee#10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)