### PR TITLE
feat(groups): activate tenant+project user groups with RBAC union

### DIFF
--- a/src/__tests__/api/groups.test.ts
+++ b/src/__tests__/api/groups.test.ts
@@ -1,0 +1,205 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createMockDb } from '../helpers/db.mock';
+
+vi.mock('@/lib/database', () => ({ getDatabase: vi.fn() }));
+
+import { getDatabase } from '@/lib/database';
+import { groupsApiPlugin } from '@/server/api/plugins/groups';
+import { createFastifyApiTestApp, parseJsonBody } from '../helpers/fastify-api';
+
+const adminHeaders = {
+  'x-license-type': 'FREE',
+  'x-tenant-db-name': 'tenant_acme',
+  'x-tenant-id': 'tenant-1',
+  'x-tenant-slug': 'acme',
+  'x-user-id': 'admin-1',
+  'x-user-role': 'admin',
+};
+
+const userHeaders = { ...adminHeaders, 'x-user-id': 'user-2', 'x-user-role': 'user' };
+
+function makeGroup(over: Record<string, unknown> = {}) {
+  return {
+    _id: 'grp-1',
+    tenantId: 'tenant-1',
+    name: 'Engineers',
+    description: null,
+    tenantRole: null,
+    servicePermissions: {},
+    source: 'local',
+    externalId: null,
+    createdBy: 'admin-1',
+    ...over,
+  };
+}
+
+describe('groups API', () => {
+  let app: Awaited<ReturnType<typeof createFastifyApiTestApp>>;
+  let db: ReturnType<typeof createMockDb>;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    db = createMockDb();
+    (getDatabase as ReturnType<typeof vi.fn>).mockResolvedValue(db);
+    // The RBAC gate (members service) loads the caller via findUserById; the
+    // handlers also look up target users. Resolve known ids, null otherwise.
+    db.findUserById.mockImplementation((async (id: string) => {
+      const map: Record<string, unknown> = {
+        'admin-1': { _id: 'admin-1', role: 'admin', tenantId: 'tenant-1' },
+        'user-2': { _id: 'user-2', role: 'user', tenantId: 'tenant-1' },
+        u9: { _id: 'u9', role: 'user', tenantId: 'tenant-1' },
+      };
+      return map[id] ?? null;
+    }) as never);
+    db.listGroupMembersByUser.mockResolvedValue([] as never);
+    app = await createFastifyApiTestApp(groupsApiPlugin);
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  describe('authorization', () => {
+    it('forbids non-admins from listing groups', async () => {
+      const res = await app.inject({ method: 'GET', url: '/api/groups', headers: userHeaders });
+      expect(res.statusCode).toBe(403);
+    });
+
+    it('forbids non-admins from creating groups', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/groups',
+        headers: { ...userHeaders, 'content-type': 'application/json' },
+        payload: JSON.stringify({ name: 'X' }),
+      });
+      expect(res.statusCode).toBe(403);
+    });
+  });
+
+  describe('GET /api/groups', () => {
+    it('lists groups with member/project counts', async () => {
+      db.listGroups.mockResolvedValue([makeGroup()] as never);
+      db.listGroupMembers.mockResolvedValue([{ userId: 'u1' }, { userId: 'u2' }] as never);
+      db.listGroupProjectsByGroup.mockResolvedValue([{ projectId: 'p1' }] as never);
+
+      const res = await app.inject({ method: 'GET', url: '/api/groups', headers: adminHeaders });
+      expect(res.statusCode).toBe(200);
+      const body = parseJsonBody<{ groups: Array<{ memberCount: number; projectCount: number }> }>(res.body);
+      expect(body.groups).toHaveLength(1);
+      expect(body.groups[0].memberCount).toBe(2);
+      expect(body.groups[0].projectCount).toBe(1);
+    });
+  });
+
+  describe('POST /api/groups', () => {
+    it('requires a name', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/groups',
+        headers: { ...adminHeaders, 'content-type': 'application/json' },
+        payload: JSON.stringify({ name: '   ' }),
+      });
+      expect(res.statusCode).toBe(400);
+    });
+
+    it('rejects an owner tenantRole grant', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/groups',
+        headers: { ...adminHeaders, 'content-type': 'application/json' },
+        payload: JSON.stringify({ name: 'X', tenantRole: 'owner' }),
+      });
+      expect(res.statusCode).toBe(400);
+    });
+
+    it('creates a group with a tenantRole grant', async () => {
+      db.createGroup.mockImplementation(async (g) => makeGroup({ ...g, _id: 'grp-new' }) as never);
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/groups',
+        headers: { ...adminHeaders, 'content-type': 'application/json' },
+        payload: JSON.stringify({ name: 'Admins', tenantRole: 'admin', servicePermissions: { audit: 'read' } }),
+      });
+      expect(res.statusCode).toBe(201);
+      expect(db.createGroup).toHaveBeenCalledWith(
+        expect.objectContaining({ name: 'Admins', tenantRole: 'admin', source: 'local', tenantId: 'tenant-1' }),
+      );
+    });
+  });
+
+  describe('membership', () => {
+    it('adds a member to a local group', async () => {
+      db.findGroupById.mockResolvedValue(makeGroup() as never);
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/groups/grp-1/members',
+        headers: { ...adminHeaders, 'content-type': 'application/json' },
+        payload: JSON.stringify({ userId: 'u9' }),
+      });
+      expect(res.statusCode).toBe(201);
+      expect(db.addGroupMember).toHaveBeenCalledWith(
+        expect.objectContaining({ groupId: 'grp-1', userId: 'u9', source: 'local' }),
+      );
+    });
+
+    it('refuses membership edits on an LDAP-synced group', async () => {
+      db.findGroupById.mockResolvedValue(makeGroup({ source: 'ldap', externalId: 'cn=eng' }) as never);
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/groups/grp-1/members',
+        headers: { ...adminHeaders, 'content-type': 'application/json' },
+        payload: JSON.stringify({ userId: 'u9' }),
+      });
+      expect(res.statusCode).toBe(409);
+      expect(db.addGroupMember).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('DELETE /api/groups/:id', () => {
+    it('cascades member + project cleanup for local groups', async () => {
+      db.findGroupById.mockResolvedValue(makeGroup() as never);
+      const res = await app.inject({ method: 'DELETE', url: '/api/groups/grp-1', headers: adminHeaders });
+      expect(res.statusCode).toBe(200);
+      expect(db.deleteGroupMembersByGroup).toHaveBeenCalledWith('grp-1');
+      expect(db.deleteGroupProjectsByGroup).toHaveBeenCalledWith('grp-1');
+      expect(db.deleteGroup).toHaveBeenCalledWith('grp-1');
+    });
+
+    it('refuses to delete an LDAP-synced group', async () => {
+      db.findGroupById.mockResolvedValue(makeGroup({ source: 'ldap' }) as never);
+      const res = await app.inject({ method: 'DELETE', url: '/api/groups/grp-1', headers: adminHeaders });
+      expect(res.statusCode).toBe(409);
+      expect(db.deleteGroup).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('project assignment', () => {
+    it('assigns a project to a group', async () => {
+      db.findGroupById.mockResolvedValue(makeGroup() as never);
+      db.findProjectById.mockResolvedValue({ _id: 'p1', tenantId: 'tenant-1', name: 'Proj' } as never);
+      db.upsertGroupProject.mockResolvedValue({ projectId: 'p1', role: 'project_admin', servicePermissions: {} } as never);
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/groups/grp-1/projects',
+        headers: { ...adminHeaders, 'content-type': 'application/json' },
+        payload: JSON.stringify({ projectId: 'p1', role: 'project_admin' }),
+      });
+      expect(res.statusCode).toBe(201);
+      expect(db.upsertGroupProject).toHaveBeenCalledWith(
+        expect.objectContaining({ groupId: 'grp-1', projectId: 'p1', role: 'project_admin' }),
+      );
+    });
+
+    it('404s when the project does not exist', async () => {
+      db.findGroupById.mockResolvedValue(makeGroup() as never);
+      db.findProjectById.mockResolvedValue(null as never);
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/groups/grp-1/projects',
+        headers: { ...adminHeaders, 'content-type': 'application/json' },
+        payload: JSON.stringify({ projectId: 'nope' }),
+      });
+      expect(res.statusCode).toBe(404);
+    });
+  });
+});

--- a/src/__tests__/integration/groups-db.test.ts
+++ b/src/__tests__/integration/groups-db.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Integration test for the user-group data layer against a real SQLite tenant DB.
+ *
+ * Exercises the group schema extensions (tenantRole, servicePermissions, source,
+ * externalId), membership with provenance, project assignment, external-id lookup
+ * used by LDAP sync, and the cascade-delete helpers.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+const tmpRoot = mkdtempSync(path.join(tmpdir(), 'cognipeer-groups-db-'));
+process.env.DB_PROVIDER = 'sqlite';
+process.env.SQLITE_DATA_DIR = tmpRoot;
+process.env.MAIN_DB_NAME = 'groups_db_main';
+
+import { reloadConfig } from '@/lib/core/config';
+import { disconnectDatabase, getDatabase } from '@/lib/database';
+
+const TENANT_DB_NAME = 'groups_db_tenant';
+const TENANT_ID = 'tenant-groups-db';
+
+beforeAll(() => {
+  reloadConfig();
+});
+
+afterAll(async () => {
+  await disconnectDatabase();
+  rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+describe('groups data layer (sqlite)', () => {
+  it('round-trips a group with tenant-level grants', async () => {
+    const db = await getDatabase();
+    await db.switchToTenant(TENANT_DB_NAME);
+
+    const created = await db.createGroup({
+      tenantId: TENANT_ID,
+      name: 'Platform Admins',
+      description: 'Tenant admins via group',
+      tenantRole: 'admin',
+      servicePermissions: { audit: 'read', config: 'admin' },
+      source: 'local',
+      createdBy: 'owner-1',
+    });
+
+    const loaded = await db.findGroupById(String(created._id));
+    expect(loaded).not.toBeNull();
+    expect(loaded!.name).toBe('Platform Admins');
+    expect(loaded!.tenantRole).toBe('admin');
+    expect(loaded!.servicePermissions).toEqual({ audit: 'read', config: 'admin' });
+    expect(loaded!.source).toBe('local');
+  });
+
+  it('looks up a directory-sourced group by external id (LDAP sync path)', async () => {
+    const db = await getDatabase();
+    await db.switchToTenant(TENANT_DB_NAME);
+
+    const dn = 'cn=engineers,ou=groups,dc=example,dc=org';
+    await db.createGroup({
+      tenantId: TENANT_ID,
+      name: 'Engineers',
+      source: 'ldap',
+      externalId: dn,
+      createdBy: 'ldap-sync',
+    });
+
+    const found = await db.findGroupByExternalId(dn);
+    expect(found).not.toBeNull();
+    expect(found!.name).toBe('Engineers');
+    expect(found!.source).toBe('ldap');
+    expect(await db.findGroupByExternalId('cn=missing')).toBeNull();
+  });
+
+  it('tracks membership provenance and lists by user', async () => {
+    const db = await getDatabase();
+    await db.switchToTenant(TENANT_DB_NAME);
+
+    const group = await db.createGroup({
+      tenantId: TENANT_ID, name: 'Squad A', source: 'local', createdBy: 'owner-1',
+    });
+    const groupId = String(group._id);
+
+    await db.addGroupMember({ tenantId: TENANT_ID, groupId, userId: 'u-local', role: 'member', source: 'local' });
+    await db.addGroupMember({ tenantId: TENANT_ID, groupId, userId: 'u-ldap', role: 'member', source: 'ldap' });
+
+    const members = await db.listGroupMembers(groupId);
+    expect(members).toHaveLength(2);
+    const bySource = Object.fromEntries(members.map((m) => [m.userId, m.source]));
+    expect(bySource['u-local']).toBe('local');
+    expect(bySource['u-ldap']).toBe('ldap');
+
+    const byUser = await db.listGroupMembersByUser('u-ldap');
+    expect(byUser).toHaveLength(1);
+    expect(byUser[0].groupId).toBe(groupId);
+  });
+
+  it('assigns projects to a group and lists them by group', async () => {
+    const db = await getDatabase();
+    await db.switchToTenant(TENANT_DB_NAME);
+
+    const group = await db.createGroup({
+      tenantId: TENANT_ID, name: 'Squad B', source: 'local', createdBy: 'owner-1',
+    });
+    const groupId = String(group._id);
+
+    await db.upsertGroupProject({
+      tenantId: TENANT_ID, groupId, projectId: 'proj-1', role: 'project_admin', servicePermissions: { models: 'write' },
+    });
+
+    const byGroup = await db.listGroupProjectsByGroup(groupId);
+    expect(byGroup).toHaveLength(1);
+    expect(byGroup[0].role).toBe('project_admin');
+    expect(byGroup[0].servicePermissions).toEqual({ models: 'write' });
+
+    const byProject = await db.listGroupProjectsByProject('proj-1');
+    expect(byProject.some((gp) => String(gp.groupId) === groupId)).toBe(true);
+  });
+
+  it('cascade helpers remove members and project assignments', async () => {
+    const db = await getDatabase();
+    await db.switchToTenant(TENANT_DB_NAME);
+
+    const group = await db.createGroup({
+      tenantId: TENANT_ID, name: 'Squad C', source: 'local', createdBy: 'owner-1',
+    });
+    const groupId = String(group._id);
+    await db.addGroupMember({ tenantId: TENANT_ID, groupId, userId: 'm1', role: 'member' });
+    await db.upsertGroupProject({ tenantId: TENANT_ID, groupId, projectId: 'proj-c', role: 'member' });
+
+    await db.deleteGroupMembersByGroup(groupId);
+    await db.deleteGroupProjectsByGroup(groupId);
+    await db.deleteGroup(groupId);
+
+    expect(await db.listGroupMembers(groupId)).toHaveLength(0);
+    expect(await db.listGroupProjectsByGroup(groupId)).toHaveLength(0);
+    expect(await db.findGroupById(groupId)).toBeNull();
+  });
+});
+
+describe('user identity provenance (sqlite)', () => {
+  it('persists authProvider + externalId for directory-provisioned users', async () => {
+    const db = await getDatabase();
+    await db.switchToTenant(TENANT_DB_NAME);
+
+    const created = await db.createUser({
+      email: 'ldapuser@example.org',
+      name: 'LDAP User',
+      password: 'ldap:placeholder',
+      role: 'admin',
+      tenantId: TENANT_ID,
+      licenseId: 'lic_ent',
+      features: [],
+      authProvider: 'ldap',
+      externalId: 'uid=ldapuser,ou=people,dc=example,dc=org',
+    });
+
+    const byId = await db.findUserById(String(created._id));
+    expect(byId!.authProvider).toBe('ldap');
+    expect(byId!.externalId).toBe('uid=ldapuser,ou=people,dc=example,dc=org');
+
+    const byEmail = await db.findUserByEmail('ldapuser@example.org');
+    expect(byEmail!.authProvider).toBe('ldap');
+
+    // Local users default to 'local'.
+    const local = await db.createUser({
+      email: 'localuser@example.org', name: 'Local', password: 'x', role: 'user',
+      tenantId: TENANT_ID, licenseId: 'FREE', features: [],
+    });
+    expect((await db.findUserById(String(local._id)))!.authProvider).toBe('local');
+  });
+});

--- a/src/__tests__/unit/rbac.test.ts
+++ b/src/__tests__/unit/rbac.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import {
   authorizeServiceRequest,
+  getEffectiveServicePermissionWithGroups,
   getPermissionServiceForPath,
+  mergeServicePermissions,
   normalizeServicePermissions,
 } from '@/lib/security/rbac';
 
@@ -36,5 +38,51 @@ describe('RBAC authorization', () => {
   it('normalizes invalid service permissions out', () => {
     expect(normalizeServicePermissions({ models: 'read', unknown: 'admin', audit: 'invalid' }))
       .toEqual({ models: 'read' });
+  });
+});
+
+describe('RBAC group-inherited permissions', () => {
+  it('raises a plain user to admin on an admin service via a group tenantRole', () => {
+    const user = { role: 'user' as const };
+    // Without groups: denied admin service.
+    expect(getEffectiveServicePermissionWithGroups(user, [], 'audit')).toBe('none');
+    // In an admin-granting group: allowed.
+    expect(getEffectiveServicePermissionWithGroups(user, [{ tenantRole: 'admin' }], 'audit')).toBe('admin');
+  });
+
+  it('grants a specific service through a group servicePermissions override', () => {
+    const user = { role: 'user' as const };
+    const grants = [{ servicePermissions: { audit: 'read' as const } }];
+    expect(getEffectiveServicePermissionWithGroups(user, grants, 'audit')).toBe('read');
+    // Unrelated admin service stays denied.
+    expect(getEffectiveServicePermissionWithGroups(user, grants, 'license')).toBe('none');
+  });
+
+  it('never lowers a user below their own access', () => {
+    const user = { role: 'admin' as const };
+    // A weak group grant cannot demote an admin.
+    expect(getEffectiveServicePermissionWithGroups(user, [{ tenantRole: 'user' }], 'audit')).toBe('admin');
+  });
+
+  it('authorizeServiceRequest honours group grants', () => {
+    const denied = authorizeServiceRequest({ role: 'user' }, 'GET', '/api/audit/logs');
+    expect(denied.allowed).toBe(false);
+
+    const allowed = authorizeServiceRequest(
+      { role: 'user' },
+      'GET',
+      '/api/audit/logs',
+      [{ tenantRole: 'admin' }],
+    );
+    expect(allowed.allowed).toBe(true);
+  });
+
+  it('merges service permission maps keeping the highest level', () => {
+    expect(mergeServicePermissions([
+      { models: 'read', audit: 'read' },
+      { models: 'admin' },
+      null,
+      { audit: 'none' },
+    ])).toEqual({ models: 'admin', audit: 'read' });
   });
 });

--- a/src/app/dashboard/members/page.tsx
+++ b/src/app/dashboard/members/page.tsx
@@ -1,11 +1,16 @@
 'use client';
 
+import { useState } from 'react';
+import { Tabs } from '@mantine/core';
+import { IconUsers, IconUsersGroup } from '@tabler/icons-react';
 import PageContainer, { PageHeader } from '@/components/common/ui/PageContainer';
 import UserManagement from '@/components/settings/UserManagement';
+import GroupManagement from '@/components/settings/GroupManagement';
 import { useTranslations } from '@/lib/i18n';
 
 export default function MembersPage() {
   const t = useTranslations('navigation');
+  const [tab, setTab] = useState<string | null>('users');
 
   return (
     <PageContainer>
@@ -14,7 +19,22 @@ export default function MembersPage() {
         title={t('members')}
         subtitle={t('membersDescription')}
       />
-      <UserManagement />
+      <Tabs value={tab} onChange={setTab} keepMounted={false}>
+        <Tabs.List mb="md">
+          <Tabs.Tab value="users" leftSection={<IconUsers size={15} />}>
+            Users
+          </Tabs.Tab>
+          <Tabs.Tab value="groups" leftSection={<IconUsersGroup size={15} />}>
+            Groups
+          </Tabs.Tab>
+        </Tabs.List>
+        <Tabs.Panel value="users">
+          <UserManagement />
+        </Tabs.Panel>
+        <Tabs.Panel value="groups">
+          <GroupManagement />
+        </Tabs.Panel>
+      </Tabs>
     </PageContainer>
   );
 }

--- a/src/components/settings/GroupManagement.tsx
+++ b/src/components/settings/GroupManagement.tsx
@@ -1,0 +1,562 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Badge, Button, Group, Modal, Select, Stack, Text, TextInput, Textarea } from '@mantine/core';
+import { IconFolders, IconPlus, IconShieldCheck, IconTrash, IconUsers } from '@tabler/icons-react';
+import { notifications } from '@mantine/notifications';
+import type { PermissionService, ServicePermissionLevel, UserServicePermissions } from '@/lib/security/rbac';
+import DataGrid, { type DataGridColumn } from '@/components/common/ui/DataGrid';
+
+interface GroupRow {
+  _id: string;
+  name: string;
+  description: string | null;
+  tenantRole: 'admin' | 'project_admin' | 'user' | null;
+  servicePermissions?: UserServicePermissions;
+  source: 'local' | 'ldap';
+  memberCount?: number;
+  projectCount?: number;
+}
+
+interface GroupMember {
+  userId: string;
+  name: string | null;
+  email: string | null;
+  role: 'admin' | 'member';
+  source: 'local' | 'ldap';
+}
+
+interface GroupProjectAssignment {
+  projectId: string;
+  role: 'member' | 'project_admin';
+  servicePermissions: UserServicePermissions;
+}
+
+interface TenantUser {
+  _id: string;
+  name: string;
+  email: string;
+}
+
+interface ProjectOption {
+  _id: string;
+  name: string;
+}
+
+interface PermissionServiceOption {
+  id: PermissionService;
+  label: string;
+  description: string;
+  category: string;
+  adminService?: boolean;
+}
+
+const TENANT_ROLE_OPTIONS = [
+  { value: '', label: 'No tenant role (project access only)' },
+  { value: 'user', label: 'User' },
+  { value: 'project_admin', label: 'Project Admin' },
+  { value: 'admin', label: 'Admin' },
+];
+
+export default function GroupManagement() {
+  const [groups, setGroups] = useState<GroupRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [query, setQuery] = useState('');
+  const [permissionServices, setPermissionServices] = useState<PermissionServiceOption[]>([]);
+
+  // Create/edit
+  const [editorOpened, setEditorOpened] = useState(false);
+  const [editing, setEditing] = useState<GroupRow | null>(null);
+  const [nameDraft, setNameDraft] = useState('');
+  const [descDraft, setDescDraft] = useState('');
+  const [tenantRoleDraft, setTenantRoleDraft] = useState('');
+  const [permDraft, setPermDraft] = useState<UserServicePermissions>({});
+  const [saving, setSaving] = useState(false);
+
+  // Members
+  const [membersOpened, setMembersOpened] = useState(false);
+  const [membersGroup, setMembersGroup] = useState<GroupRow | null>(null);
+  const [members, setMembers] = useState<GroupMember[]>([]);
+  const [tenantUsers, setTenantUsers] = useState<TenantUser[]>([]);
+  const [memberToAdd, setMemberToAdd] = useState<string | null>(null);
+
+  // Projects
+  const [projectsOpened, setProjectsOpened] = useState(false);
+  const [projectsGroup, setProjectsGroup] = useState<GroupRow | null>(null);
+  const [assignments, setAssignments] = useState<GroupProjectAssignment[]>([]);
+  const [projectOptions, setProjectOptions] = useState<ProjectOption[]>([]);
+  const [projectToAdd, setProjectToAdd] = useState<string | null>(null);
+  const [projectRoleToAdd, setProjectRoleToAdd] = useState<'member' | 'project_admin'>('member');
+
+  const [deleteTarget, setDeleteTarget] = useState<GroupRow | null>(null);
+
+  const notifyError = (message: string) =>
+    notifications.show({ title: 'Error', message, color: 'red' });
+  const notifyOk = (message: string) =>
+    notifications.show({ title: 'Success', message, color: 'green' });
+
+  const fetchGroups = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await fetch('/api/groups');
+      if (!res.ok) throw new Error('Failed to load groups');
+      const data = await res.json();
+      setGroups(data.groups ?? []);
+    } catch {
+      notifyError('Failed to load groups');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void fetchGroups();
+  }, [fetchGroups]);
+
+  useEffect(() => {
+    void (async () => {
+      try {
+        const res = await fetch('/api/users/permissions/services');
+        if (res.ok) {
+          const data = await res.json();
+          setPermissionServices(data.services ?? []);
+        }
+      } catch { /* ignore */ }
+    })();
+  }, []);
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return groups;
+    return groups.filter((g) => [g.name, g.description].filter(Boolean).some((v) => String(v).toLowerCase().includes(q)));
+  }, [groups, query]);
+
+  // ── Create / edit ──────────────────────────────────────────────────────────
+  const openCreate = () => {
+    setEditing(null);
+    setNameDraft('');
+    setDescDraft('');
+    setTenantRoleDraft('');
+    setPermDraft({});
+    setEditorOpened(true);
+  };
+
+  const openEdit = (group: GroupRow) => {
+    setEditing(group);
+    setNameDraft(group.name);
+    setDescDraft(group.description ?? '');
+    setTenantRoleDraft(group.tenantRole ?? '');
+    setPermDraft(group.servicePermissions ?? {});
+    setEditorOpened(true);
+  };
+
+  const saveGroup = async () => {
+    if (!nameDraft.trim()) {
+      notifyError('Group name is required');
+      return;
+    }
+    setSaving(true);
+    try {
+      const payload = {
+        name: nameDraft.trim(),
+        description: descDraft.trim() || undefined,
+        tenantRole: tenantRoleDraft || null,
+        servicePermissions: permDraft,
+      };
+      const res = editing
+        ? await fetch(`/api/groups/${encodeURIComponent(editing._id)}`, {
+            method: 'PATCH',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(editing.source === 'ldap' ? { ...payload, name: undefined } : payload),
+          })
+        : await fetch('/api/groups', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(payload),
+          });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(data?.error || 'Failed to save group');
+      notifyOk(editing ? 'Group updated' : 'Group created');
+      setEditorOpened(false);
+      await fetchGroups();
+    } catch (e) {
+      notifyError(e instanceof Error ? e.message : 'Failed to save group');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const confirmDelete = async () => {
+    if (!deleteTarget) return;
+    try {
+      const res = await fetch(`/api/groups/${encodeURIComponent(deleteTarget._id)}`, { method: 'DELETE' });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(data?.error || 'Failed to delete group');
+      notifyOk('Group deleted');
+      setDeleteTarget(null);
+      await fetchGroups();
+    } catch (e) {
+      notifyError(e instanceof Error ? e.message : 'Failed to delete group');
+    }
+  };
+
+  // ── Members ──────────────────────────────────────────────────────────────────
+  const openMembers = async (group: GroupRow) => {
+    setMembersGroup(group);
+    setMembersOpened(true);
+    setMemberToAdd(null);
+    try {
+      const [detailRes, usersRes] = await Promise.all([
+        fetch(`/api/groups/${encodeURIComponent(group._id)}`),
+        fetch('/api/users'),
+      ]);
+      const detail = await detailRes.json();
+      const usersData = await usersRes.json();
+      setMembers(detail.members ?? []);
+      setTenantUsers(usersData.users ?? []);
+    } catch {
+      notifyError('Failed to load members');
+    }
+  };
+
+  const addMember = async () => {
+    if (!membersGroup || !memberToAdd) return;
+    try {
+      const res = await fetch(`/api/groups/${encodeURIComponent(membersGroup._id)}/members`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ userId: memberToAdd, role: 'member' }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(data?.error || 'Failed to add member');
+      setMemberToAdd(null);
+      await openMembers(membersGroup);
+      await fetchGroups();
+    } catch (e) {
+      notifyError(e instanceof Error ? e.message : 'Failed to add member');
+    }
+  };
+
+  const removeMember = async (userId: string) => {
+    if (!membersGroup) return;
+    try {
+      const res = await fetch(
+        `/api/groups/${encodeURIComponent(membersGroup._id)}/members/${encodeURIComponent(userId)}`,
+        { method: 'DELETE' },
+      );
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(data?.error || 'Failed to remove member');
+      await openMembers(membersGroup);
+      await fetchGroups();
+    } catch (e) {
+      notifyError(e instanceof Error ? e.message : 'Failed to remove member');
+    }
+  };
+
+  // ── Projects ─────────────────────────────────────────────────────────────────
+  const openProjects = async (group: GroupRow) => {
+    setProjectsGroup(group);
+    setProjectsOpened(true);
+    setProjectToAdd(null);
+    setProjectRoleToAdd('member');
+    try {
+      const [detailRes, projectsRes] = await Promise.all([
+        fetch(`/api/groups/${encodeURIComponent(group._id)}`),
+        fetch('/api/projects'),
+      ]);
+      const detail = await detailRes.json();
+      const projectsData = await projectsRes.json();
+      setAssignments(detail.projects ?? []);
+      setProjectOptions((projectsData.projects ?? []).map((p: { _id: string; name: string }) => ({ _id: String(p._id), name: p.name })));
+    } catch {
+      notifyError('Failed to load project assignments');
+    }
+  };
+
+  const assignProject = async () => {
+    if (!projectsGroup || !projectToAdd) return;
+    try {
+      const res = await fetch(`/api/groups/${encodeURIComponent(projectsGroup._id)}/projects`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ projectId: projectToAdd, role: projectRoleToAdd }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(data?.error || 'Failed to assign project');
+      setProjectToAdd(null);
+      await openProjects(projectsGroup);
+      await fetchGroups();
+    } catch (e) {
+      notifyError(e instanceof Error ? e.message : 'Failed to assign project');
+    }
+  };
+
+  const removeProject = async (projectId: string) => {
+    if (!projectsGroup) return;
+    try {
+      const res = await fetch(
+        `/api/groups/${encodeURIComponent(projectsGroup._id)}/projects/${encodeURIComponent(projectId)}`,
+        { method: 'DELETE' },
+      );
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(data?.error || 'Failed to remove assignment');
+      await openProjects(projectsGroup);
+      await fetchGroups();
+    } catch (e) {
+      notifyError(e instanceof Error ? e.message : 'Failed to remove assignment');
+    }
+  };
+
+  const projectName = (id: string) => projectOptions.find((p) => p._id === id)?.name ?? id;
+  const availableUsers = tenantUsers.filter((u) => !members.some((m) => m.userId === String(u._id)));
+  const availableProjects = projectOptions.filter((p) => !assignments.some((a) => a.projectId === p._id));
+
+  const columns: DataGridColumn<GroupRow>[] = [
+    {
+      key: 'name',
+      label: 'Group',
+      render: (g) => (
+        <div className="ds-col" style={{ gap: 2 }}>
+          <span style={{ fontSize: 13, fontWeight: 500 }}>{g.name}</span>
+          {g.description ? <span className="ds-faint" style={{ fontSize: 11 }}>{g.description}</span> : null}
+        </div>
+      ),
+    },
+    {
+      key: 'tenantRole',
+      label: 'Tenant role',
+      width: 130,
+      render: (g) =>
+        g.tenantRole ? (
+          <Badge variant="light" color={g.tenantRole === 'admin' ? 'grape' : g.tenantRole === 'project_admin' ? 'cyan' : 'gray'}>
+            {g.tenantRole}
+          </Badge>
+        ) : (
+          <Text size="xs" c="dimmed">—</Text>
+        ),
+    },
+    {
+      key: 'members',
+      label: 'Members',
+      width: 90,
+      render: (g) => <Text size="sm">{g.memberCount ?? 0}</Text>,
+    },
+    {
+      key: 'projects',
+      label: 'Projects',
+      width: 90,
+      render: (g) => <Text size="sm">{g.projectCount ?? 0}</Text>,
+    },
+    {
+      key: 'source',
+      label: 'Source',
+      width: 100,
+      render: (g) => (
+        <Badge variant="light" color={g.source === 'ldap' ? 'indigo' : 'gray'}>
+          {g.source === 'ldap' ? 'LDAP' : 'Local'}
+        </Badge>
+      ),
+    },
+  ];
+
+  return (
+    <>
+      <DataGrid<GroupRow>
+        records={filtered}
+        loading={loading}
+        rowKey={(g) => String(g._id)}
+        columns={columns}
+        search={{ value: query, onChange: setQuery, placeholder: 'Search groups' }}
+        onRefresh={() => void fetchGroups()}
+        refreshing={loading}
+        toolbarRight={
+          <Button color="teal" size="xs" leftSection={<IconPlus size={13} stroke={1.7} />} onClick={openCreate}>
+            New group
+          </Button>
+        }
+        empty={{
+          title: 'No groups yet',
+          primaryAction: { label: 'New group', icon: <IconPlus size={14} stroke={1.7} />, onClick: openCreate },
+        }}
+        footerLeft={`Showing ${filtered.length} of ${groups.length} groups`}
+        rowActions={(g) => [
+          { id: 'members', label: 'Members', icon: <IconUsers size={14} />, onClick: () => void openMembers(g) },
+          { id: 'projects', label: 'Projects', icon: <IconFolders size={14} />, onClick: () => void openProjects(g) },
+          { id: 'edit', label: 'Edit grants', icon: <IconShieldCheck size={14} />, onClick: () => openEdit(g) },
+          ...(g.source === 'ldap'
+            ? []
+            : [{ id: 'delete', label: 'Delete', icon: <IconTrash size={14} />, color: 'red' as const, onClick: () => setDeleteTarget(g) }]),
+        ]}
+      />
+
+      {/* Create / edit grants */}
+      <Modal
+        opened={editorOpened}
+        onClose={() => setEditorOpened(false)}
+        title={editing ? `Edit group: ${editing.name}` : 'New group'}
+        size="xl"
+      >
+        <Stack gap="sm">
+          {editing?.source === 'ldap' && (
+            <Text size="xs" c="dimmed">
+              This group is synced from LDAP. Its name and membership are managed by the directory; you can still configure its grants here.
+            </Text>
+          )}
+          <TextInput
+            label="Name"
+            value={nameDraft}
+            onChange={(e) => setNameDraft(e.currentTarget.value)}
+            disabled={editing?.source === 'ldap'}
+            required
+          />
+          <Textarea
+            label="Description"
+            value={descDraft}
+            onChange={(e) => setDescDraft(e.currentTarget.value)}
+            autosize
+            minRows={2}
+          />
+          <Select
+            label="Tenant role granted to members"
+            description="Unioned with each member's own role — only ever raises access."
+            value={tenantRoleDraft}
+            data={TENANT_ROLE_OPTIONS}
+            onChange={(v) => setTenantRoleDraft(v ?? '')}
+          />
+          <Text size="sm" fw={500} mt="xs">Tenant service permissions</Text>
+          <div className="ds-tbl-wrap" style={{ border: '1px solid var(--ds-border-soft)', borderRadius: 8, maxHeight: 320, overflow: 'auto' }}>
+            <table className="ds-tbl">
+              <thead>
+                <tr><th>Service</th><th style={{ width: 120 }}>Category</th><th style={{ width: 180 }}>Permission</th></tr>
+              </thead>
+              <tbody>
+                {permissionServices.map((service) => (
+                  <tr key={service.id}>
+                    <td><Text size="sm" fw={500}>{service.label}</Text></td>
+                    <td><Badge variant="light" color={service.adminService ? 'grape' : 'gray'}>{service.category}</Badge></td>
+                    <td>
+                      <Select
+                        size="xs"
+                        value={permDraft[service.id] ?? 'none'}
+                        data={[
+                          { value: 'none', label: 'None' },
+                          { value: 'read', label: 'Read' },
+                          { value: 'write', label: 'Write' },
+                          { value: 'admin', label: 'Admin' },
+                        ]}
+                        onChange={(value) =>
+                          setPermDraft((cur) => ({ ...cur, [service.id]: (value ?? 'none') as ServicePermissionLevel }))
+                        }
+                      />
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+          <Group justify="flex-end">
+            <Button variant="default" onClick={() => setEditorOpened(false)}>Cancel</Button>
+            <Button loading={saving} onClick={saveGroup}>{editing ? 'Save' : 'Create'}</Button>
+          </Group>
+        </Stack>
+      </Modal>
+
+      {/* Members */}
+      <Modal opened={membersOpened} onClose={() => setMembersOpened(false)} title={membersGroup ? `Members: ${membersGroup.name}` : 'Members'} size="lg">
+        <Stack gap="sm">
+          {membersGroup?.source === 'ldap' ? (
+            <Text size="xs" c="dimmed">Membership is reconciled from LDAP on each login and cannot be edited here.</Text>
+          ) : (
+            <Group align="flex-end" gap="sm">
+              <Select
+                style={{ flex: 1 }}
+                label="Add member"
+                placeholder="Select a user"
+                searchable
+                value={memberToAdd}
+                onChange={setMemberToAdd}
+                data={availableUsers.map((u) => ({ value: String(u._id), label: `${u.name} (${u.email})` }))}
+              />
+              <Button onClick={addMember} disabled={!memberToAdd}>Add</Button>
+            </Group>
+          )}
+          <div className="ds-tbl-wrap" style={{ border: '1px solid var(--ds-border-soft)', borderRadius: 8 }}>
+            <table className="ds-tbl">
+              <thead><tr><th>Name</th><th style={{ width: 100 }}>Source</th><th style={{ width: 80 }} /></tr></thead>
+              <tbody>
+                {members.length === 0 ? (
+                  <tr><td colSpan={3}><Text size="sm" c="dimmed" ta="center" py="md">No members</Text></td></tr>
+                ) : (
+                  members.map((m) => (
+                    <tr key={m.userId}>
+                      <td><Text size="sm" fw={500}>{m.name ?? m.userId}</Text><Text size="xs" c="dimmed">{m.email}</Text></td>
+                      <td><Badge variant="light" color={m.source === 'ldap' ? 'indigo' : 'gray'}>{m.source === 'ldap' ? 'LDAP' : 'Local'}</Badge></td>
+                      <td>
+                        {m.source === 'ldap' || membersGroup?.source === 'ldap' ? null : (
+                          <Button size="compact-xs" color="red" variant="subtle" onClick={() => void removeMember(m.userId)}>Remove</Button>
+                        )}
+                      </td>
+                    </tr>
+                  ))
+                )}
+              </tbody>
+            </table>
+          </div>
+        </Stack>
+      </Modal>
+
+      {/* Projects */}
+      <Modal opened={projectsOpened} onClose={() => setProjectsOpened(false)} title={projectsGroup ? `Project access: ${projectsGroup.name}` : 'Project access'} size="lg">
+        <Stack gap="sm">
+          <Group align="flex-end" gap="sm">
+            <Select
+              style={{ flex: 1 }}
+              label="Assign project"
+              placeholder="Select a project"
+              searchable
+              value={projectToAdd}
+              onChange={setProjectToAdd}
+              data={availableProjects.map((p) => ({ value: p._id, label: p.name }))}
+            />
+            <Select
+              label="Role"
+              value={projectRoleToAdd}
+              onChange={(v) => setProjectRoleToAdd((v as 'member' | 'project_admin') ?? 'member')}
+              data={[{ value: 'member', label: 'Member' }, { value: 'project_admin', label: 'Project Admin' }]}
+            />
+            <Button onClick={assignProject} disabled={!projectToAdd}>Assign</Button>
+          </Group>
+          <div className="ds-tbl-wrap" style={{ border: '1px solid var(--ds-border-soft)', borderRadius: 8 }}>
+            <table className="ds-tbl">
+              <thead><tr><th>Project</th><th style={{ width: 140 }}>Role</th><th style={{ width: 80 }} /></tr></thead>
+              <tbody>
+                {assignments.length === 0 ? (
+                  <tr><td colSpan={3}><Text size="sm" c="dimmed" ta="center" py="md">No project assignments</Text></td></tr>
+                ) : (
+                  assignments.map((a) => (
+                    <tr key={a.projectId}>
+                      <td><Text size="sm" fw={500}>{projectName(a.projectId)}</Text></td>
+                      <td><Badge variant="light" color={a.role === 'project_admin' ? 'cyan' : 'gray'}>{a.role}</Badge></td>
+                      <td><Button size="compact-xs" color="red" variant="subtle" onClick={() => void removeProject(a.projectId)}>Remove</Button></td>
+                    </tr>
+                  ))
+                )}
+              </tbody>
+            </table>
+          </div>
+        </Stack>
+      </Modal>
+
+      {/* Delete */}
+      <Modal opened={!!deleteTarget} onClose={() => setDeleteTarget(null)} title="Delete group" size="md">
+        <Text size="sm" mb="md">
+          Delete group <strong>{deleteTarget?.name}</strong>? Members lose any access this group granted. This cannot be undone.
+        </Text>
+        <Group justify="flex-end" gap="sm">
+          <Button variant="default" onClick={() => setDeleteTarget(null)}>Cancel</Button>
+          <Button color="red" onClick={confirmDelete}>Delete</Button>
+        </Group>
+      </Modal>
+    </>
+  );
+}

--- a/src/lib/database/mongodb/user-project.mixin.ts
+++ b/src/lib/database/mongodb/user-project.mixin.ts
@@ -91,7 +91,13 @@ export function UserProjectMixin<TBase extends Constructor<MongoDBProviderBase>>
     async createGroup(data: Omit<IGroup, '_id' | 'createdAt' | 'updatedAt'>): Promise<IGroup> {
       const db = this.getTenantDb();
       const now = new Date();
-      const payload = { ...data, createdAt: now, updatedAt: now };
+      const payload = {
+        ...data,
+        source: data.source ?? 'local',
+        servicePermissions: normalizeServicePermissions(data.servicePermissions),
+        createdAt: now,
+        updatedAt: now,
+      };
       const result = await db.collection<IGroup>(COLLECTIONS.groups).insertOne(payload);
       return { ...payload, _id: result.insertedId.toString() };
     }
@@ -103,7 +109,16 @@ export function UserProjectMixin<TBase extends Constructor<MongoDBProviderBase>>
         ? await db.collection<IGroup>(COLLECTIONS.groups).findOne({ _id: oid as unknown as IGroup['_id'] })
         : null;
       if (!doc) return null;
-      return { ...doc, _id: doc._id?.toString() };
+      return this.mapGroup(doc);
+    }
+
+    async findGroupByExternalId(externalId: string): Promise<IGroup | null> {
+      const db = this.getTenantDb();
+      const doc = await db.collection<IGroup>(COLLECTIONS.groups)
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        .findOne({ externalId } as any);
+      if (!doc) return null;
+      return this.mapGroup(doc);
     }
 
     async listGroups(tenantId: string): Promise<IGroup[]> {
@@ -113,20 +128,36 @@ export function UserProjectMixin<TBase extends Constructor<MongoDBProviderBase>>
         .find({ tenantId } as any)
         .sort({ name: 1 })
         .toArray();
-      return docs.map((d) => ({ ...d, _id: d._id?.toString() }));
+      return docs.map((d) => this.mapGroup(d));
     }
 
-    async updateGroup(id: string, data: Partial<Pick<IGroup, 'name' | 'description' | 'updatedBy'>>): Promise<IGroup | null> {
+    async updateGroup(
+      id: string,
+      data: Partial<Pick<IGroup, 'name' | 'description' | 'updatedBy' | 'tenantRole' | 'servicePermissions' | 'source' | 'externalId'>>,
+    ): Promise<IGroup | null> {
       const db = this.getTenantDb();
       const oid = ObjectId.isValid(id) ? new ObjectId(id) : null;
       if (!oid) return null;
+      const patch: Record<string, unknown> = { ...data, updatedAt: new Date() };
+      if (data.servicePermissions !== undefined) {
+        patch.servicePermissions = normalizeServicePermissions(data.servicePermissions);
+      }
       const result = await db.collection<IGroup>(COLLECTIONS.groups).findOneAndUpdate(
         { _id: oid as unknown as IGroup['_id'] },
-        { $set: { ...data, updatedAt: new Date() } },
+        { $set: patch },
         { returnDocument: 'after' },
       );
       if (!result) return null;
-      return { ...result, _id: result._id?.toString() };
+      return this.mapGroup(result);
+    }
+
+    private mapGroup(doc: IGroup & { _id?: unknown }): IGroup {
+      return {
+        ...doc,
+        _id: doc._id?.toString(),
+        source: doc.source ?? 'local',
+        servicePermissions: normalizeServicePermissions(doc.servicePermissions),
+      };
     }
 
     async deleteGroup(id: string): Promise<boolean> {
@@ -142,7 +173,7 @@ export function UserProjectMixin<TBase extends Constructor<MongoDBProviderBase>>
     async addGroupMember(data: Omit<IGroupMember, '_id' | 'createdAt'>): Promise<IGroupMember> {
       const db = this.getTenantDb();
       const now = new Date();
-      const payload = { ...data, createdAt: now };
+      const payload = { ...data, source: data.source ?? 'local', createdAt: now };
       await db.collection<IGroupMember>(COLLECTIONS.groupMembers).replaceOne(
         { tenantId: data.tenantId, groupId: data.groupId, userId: data.userId },
         payload,
@@ -199,12 +230,32 @@ export function UserProjectMixin<TBase extends Constructor<MongoDBProviderBase>>
     async listGroupProjectsByProject(projectId: string): Promise<IGroupProject[]> {
       const db = this.getTenantDb();
       const docs = await db.collection<IGroupProject>(COLLECTIONS.groupProjects).find({ projectId }).toArray();
-      return docs.map((d) => ({
+      return docs.map((d) => this.mapGroupProject(d));
+    }
+
+    async listGroupProjectsByGroup(groupId: string): Promise<IGroupProject[]> {
+      const db = this.getTenantDb();
+      const docs = await db.collection<IGroupProject>(COLLECTIONS.groupProjects).find({ groupId }).toArray();
+      return docs.map((d) => this.mapGroupProject(d));
+    }
+
+    async deleteGroupMembersByGroup(groupId: string): Promise<void> {
+      const db = this.getTenantDb();
+      await db.collection(COLLECTIONS.groupMembers).deleteMany({ groupId });
+    }
+
+    async deleteGroupProjectsByGroup(groupId: string): Promise<void> {
+      const db = this.getTenantDb();
+      await db.collection(COLLECTIONS.groupProjects).deleteMany({ groupId });
+    }
+
+    private mapGroupProject(d: IGroupProject & { _id?: unknown }): IGroupProject {
+      return {
         ...d,
         _id: d._id?.toString(),
         servicePermissions: normalizeServicePermissions(d.servicePermissions),
         role: d.role as ProjectRole,
-      }));
+      };
     }
   };
 }

--- a/src/lib/database/provider/contract.ts
+++ b/src/lib/database/provider/contract.ts
@@ -177,11 +177,16 @@ export interface DatabaseProvider extends EnterpriseDbMethods {
   deleteUserProjectsByProject(projectId: string): Promise<void>;
   deleteUserProjectsByUser(userId: string): Promise<void>;
 
-  // Groups / Teams (future — stub, not yet enforced)
+  // Groups / Teams (tenant + project scoped access grants)
   createGroup(data: Omit<IGroup, '_id' | 'createdAt' | 'updatedAt'>): Promise<IGroup>;
   findGroupById(id: string): Promise<IGroup | null>;
+  /** Look up a directory-sourced group by its stable external id (e.g. LDAP DN). */
+  findGroupByExternalId(externalId: string): Promise<IGroup | null>;
   listGroups(tenantId: string): Promise<IGroup[]>;
-  updateGroup(id: string, data: Partial<Pick<IGroup, 'name' | 'description' | 'updatedBy'>>): Promise<IGroup | null>;
+  updateGroup(
+    id: string,
+    data: Partial<Pick<IGroup, 'name' | 'description' | 'updatedBy' | 'tenantRole' | 'servicePermissions' | 'source' | 'externalId'>>,
+  ): Promise<IGroup | null>;
   deleteGroup(id: string): Promise<boolean>;
   addGroupMember(data: Omit<IGroupMember, '_id' | 'createdAt'>): Promise<IGroupMember>;
   removeGroupMember(groupId: string, userId: string): Promise<boolean>;
@@ -190,6 +195,10 @@ export interface DatabaseProvider extends EnterpriseDbMethods {
   upsertGroupProject(data: Omit<IGroupProject, '_id' | 'createdAt' | 'updatedAt'>): Promise<IGroupProject>;
   removeGroupProject(groupId: string, projectId: string): Promise<boolean>;
   listGroupProjectsByProject(projectId: string): Promise<IGroupProject[]>;
+  listGroupProjectsByGroup(groupId: string): Promise<IGroupProject[]>;
+  /** Cascade helpers used when a group is deleted. */
+  deleteGroupMembersByGroup(groupId: string): Promise<void>;
+  deleteGroupProjectsByGroup(groupId: string): Promise<void>;
 
   // General audit logs (tenant-specific)
   createAuditLog(

--- a/src/lib/database/provider/types.base.ts
+++ b/src/lib/database/provider/types.base.ts
@@ -13,6 +13,7 @@ import type {
 import type {
   PermissionService,
   ServicePermissionLevel,
+  UserRole,
   UserServicePermissions,
 } from '@/lib/security/rbac';
 
@@ -789,18 +790,33 @@ export interface IUserProject {
   updatedAt?: Date;
 }
 
-// ── Groups / Teams (future) ───────────────────────────────────────────────
+// ── Groups / Teams ─────────────────────────────────────────────────────────
+
+/** Origin of a group or membership record. LDAP-sourced rows are reconciled
+ *  on each directory login and must not be hand-edited in the console. */
+export type GroupSource = 'local' | 'ldap';
 
 /**
  * A named group of users within a tenant (team, department, squad, etc.).
- * Groups can be assigned to projects with a role, granting all group members
- * effective access via the union of direct UserProject + GroupProject permissions.
+ *
+ * A group grants its members access at two levels, unioned with the member's
+ * direct grants (highest permission wins):
+ *   - tenant-wide: `tenantRole` + `servicePermissions` (e.g. make members admin)
+ *   - per-project: via IGroupProject assignments
  */
 export interface IGroup {
   _id?: ObjectId | string;
   tenantId: string;
   name: string;
   description?: string;
+  /** Tenant-wide role granted to every member (unioned with their own role). */
+  tenantRole?: UserRole;
+  /** Tenant-level service permission grants applied to every member. */
+  servicePermissions?: UserServicePermissions;
+  /** Where the group came from. Defaults to 'local'. */
+  source?: GroupSource;
+  /** Stable external identifier for directory-sourced groups (e.g. LDAP group DN). */
+  externalId?: string;
   createdBy: string;
   updatedBy?: string;
   createdAt?: Date;
@@ -815,6 +831,9 @@ export interface IGroupMember {
   userId: string;
   /** Whether the user can manage group membership. */
   role: 'admin' | 'member';
+  /** Where the membership came from. LDAP-sourced rows are reconciled on
+   *  directory login; local rows are never touched by the sync. Defaults to 'local'. */
+  source?: GroupSource;
   addedBy?: string;
   createdAt?: Date;
 }

--- a/src/lib/database/sqlite/base.ts
+++ b/src/lib/database/sqlite/base.ts
@@ -381,6 +381,17 @@ export class SQLiteProviderBase {
     this.ensureTableColumn(db, TABLES.modelUsageLogs, 'routing', 'routing TEXT');
     // Analysis conversation tags for grouping/filtering (added later). Safe on boot.
     this.ensureTableColumn(db, TABLES.analysisConversations, 'tags', "tags TEXT DEFAULT '[]'");
+    // Group tenant-level grants + directory-sync provenance (added with user
+    // groups). Safe to ensure on boot for tenants created before the feature.
+    this.ensureTableColumn(db, TABLES.groups, 'tenantRole', 'tenantRole TEXT');
+    this.ensureTableColumn(db, TABLES.groups, 'servicePermissions', "servicePermissions TEXT DEFAULT '{}'");
+    this.ensureTableColumn(db, TABLES.groups, 'source', "source TEXT NOT NULL DEFAULT 'local'");
+    this.ensureTableColumn(db, TABLES.groups, 'externalId', 'externalId TEXT');
+    this.ensureTableColumn(db, TABLES.groupMembers, 'source', "source TEXT NOT NULL DEFAULT 'local'");
+    // External identity provenance on users (LDAP/SSO JIT provisioning). Added
+    // with directory auth; safe to ensure on boot for pre-existing tenants.
+    this.ensureTableColumn(db, TABLES.users, 'authProvider', "authProvider TEXT NOT NULL DEFAULT 'local'");
+    this.ensureTableColumn(db, TABLES.users, 'externalId', 'externalId TEXT');
   }
 
   private migrateOcrJobsSchema(db: Database.Database): void {

--- a/src/lib/database/sqlite/schema.ts
+++ b/src/lib/database/sqlite/schema.ts
@@ -172,6 +172,8 @@ export const TENANT_SCHEMA_SQL = `
     inviteAcceptedAt TEXT,
     mustChangePassword INTEGER DEFAULT 0,
     passwordChangedAt TEXT,
+    authProvider TEXT NOT NULL DEFAULT 'local',
+    externalId TEXT,
     createdAt TEXT NOT NULL,
     updatedAt TEXT NOT NULL
   );
@@ -1533,18 +1535,23 @@ export const TENANT_SCHEMA_SQL = `
   CREATE INDEX IF NOT EXISTS idx_user_projects_user ON user_projects(tenantId, userId);
   CREATE INDEX IF NOT EXISTS idx_user_projects_project ON user_projects(tenantId, projectId);
 
-  -- Groups / Teams (future)
+  -- Groups / Teams (tenant + project scoped access grants)
   CREATE TABLE IF NOT EXISTS groups (
     id TEXT PRIMARY KEY,
     tenantId TEXT NOT NULL,
     name TEXT NOT NULL,
     description TEXT,
+    tenantRole TEXT,
+    servicePermissions TEXT DEFAULT '{}',
+    source TEXT NOT NULL DEFAULT 'local',
+    externalId TEXT,
     createdBy TEXT NOT NULL,
     updatedBy TEXT,
     createdAt TEXT NOT NULL,
     updatedAt TEXT NOT NULL
   );
   CREATE INDEX IF NOT EXISTS idx_groups_tenant ON groups(tenantId);
+  CREATE INDEX IF NOT EXISTS idx_groups_externalId ON groups(tenantId, externalId);
 
   CREATE TABLE IF NOT EXISTS group_members (
     id TEXT PRIMARY KEY,
@@ -1552,6 +1559,7 @@ export const TENANT_SCHEMA_SQL = `
     groupId TEXT NOT NULL,
     userId TEXT NOT NULL,
     role TEXT NOT NULL DEFAULT 'member',
+    source TEXT NOT NULL DEFAULT 'local',
     addedBy TEXT,
     createdAt TEXT NOT NULL,
     UNIQUE(tenantId, groupId, userId)

--- a/src/lib/database/sqlite/user-project.mixin.ts
+++ b/src/lib/database/sqlite/user-project.mixin.ts
@@ -129,25 +129,43 @@ export function UserProjectMixin<TBase extends Constructor<SQLiteProviderBase>>(
 
       db.prepare(`
         INSERT INTO ${TABLES.groups}
-        (id, tenantId, name, description, createdBy, updatedBy, createdAt, updatedAt)
-        VALUES (@id, @tenantId, @name, @description, @createdBy, @updatedBy, @createdAt, @updatedAt)
+        (id, tenantId, name, description, tenantRole, servicePermissions, source, externalId, createdBy, updatedBy, createdAt, updatedAt)
+        VALUES (@id, @tenantId, @name, @description, @tenantRole, @servicePermissions, @source, @externalId, @createdBy, @updatedBy, @createdAt, @updatedAt)
       `).run({
         id,
         tenantId: data.tenantId,
         name: data.name,
         description: data.description ?? null,
+        tenantRole: data.tenantRole ?? null,
+        servicePermissions: this.toJson(normalizeServicePermissions(data.servicePermissions)),
+        source: data.source ?? 'local',
+        externalId: data.externalId ?? null,
         createdBy: data.createdBy,
         updatedBy: data.updatedBy ?? null,
         createdAt: now,
         updatedAt: now,
       });
 
-      return { ...data, _id: id, createdAt: new Date(now), updatedAt: new Date(now) };
+      return {
+        ...data,
+        _id: id,
+        source: data.source ?? 'local',
+        servicePermissions: normalizeServicePermissions(data.servicePermissions),
+        createdAt: new Date(now),
+        updatedAt: new Date(now),
+      };
     }
 
     async findGroupById(id: string): Promise<IGroup | null> {
       const db = this.getTenantDb();
       const row = db.prepare(`SELECT * FROM ${TABLES.groups} WHERE id = @id`).get({ id }) as SqliteRow | undefined;
+      return row ? this.mapGroupRow(row) : null;
+    }
+
+    async findGroupByExternalId(externalId: string): Promise<IGroup | null> {
+      const db = this.getTenantDb();
+      const row = db.prepare(`SELECT * FROM ${TABLES.groups} WHERE externalId = @externalId LIMIT 1`)
+        .get({ externalId }) as SqliteRow | undefined;
       return row ? this.mapGroupRow(row) : null;
     }
 
@@ -158,7 +176,10 @@ export function UserProjectMixin<TBase extends Constructor<SQLiteProviderBase>>(
       return rows.map((r) => this.mapGroupRow(r));
     }
 
-    async updateGroup(id: string, data: Partial<Pick<IGroup, 'name' | 'description' | 'updatedBy'>>): Promise<IGroup | null> {
+    async updateGroup(
+      id: string,
+      data: Partial<Pick<IGroup, 'name' | 'description' | 'updatedBy' | 'tenantRole' | 'servicePermissions' | 'source' | 'externalId'>>,
+    ): Promise<IGroup | null> {
       const db = this.getTenantDb();
       const sets: string[] = ['updatedAt = @updatedAt'];
       const params: Record<string, unknown> = { id, updatedAt: this.now() };
@@ -166,6 +187,13 @@ export function UserProjectMixin<TBase extends Constructor<SQLiteProviderBase>>(
       if (data.name !== undefined) { sets.push('name = @name'); params.name = data.name; }
       if (data.description !== undefined) { sets.push('description = @description'); params.description = data.description; }
       if (data.updatedBy !== undefined) { sets.push('updatedBy = @updatedBy'); params.updatedBy = data.updatedBy; }
+      if (data.tenantRole !== undefined) { sets.push('tenantRole = @tenantRole'); params.tenantRole = data.tenantRole ?? null; }
+      if (data.servicePermissions !== undefined) {
+        sets.push('servicePermissions = @servicePermissions');
+        params.servicePermissions = this.toJson(normalizeServicePermissions(data.servicePermissions));
+      }
+      if (data.source !== undefined) { sets.push('source = @source'); params.source = data.source; }
+      if (data.externalId !== undefined) { sets.push('externalId = @externalId'); params.externalId = data.externalId ?? null; }
 
       db.prepare(`UPDATE ${TABLES.groups} SET ${sets.join(', ')} WHERE id = @id`).run(params);
       return this.findGroupById(id);
@@ -186,19 +214,20 @@ export function UserProjectMixin<TBase extends Constructor<SQLiteProviderBase>>(
 
       db.prepare(`
         INSERT OR REPLACE INTO ${TABLES.groupMembers}
-        (id, tenantId, groupId, userId, role, addedBy, createdAt)
-        VALUES (@id, @tenantId, @groupId, @userId, @role, @addedBy, @createdAt)
+        (id, tenantId, groupId, userId, role, source, addedBy, createdAt)
+        VALUES (@id, @tenantId, @groupId, @userId, @role, @source, @addedBy, @createdAt)
       `).run({
         id,
         tenantId: data.tenantId,
         groupId: data.groupId,
         userId: data.userId,
         role: data.role,
+        source: data.source ?? 'local',
         addedBy: data.addedBy ?? null,
         createdAt: now,
       });
 
-      return { ...data, _id: id, createdAt: new Date(now) };
+      return { ...data, _id: id, source: data.source ?? 'local', createdAt: new Date(now) };
     }
 
     async removeGroupMember(groupId: string, userId: string): Promise<boolean> {
@@ -281,6 +310,23 @@ export function UserProjectMixin<TBase extends Constructor<SQLiteProviderBase>>(
       return rows.map((r) => this.mapGroupProjectRow(r));
     }
 
+    async listGroupProjectsByGroup(groupId: string): Promise<IGroupProject[]> {
+      const db = this.getTenantDb();
+      const rows = db.prepare(`SELECT * FROM ${TABLES.groupProjects} WHERE groupId = @groupId`)
+        .all({ groupId }) as SqliteRow[];
+      return rows.map((r) => this.mapGroupProjectRow(r));
+    }
+
+    async deleteGroupMembersByGroup(groupId: string): Promise<void> {
+      const db = this.getTenantDb();
+      db.prepare(`DELETE FROM ${TABLES.groupMembers} WHERE groupId = @groupId`).run({ groupId });
+    }
+
+    async deleteGroupProjectsByGroup(groupId: string): Promise<void> {
+      const db = this.getTenantDb();
+      db.prepare(`DELETE FROM ${TABLES.groupProjects} WHERE groupId = @groupId`).run({ groupId });
+    }
+
     // ── Private mappers ──────────────────────────────────────────────────
 
     protected mapGroupRow(r: SqliteRow): IGroup {
@@ -289,6 +335,10 @@ export function UserProjectMixin<TBase extends Constructor<SQLiteProviderBase>>(
         tenantId: r.tenantId as string,
         name: r.name as string,
         description: r.description as string | undefined,
+        tenantRole: (r.tenantRole as IGroup['tenantRole']) ?? undefined,
+        servicePermissions: normalizeServicePermissions(this.parseJson(r.servicePermissions, {})),
+        source: ((r.source as string) || 'local') as IGroup['source'],
+        externalId: (r.externalId as string | null) ?? undefined,
         createdBy: r.createdBy as string,
         updatedBy: r.updatedBy as string | undefined,
         createdAt: this.toDate(r.createdAt),
@@ -303,6 +353,7 @@ export function UserProjectMixin<TBase extends Constructor<SQLiteProviderBase>>(
         groupId: r.groupId as string,
         userId: r.userId as string,
         role: r.role as 'admin' | 'member',
+        source: ((r.source as string) || 'local') as IGroupMember['source'],
         addedBy: r.addedBy as string | undefined,
         createdAt: this.toDate(r.createdAt),
       };

--- a/src/lib/database/sqlite/user.mixin.ts
+++ b/src/lib/database/sqlite/user.mixin.ts
@@ -49,9 +49,9 @@ export function UserMixin<TBase extends Constructor<SQLiteProviderBase & WithTen
       db.prepare(`
         INSERT INTO ${TABLES.users}
         (id, email, emailLower, password, name, tenantId, role, projectIds, servicePermissions, licenseId, features,
-         invitedBy, invitedAt, inviteAcceptedAt, mustChangePassword, passwordChangedAt, createdAt, updatedAt)
+         invitedBy, invitedAt, inviteAcceptedAt, mustChangePassword, passwordChangedAt, authProvider, externalId, createdAt, updatedAt)
         VALUES (@id, @email, @emailLower, @password, @name, @tenantId, @role, @projectIds, @servicePermissions, @licenseId, @features,
-         @invitedBy, @invitedAt, @inviteAcceptedAt, @mustChangePassword, @passwordChangedAt, @createdAt, @updatedAt)
+         @invitedBy, @invitedAt, @inviteAcceptedAt, @mustChangePassword, @passwordChangedAt, @authProvider, @externalId, @createdAt, @updatedAt)
       `).run({
         id,
         email: trimmedEmail,
@@ -69,6 +69,8 @@ export function UserMixin<TBase extends Constructor<SQLiteProviderBase & WithTen
         inviteAcceptedAt: userData.inviteAcceptedAt?.toISOString() ?? null,
         mustChangePassword: this.toBoolInt(userData.mustChangePassword),
         passwordChangedAt: userData.passwordChangedAt?.toISOString() ?? now,
+        authProvider: userData.authProvider ?? 'local',
+        externalId: userData.externalId ?? null,
         createdAt: now,
         updatedAt: now,
       });
@@ -135,6 +137,8 @@ export function UserMixin<TBase extends Constructor<SQLiteProviderBase & WithTen
         sets.push('passwordChangedAt = @passwordChangedAt');
         params.passwordChangedAt = data.passwordChangedAt?.toISOString() ?? null;
       }
+      if (data.authProvider !== undefined) { sets.push('authProvider = @authProvider'); params.authProvider = data.authProvider; }
+      if (data.externalId !== undefined) { sets.push('externalId = @externalId'); params.externalId = data.externalId ?? null; }
 
       db.prepare(`UPDATE ${TABLES.users} SET ${sets.join(', ')} WHERE id = @id`).run(params);
 
@@ -214,6 +218,8 @@ export function UserMixin<TBase extends Constructor<SQLiteProviderBase & WithTen
         inviteAcceptedAt: this.toDate(r.inviteAcceptedAt),
         mustChangePassword: this.fromBoolInt(r.mustChangePassword),
         passwordChangedAt: this.toDate(r.passwordChangedAt),
+        authProvider: ((r.authProvider as string) || 'local') as IUser['authProvider'],
+        externalId: (r.externalId as string | null) ?? undefined,
         createdAt: this.toDate(r.createdAt),
         updatedAt: this.toDate(r.updatedAt),
       };

--- a/src/lib/security/rbac.ts
+++ b/src/lib/security/rbac.ts
@@ -141,6 +141,7 @@ const ROUTE_PREFIXES: Array<{ prefix: string; service: PermissionService }> = [
   { prefix: '/api/models/v1', service: 'models' },
   { prefix: '/api/audit', service: 'audit' },
   { prefix: '/api/users', service: 'members' },
+  { prefix: '/api/groups', service: 'members' },
   { prefix: '/api/license', service: 'license' },
   { prefix: '/api/providers', service: 'providers' },
   { prefix: '/api/config', service: 'config' },
@@ -321,6 +322,55 @@ export function getEffectiveServicePermission(
   return explicit ?? getRoleDefaultPermission(user.role, service);
 }
 
+/**
+ * A group's tenant-level grant as seen by the permission resolver: a tenant
+ * role and/or explicit service-permission overrides applied to every member.
+ */
+export interface GroupTenantGrant {
+  tenantRole?: UserRole;
+  servicePermissions?: UserServicePermissions | null;
+}
+
+/**
+ * Effective tenant-level service permission for a user, unioned with the
+ * tenant-level grants of every group they belong to. Highest level wins, so a
+ * group can only ever raise a user's access, never lower it.
+ */
+export function getEffectiveServicePermissionWithGroups(
+  user: RbacUserLike,
+  groupGrants: GroupTenantGrant[],
+  service: PermissionService,
+): ServicePermissionLevel {
+  let best = getEffectiveServicePermission(user, service);
+  if (LEVEL_RANK[best] === LEVEL_RANK.admin) return best;
+
+  for (const grant of groupGrants) {
+    const level = getEffectiveServicePermission(
+      { role: grant.tenantRole, servicePermissions: grant.servicePermissions },
+      service,
+    );
+    if (LEVEL_RANK[level] > LEVEL_RANK[best]) best = level;
+  }
+  return best;
+}
+
+/** Merge several service-permission maps, keeping the highest level per service. */
+export function mergeServicePermissions(
+  maps: Array<UserServicePermissions | null | undefined>,
+): UserServicePermissions {
+  const merged: UserServicePermissions = {};
+  for (const map of maps) {
+    const normalized = normalizeServicePermissions(map);
+    for (const [service, level] of Object.entries(normalized) as Array<[PermissionService, ServicePermissionLevel]>) {
+      const current = merged[service];
+      if (!current || LEVEL_RANK[level] > LEVEL_RANK[current]) {
+        merged[service] = level;
+      }
+    }
+  }
+  return merged;
+}
+
 export function hasServicePermission(
   user: RbacUserLike,
   service: PermissionService,
@@ -333,6 +383,7 @@ export function authorizeServiceRequest(
   user: RbacUserLike,
   method: string,
   pathname: string,
+  groupGrants: GroupTenantGrant[] = [],
 ): { allowed: true; service: PermissionService | null; required?: ServicePermissionLevel } | {
   allowed: false;
   service: PermissionService;
@@ -345,7 +396,7 @@ export function authorizeServiceRequest(
   }
 
   const required = getRequiredPermissionLevel(method, service);
-  const current = getEffectiveServicePermission(user, service);
+  const current = getEffectiveServicePermissionWithGroups(user, groupGrants, service);
   if (LEVEL_RANK[current] >= LEVEL_RANK[required]) {
     return { allowed: true, service, required };
   }

--- a/src/server/api/fastify-utils.ts
+++ b/src/server/api/fastify-utils.ts
@@ -7,6 +7,7 @@ import { runWithRequestContext } from '@/lib/core/requestContext';
 import {
   authorizeServiceRequest,
   getPermissionServiceForPath,
+  type GroupTenantGrant,
 } from '@/lib/security/rbac';
 import {
   ApiTokenAuthError,
@@ -184,6 +185,36 @@ async function loadRbacUser(session: ApiSessionContext): Promise<IUser> {
   return user;
 }
 
+/**
+ * Loads the tenant-level grants of every group the user belongs to. These are
+ * unioned with the user's own role/permissions at authorization time, so group
+ * membership can only ever raise access. Resolved per request (not baked into
+ * the session) so group edits take effect immediately without re-login.
+ */
+async function loadGroupTenantGrants(
+  db: Awaited<ReturnType<typeof getDatabase>>,
+  userId: string,
+): Promise<GroupTenantGrant[]> {
+  // Defensive: a provider without group support (or a partial test double) must
+  // never break the authorization gate — treat a missing/empty result as "no
+  // group grants" rather than throwing.
+  const memberships = typeof db.listGroupMembersByUser === 'function'
+    ? await db.listGroupMembersByUser(userId)
+    : [];
+  if (!Array.isArray(memberships) || memberships.length === 0) return [];
+
+  const grants: GroupTenantGrant[] = [];
+  for (const membership of memberships) {
+    const group = await db.findGroupById(String(membership.groupId));
+    if (!group) continue;
+    const hasServiceGrant = group.servicePermissions && Object.keys(group.servicePermissions).length > 0;
+    if (group.tenantRole || hasServiceGrant) {
+      grants.push({ tenantRole: group.tenantRole, servicePermissions: group.servicePermissions });
+    }
+  }
+  return grants;
+}
+
 async function enforceSessionRbac(request: FastifyRequest, session: ApiSessionContext): Promise<void> {
   const pathname = getRequestPathname(request);
   if (!getPermissionServiceForPath(pathname)) {
@@ -192,7 +223,10 @@ async function enforceSessionRbac(request: FastifyRequest, session: ApiSessionCo
 
   const user = await loadRbacUser(session);
   request.rbacUser = user;
-  const decision = authorizeServiceRequest(user, request.method, pathname);
+  // db is already switched to the session tenant by loadRbacUser.
+  const db = await getDatabase();
+  const groupGrants = await loadGroupTenantGrants(db, String(user._id));
+  const decision = authorizeServiceRequest(user, request.method, pathname, groupGrants);
   if (!decision.allowed) {
     throw new RbacAuthorizationError(
       `Forbidden: ${decision.service} requires ${decision.required} permission`,

--- a/src/server/api/plugin.ts
+++ b/src/server/api/plugin.ts
@@ -59,6 +59,7 @@ import { mcpApiPlugin } from './plugins/mcp';
 import { memoryApiPlugin } from './plugins/memory';
 import { metricsApiPlugin } from './plugins/metrics';
 import { modelsApiPlugin } from './plugins/models';
+import { groupsApiPlugin } from './plugins/groups';
 import { promptsApiPlugin } from './plugins/prompts';
 import { providersApiPlugin } from './plugins/providers';
 import { projectsApiPlugin } from './plugins/projects';
@@ -390,6 +391,7 @@ export const fastifyApiPlugin: FastifyPluginAsync = async (app) => {
   await app.register(promptsApiPlugin);
   await app.register(providersApiPlugin);
   await app.register(projectsApiPlugin);
+  await app.register(groupsApiPlugin);
   await app.register(quotaApiPlugin);
   await app.register(ragApiPlugin);
   await app.register(rerankerApiPlugin);

--- a/src/server/api/plugins/groups.ts
+++ b/src/server/api/plugins/groups.ts
@@ -1,0 +1,423 @@
+/**
+ * Groups API — tenant user groups that grant access at two levels:
+ *   - tenant-wide: a `tenantRole` + `servicePermissions` applied to every member
+ *   - per-project: IGroupProject assignments (role + service overrides)
+ *
+ * Effective permissions are the union of a user's direct grants and the grants
+ * of every group they belong to (highest level wins — see lib/security/rbac).
+ *
+ * Owner/admin only. Directory-sourced groups (`source: 'ldap'`) have their
+ * membership reconciled by the external-auth sync and reject manual membership
+ * edits / deletion here; their grants remain editable.
+ */
+import type { FastifyPluginAsync, FastifyReply } from 'fastify';
+import { createLogger } from '@/lib/core/logger';
+import { getDatabase } from '@/lib/database';
+import type { IGroup } from '@/lib/database';
+import {
+  normalizeServicePermissions,
+  type UserRole,
+} from '@/lib/security/rbac';
+import {
+  readJsonBody,
+  requireSessionContext,
+  withApiRequestContext,
+} from '../fastify-utils';
+
+const logger = createLogger('api:groups');
+
+/** Roles a group may grant tenant-wide. `owner` is intentionally excluded —
+ *  ownership is unique to the tenant owner and never group-derived. */
+const GRANTABLE_TENANT_ROLES: UserRole[] = ['admin', 'project_admin', 'user'];
+
+function isUserAdmin(role: string | undefined): boolean {
+  return role === 'owner' || role === 'admin';
+}
+
+function serializeGroup(group: IGroup, counts?: { members: number; projects: number }) {
+  return {
+    _id: String(group._id),
+    name: group.name,
+    description: group.description ?? null,
+    tenantRole: group.tenantRole ?? null,
+    servicePermissions: normalizeServicePermissions(group.servicePermissions),
+    source: group.source ?? 'local',
+    externalId: group.externalId ?? null,
+    createdBy: group.createdBy,
+    createdAt: group.createdAt,
+    updatedAt: group.updatedAt,
+    ...(counts ? { memberCount: counts.members, projectCount: counts.projects } : {}),
+  };
+}
+
+function parseTenantRole(value: unknown): { ok: true; role: UserRole | undefined } | { ok: false } {
+  if (value === undefined || value === null || value === '') {
+    return { ok: true, role: undefined };
+  }
+  if (typeof value === 'string' && (GRANTABLE_TENANT_ROLES as string[]).includes(value)) {
+    return { ok: true, role: value as UserRole };
+  }
+  return { ok: false };
+}
+
+export const groupsApiPlugin: FastifyPluginAsync = async (app) => {
+  // ── List ──────────────────────────────────────────────────────────────────
+  app.get('/groups', withApiRequestContext(async (request, reply) => {
+    try {
+      const session = requireSessionContext(request);
+      if (!isUserAdmin(session.userRole)) {
+        return reply.code(403).send({ error: 'Forbidden' });
+      }
+
+      const db = await getDatabase();
+      await db.switchToTenant(session.tenantDbName);
+
+      const groups = await db.listGroups(session.tenantId);
+      const enriched = await Promise.all(
+        groups.map(async (group) => {
+          const [members, projects] = await Promise.all([
+            db.listGroupMembers(String(group._id)),
+            db.listGroupProjectsByGroup(String(group._id)),
+          ]);
+          return serializeGroup(group, { members: members.length, projects: projects.length });
+        }),
+      );
+
+      return reply.code(200).send({ groups: enriched });
+    } catch (error) {
+      return handleError(error, reply, 'List groups');
+    }
+  }));
+
+  // ── Create ──────────────────────────────────────────────────────────────────
+  app.post('/groups', withApiRequestContext(async (request, reply) => {
+    try {
+      const session = requireSessionContext(request);
+      if (!isUserAdmin(session.userRole)) {
+        return reply.code(403).send({ error: 'Only owners and admins can create groups' });
+      }
+
+      const body = readJsonBody<{
+        name?: string;
+        description?: string;
+        tenantRole?: unknown;
+        servicePermissions?: unknown;
+      }>(request);
+
+      const name = String(body.name ?? '').trim();
+      if (!name) {
+        return reply.code(400).send({ error: 'Group name is required' });
+      }
+
+      const tenantRole = parseTenantRole(body.tenantRole);
+      if (!tenantRole.ok) {
+        return reply.code(400).send({ error: 'Invalid tenantRole. Must be admin, project_admin, user, or empty' });
+      }
+
+      const db = await getDatabase();
+      await db.switchToTenant(session.tenantDbName);
+
+      const group = await db.createGroup({
+        tenantId: session.tenantId,
+        name,
+        description: body.description ? String(body.description) : undefined,
+        tenantRole: tenantRole.role,
+        servicePermissions: normalizeServicePermissions(body.servicePermissions),
+        source: 'local',
+        createdBy: session.userId,
+      });
+
+      return reply.code(201).send({ group: serializeGroup(group) });
+    } catch (error) {
+      return handleError(error, reply, 'Create group');
+    }
+  }));
+
+  // ── Detail (group + members + project assignments) ──────────────────────────
+  app.get('/groups/:id', withApiRequestContext(async (request, reply) => {
+    try {
+      const session = requireSessionContext(request);
+      if (!isUserAdmin(session.userRole)) {
+        return reply.code(403).send({ error: 'Forbidden' });
+      }
+      const { id } = request.params as { id: string };
+
+      const db = await getDatabase();
+      await db.switchToTenant(session.tenantDbName);
+
+      const group = await db.findGroupById(id);
+      if (!group || String(group.tenantId) !== String(session.tenantId)) {
+        return reply.code(404).send({ error: 'Group not found' });
+      }
+
+      const [memberRows, projectRows, allUsers] = await Promise.all([
+        db.listGroupMembers(id),
+        db.listGroupProjectsByGroup(id),
+        db.listUsers(),
+      ]);
+      const userById = new Map(allUsers.map((u) => [String(u._id), u]));
+
+      const members = memberRows.map((m) => {
+        const user = userById.get(String(m.userId));
+        return {
+          userId: String(m.userId),
+          name: user?.name ?? null,
+          email: user?.email ?? null,
+          role: m.role,
+          source: m.source ?? 'local',
+        };
+      });
+
+      const projects = projectRows.map((p) => ({
+        projectId: String(p.projectId),
+        role: p.role,
+        servicePermissions: normalizeServicePermissions(p.servicePermissions),
+      }));
+
+      return reply.code(200).send({ group: serializeGroup(group), members, projects });
+    } catch (error) {
+      return handleError(error, reply, 'Get group');
+    }
+  }));
+
+  // ── Update grants/metadata ──────────────────────────────────────────────────
+  app.patch('/groups/:id', withApiRequestContext(async (request, reply) => {
+    try {
+      const session = requireSessionContext(request);
+      if (!isUserAdmin(session.userRole)) {
+        return reply.code(403).send({ error: 'Only owners and admins can edit groups' });
+      }
+      const { id } = request.params as { id: string };
+      const body = readJsonBody<{
+        name?: string;
+        description?: string;
+        tenantRole?: unknown;
+        servicePermissions?: unknown;
+      }>(request);
+
+      const db = await getDatabase();
+      await db.switchToTenant(session.tenantDbName);
+
+      const group = await db.findGroupById(id);
+      if (!group || String(group.tenantId) !== String(session.tenantId)) {
+        return reply.code(404).send({ error: 'Group not found' });
+      }
+
+      const patch: Parameters<typeof db.updateGroup>[1] = { updatedBy: session.userId };
+
+      // Name is directory-managed for LDAP groups; grants stay editable.
+      if (body.name !== undefined) {
+        if ((group.source ?? 'local') === 'ldap') {
+          return reply.code(409).send({ error: 'Cannot rename a directory-synced group' });
+        }
+        const name = String(body.name).trim();
+        if (!name) return reply.code(400).send({ error: 'Group name cannot be empty' });
+        patch.name = name;
+      }
+      if (body.description !== undefined) patch.description = body.description ? String(body.description) : undefined;
+      if (body.tenantRole !== undefined) {
+        const tenantRole = parseTenantRole(body.tenantRole);
+        if (!tenantRole.ok) {
+          return reply.code(400).send({ error: 'Invalid tenantRole. Must be admin, project_admin, user, or empty' });
+        }
+        patch.tenantRole = tenantRole.role;
+      }
+      if (body.servicePermissions !== undefined) {
+        patch.servicePermissions = normalizeServicePermissions(body.servicePermissions);
+      }
+
+      const updated = await db.updateGroup(id, patch);
+      if (!updated) return reply.code(500).send({ error: 'Failed to update group' });
+
+      return reply.code(200).send({ group: serializeGroup(updated) });
+    } catch (error) {
+      return handleError(error, reply, 'Update group');
+    }
+  }));
+
+  // ── Delete ──────────────────────────────────────────────────────────────────
+  app.delete('/groups/:id', withApiRequestContext(async (request, reply) => {
+    try {
+      const session = requireSessionContext(request);
+      if (!isUserAdmin(session.userRole)) {
+        return reply.code(403).send({ error: 'Only owners and admins can delete groups' });
+      }
+      const { id } = request.params as { id: string };
+
+      const db = await getDatabase();
+      await db.switchToTenant(session.tenantDbName);
+
+      const group = await db.findGroupById(id);
+      if (!group || String(group.tenantId) !== String(session.tenantId)) {
+        return reply.code(404).send({ error: 'Group not found' });
+      }
+      if ((group.source ?? 'local') === 'ldap') {
+        return reply.code(409).send({ error: 'Directory-synced groups are managed by LDAP and cannot be deleted here' });
+      }
+
+      await db.deleteGroupMembersByGroup(id);
+      await db.deleteGroupProjectsByGroup(id);
+      await db.deleteGroup(id);
+
+      return reply.code(200).send({ message: 'Group deleted successfully' });
+    } catch (error) {
+      return handleError(error, reply, 'Delete group');
+    }
+  }));
+
+  // ── Membership ──────────────────────────────────────────────────────────────
+  app.post('/groups/:id/members', withApiRequestContext(async (request, reply) => {
+    try {
+      const session = requireSessionContext(request);
+      if (!isUserAdmin(session.userRole)) {
+        return reply.code(403).send({ error: 'Only owners and admins can manage group members' });
+      }
+      const { id } = request.params as { id: string };
+      const body = readJsonBody<{ userId?: string; role?: string }>(request);
+
+      const userId = String(body.userId ?? '').trim();
+      if (!userId) return reply.code(400).send({ error: 'userId is required' });
+      const role: 'admin' | 'member' = body.role === 'admin' ? 'admin' : 'member';
+
+      const db = await getDatabase();
+      await db.switchToTenant(session.tenantDbName);
+
+      const group = await db.findGroupById(id);
+      if (!group || String(group.tenantId) !== String(session.tenantId)) {
+        return reply.code(404).send({ error: 'Group not found' });
+      }
+      if ((group.source ?? 'local') === 'ldap') {
+        return reply.code(409).send({ error: 'Membership of directory-synced groups is managed by LDAP' });
+      }
+
+      const target = await db.findUserById(userId);
+      if (!target || String(target.tenantId) !== String(session.tenantId)) {
+        return reply.code(404).send({ error: 'User not found' });
+      }
+
+      await db.addGroupMember({
+        tenantId: session.tenantId,
+        groupId: id,
+        userId,
+        role,
+        source: 'local',
+        addedBy: session.userId,
+      });
+
+      return reply.code(201).send({ message: 'Member added', member: { userId, role, source: 'local' } });
+    } catch (error) {
+      return handleError(error, reply, 'Add group member');
+    }
+  }));
+
+  app.delete('/groups/:id/members/:userId', withApiRequestContext(async (request, reply) => {
+    try {
+      const session = requireSessionContext(request);
+      if (!isUserAdmin(session.userRole)) {
+        return reply.code(403).send({ error: 'Only owners and admins can manage group members' });
+      }
+      const { id, userId } = request.params as { id: string; userId: string };
+
+      const db = await getDatabase();
+      await db.switchToTenant(session.tenantDbName);
+
+      const group = await db.findGroupById(id);
+      if (!group || String(group.tenantId) !== String(session.tenantId)) {
+        return reply.code(404).send({ error: 'Group not found' });
+      }
+      if ((group.source ?? 'local') === 'ldap') {
+        return reply.code(409).send({ error: 'Membership of directory-synced groups is managed by LDAP' });
+      }
+
+      const removed = await db.removeGroupMember(id, userId);
+      if (!removed) return reply.code(404).send({ error: 'Membership not found' });
+
+      return reply.code(200).send({ message: 'Member removed' });
+    } catch (error) {
+      return handleError(error, reply, 'Remove group member');
+    }
+  }));
+
+  // ── Project assignments ─────────────────────────────────────────────────────
+  app.post('/groups/:id/projects', withApiRequestContext(async (request, reply) => {
+    try {
+      const session = requireSessionContext(request);
+      if (!isUserAdmin(session.userRole)) {
+        return reply.code(403).send({ error: 'Only owners and admins can assign group projects' });
+      }
+      const { id } = request.params as { id: string };
+      const body = readJsonBody<{ projectId?: string; role?: string; servicePermissions?: unknown }>(request);
+
+      const projectId = String(body.projectId ?? '').trim();
+      if (!projectId) return reply.code(400).send({ error: 'projectId is required' });
+      if (body.role !== undefined && body.role !== 'member' && body.role !== 'project_admin') {
+        return reply.code(400).send({ error: 'role must be "member" or "project_admin"' });
+      }
+      const role: 'member' | 'project_admin' = body.role === 'project_admin' ? 'project_admin' : 'member';
+
+      const db = await getDatabase();
+      await db.switchToTenant(session.tenantDbName);
+
+      const group = await db.findGroupById(id);
+      if (!group || String(group.tenantId) !== String(session.tenantId)) {
+        return reply.code(404).send({ error: 'Group not found' });
+      }
+
+      const project = await db.findProjectById(projectId);
+      if (!project || String(project.tenantId) !== String(session.tenantId)) {
+        return reply.code(404).send({ error: 'Project not found' });
+      }
+
+      const assignment = await db.upsertGroupProject({
+        tenantId: session.tenantId,
+        groupId: id,
+        projectId,
+        role,
+        servicePermissions: normalizeServicePermissions(body.servicePermissions),
+      });
+
+      return reply.code(201).send({
+        assignment: {
+          projectId: String(assignment.projectId),
+          role: assignment.role,
+          servicePermissions: normalizeServicePermissions(assignment.servicePermissions),
+        },
+      });
+    } catch (error) {
+      return handleError(error, reply, 'Assign group project');
+    }
+  }));
+
+  app.delete('/groups/:id/projects/:projectId', withApiRequestContext(async (request, reply) => {
+    try {
+      const session = requireSessionContext(request);
+      if (!isUserAdmin(session.userRole)) {
+        return reply.code(403).send({ error: 'Only owners and admins can assign group projects' });
+      }
+      const { id, projectId } = request.params as { id: string; projectId: string };
+
+      const db = await getDatabase();
+      await db.switchToTenant(session.tenantDbName);
+
+      const group = await db.findGroupById(id);
+      if (!group || String(group.tenantId) !== String(session.tenantId)) {
+        return reply.code(404).send({ error: 'Group not found' });
+      }
+
+      const removed = await db.removeGroupProject(id, projectId);
+      if (!removed) return reply.code(404).send({ error: 'Assignment not found' });
+
+      return reply.code(200).send({ message: 'Assignment removed' });
+    } catch (error) {
+      return handleError(error, reply, 'Remove group project');
+    }
+  }));
+};
+
+function handleError(error: unknown, reply: FastifyReply, label: string) {
+  if (error instanceof Error && error.message === 'Unauthorized') {
+    return reply.code(401).send({ error: 'Unauthorized' });
+  }
+  logger.error(`${label} error`, { error });
+  return reply.code(500).send({ error: 'Internal server error' });
+}

--- a/src/server/api/plugins/projects.ts
+++ b/src/server/api/plugins/projects.ts
@@ -12,6 +12,8 @@ import {
   listAccessibleProjects,
 } from '@/lib/services/projects/projectService';
 import type { ProjectRole } from '@/lib/database/provider/types.base';
+import type { UserServicePermissions } from '@/lib/security/rbac';
+import { mergeServicePermissions } from '@/lib/security/rbac';
 import {
   readJsonBody,
   requireSessionContext,
@@ -42,7 +44,55 @@ async function collectAccessibleProjectIds(
     }
   }
 
+  // Projects inherited through group membership.
+  const groupMemberships = await db.listGroupMembersByUser(userId);
+  for (const groupMembership of groupMemberships) {
+    const groupProjects = await db.listGroupProjectsByGroup(String(groupMembership.groupId));
+    for (const groupProject of groupProjects) {
+      if (groupProject.projectId) {
+        projectIds.add(String(groupProject.projectId));
+      }
+    }
+  }
+
   return Array.from(projectIds);
+}
+
+/**
+ * Resolves the strongest project role + merged service overrides a user has for
+ * a project, unioning direct UserProject membership, legacy projectIds, and any
+ * group→project assignment the user inherits. Returns null when none apply.
+ */
+async function resolveProjectMembership(
+  db: Awaited<ReturnType<typeof getDatabase>>,
+  params: { userId: string; userRole: string; projectId: string; legacyProjectIds?: string[] },
+): Promise<{ role: ProjectRole; servicePermissions?: UserServicePermissions } | null> {
+  const { userId, userRole, projectId, legacyProjectIds } = params;
+  const sources: Array<{ role: ProjectRole; servicePermissions?: UserServicePermissions | null }> = [];
+
+  const direct = await db.findUserProject(userId, projectId);
+  if (direct) {
+    sources.push({ role: direct.role, servicePermissions: direct.servicePermissions });
+  } else if (getLegacyProjectIds(legacyProjectIds).includes(String(projectId))) {
+    sources.push({ role: userRole === 'project_admin' ? 'project_admin' : 'member' });
+  }
+
+  const groupMemberships = await db.listGroupMembersByUser(userId);
+  if (groupMemberships.length > 0) {
+    const groupIds = new Set(groupMemberships.map((m) => String(m.groupId)));
+    const groupProjects = await db.listGroupProjectsByProject(projectId);
+    for (const groupProject of groupProjects) {
+      if (groupIds.has(String(groupProject.groupId))) {
+        sources.push({ role: groupProject.role, servicePermissions: groupProject.servicePermissions });
+      }
+    }
+  }
+
+  if (sources.length === 0) return null;
+
+  const role: ProjectRole = sources.some((s) => s.role === 'project_admin') ? 'project_admin' : 'member';
+  const servicePermissions = mergeServicePermissions(sources.map((s) => s.servicePermissions));
+  return { role, servicePermissions };
 }
 
 async function loadTenantUser(session: ReturnType<typeof requireSessionContext>) {
@@ -80,33 +130,34 @@ async function assertProjectAccess(params: {
     return { error: 'Unauthorized' as const, ok: false as const, status: 401 as const };
   }
 
-  const userProject = await db.findUserProject(session.userId, projectId);
-  if (!userProject) {
-    const legacyAllowed = getLegacyProjectIds(user.projectIds).includes(String(projectId));
-    if (!legacyAllowed) {
-      return { error: 'Forbidden' as const, ok: false as const, status: 403 as const };
-    }
+  // Effective access unions direct membership, legacy projectIds and groups.
+  const membership = await resolveProjectMembership(db, {
+    userId: session.userId,
+    userRole: session.userRole,
+    projectId,
+    legacyProjectIds: user.projectIds,
+  });
 
-    const legacyRole: ProjectRole = session.userRole === 'project_admin' ? 'project_admin' : 'member';
-    return {
-      db,
-      ok: true as const,
-      project,
-      userProject: {
-        projectId,
-        role: legacyRole,
-        servicePermissions: undefined,
-        tenantId: session.tenantId,
-        userId: session.userId,
-      },
-    };
-  }
-
-  if (requireAdmin && userProject.role !== 'project_admin') {
+  if (!membership) {
     return { error: 'Forbidden' as const, ok: false as const, status: 403 as const };
   }
 
-  return { db, ok: true as const, project, userProject };
+  if (requireAdmin && membership.role !== 'project_admin') {
+    return { error: 'Forbidden' as const, ok: false as const, status: 403 as const };
+  }
+
+  return {
+    db,
+    ok: true as const,
+    project,
+    userProject: {
+      projectId,
+      role: membership.role,
+      servicePermissions: membership.servicePermissions,
+      tenantId: session.tenantId,
+      userId: session.userId,
+    },
+  };
 }
 
 export const projectsApiPlugin: FastifyPluginAsync = async (app) => {


### PR DESCRIPTION
Adds a tenant user-group structure alongside owner/admin, granting access at two levels (unioned with a member's own grants, highest wins):
- tenant-wide via IGroup.tenantRole + servicePermissions
- per-project via IGroupProject

Changes:
- types: IGroup gains tenantRole/servicePermissions/source/externalId; IGroupMember gains source. New DB methods findGroupByExternalId, listGroupProjectsByGroup, deleteGroup{Members,Projects}ByGroup (sqlite+mongo).
- schema: groups/group_members columns + lazy boot migrations.
- API: /api/groups plugin (owner/admin), registered + mapped to the members RBAC service. UI: Members page "Groups" tab.
- RBAC: getEffectiveServicePermissionWithGroups + mergeServicePermissions; the request gate folds group tenant grants in per request; assertProjectAccess unions group->project access.
- fix: persist authProvider/externalId on sqlite users (was silently dropped), so directory-provisioned (LDAP) users keep their provenance.
- tests: RBAC union (unit), groups API (plugin), groups + user-identity DB integration (real sqlite).

## Summary

Describe the problem and the change in one or two paragraphs.

## Changes

- 

## Validation

- [ ] `npm run lint`
- [ ] `npm run test`
- [ ] `npm run build`
- [ ] `npm run docs:build`

## Release Notes

- [ ] Docs updated when behavior changed
- [ ] Security-sensitive changes reviewed
- [ ] License or policy files updated if repo-facing behavior changed