### PR TITLE
fix(db): add runWithTenant and bind tenant per client-API request

### DIFF
--- a/src/lib/database/mongodb/base.ts
+++ b/src/lib/database/mongodb/base.ts
@@ -165,6 +165,25 @@ export class MongoDBProviderBase {
   }
 
   /**
+   * Run `fn` with the tenant DB bound for its entire (sync + async) execution
+   * via a real AsyncLocalStorage scope. `switchToTenant` uses `enterWith`,
+   * whose binding does NOT propagate to the caller's continuation after an
+   * `await` — so a caller that does not establish a tenant scope at request
+   * top falls back to the process-global `this.tenantDb`, which a concurrent
+   * request for another tenant can overwrite (cross-tenant data leakage).
+   * `runWithTenant` is immune to both problems.
+   */
+  async runWithTenant<T>(tenantDbName: string, fn: () => T | Promise<T>): Promise<T> {
+    if (!this.client) {
+      throw new Error('Database client not connected. Call connect() first.');
+    }
+    const tenantDb = this.client.db(tenantDbName);
+    return this.tenantContext.run(tenantDb, () =>
+      this.tenantNameContext.run(tenantDbName, () => fn()),
+    );
+  }
+
+  /**
    * Name of the tenant DB currently bound to this request context.
    * Returns `null` when no tenant is active (request hasn't called switchToTenant).
    */

--- a/src/lib/database/provider/contract.ts
+++ b/src/lib/database/provider/contract.ts
@@ -157,6 +157,15 @@ export interface DatabaseProvider extends EnterpriseDbMethods {
   getCurrentTenantDbName(): string | null;
   /** Throws if the active tenant context does not match the expected tenant. */
   assertTenantContext(expectedTenantDbName: string): void;
+  /**
+   * Run `fn` with the given tenant DB bound for its entire (sync + async)
+   * execution via a real AsyncLocalStorage scope. Unlike `switchToTenant`
+   * (which relies on `enterWith` and can lose the binding across an `await`
+   * boundary in the caller's continuation), this guarantees every nested query
+   * resolves to the correct tenant even under concurrent requests for different
+   * tenants. Optional so partial test doubles need not implement it.
+   */
+  runWithTenant?<T>(tenantDbName: string, fn: () => T | Promise<T>): Promise<T>;
 
   // Cross-tenant user directory (uses main/shared database)
   registerUserInDirectory(entry: ITenantUserDirectoryEntry): Promise<void>;

--- a/src/lib/database/sqlite/base.ts
+++ b/src/lib/database/sqlite/base.ts
@@ -185,6 +185,24 @@ export class SQLiteProviderBase {
   }
 
   /**
+   * Run `fn` with the tenant DB bound for its entire (sync + async) execution
+   * via a real AsyncLocalStorage scope — immune to the `enterWith`
+   * across-`await` binding loss and to process-global overwrites by concurrent
+   * requests for other tenants. See the MongoDB provider for the rationale.
+   */
+  async runWithTenant<T>(tenantDbName: string, fn: () => T | Promise<T>): Promise<T> {
+    // Ensure the tenant DB is opened/cached and the global fallback is warm.
+    await this.switchToTenant(tenantDbName);
+    const db = this.tenantDbCache.get(tenantDbName);
+    if (!db) {
+      throw new Error(`Tenant database not available: ${tenantDbName}`);
+    }
+    return this.tenantContext.run(db, () =>
+      this.tenantNameContext.run(tenantDbName, () => fn()),
+    );
+  }
+
+  /**
    * Name of the tenant DB currently bound to this request context.
    * Returns `null` when no tenant is active (request hasn't called switchToTenant).
    */

--- a/src/server/api/fastify-utils.ts
+++ b/src/server/api/fastify-utils.ts
@@ -395,7 +395,23 @@ export function withClientApiRequestContext<
           tenantSlug: apiToken.tenantSlug,
           userId: apiToken.user?._id ? String(apiToken.user._id) : undefined,
         },
-        () => handler(request as TRequest, reply),
+        async () => {
+          // Bind the tenant DB for the whole handler execution so every nested
+          // query resolves to the token's tenant. Without this, client-API
+          // (token) requests never establish a tenant scope at request top and
+          // fall back to the process-global tenant binding, which a concurrent
+          // request for another tenant can overwrite — causing cross-tenant
+          // reads/writes (e.g. sandbox rows landing in the wrong tenant DB).
+          // Mirrors the cookie/RBAC path, which binds the tenant per request.
+          const db = await getDatabase();
+          if (typeof db.runWithTenant === 'function') {
+            return db.runWithTenant(apiToken.tenantDbName, () =>
+              handler(request as TRequest, reply),
+            );
+          }
+          await db.switchToTenant(apiToken.tenantDbName);
+          return handler(request as TRequest, reply);
+        },
       );
     } catch (error) {
       return sendApiTokenError(reply, error)


### PR DESCRIPTION
Brings the `runWithTenant` per-request tenant-binding fix onto `main` (was only living on `fix/sandbox-tenant-isolation` and pinned by SHA in console-ee's COMPAT.json). This fix stops client-API requests from leaking sandbox rows into the wrong tenant DB, and is already in production via the EE overlay pin — landing it on main so a clean console tag (v1.2.8) can carry both it and the provider work.

Cherry-pick of e11ae0f1c onto current main. Adds `provider.runWithTenant(name, fn)` (AsyncLocalStorage scope, immune to `enterWith` loss across awaits) to the mongodb/sqlite bases + contract, and binds the tenant in `withClientApiRequestContext`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)