### PR TITLE
fix(api): bind tenant DB per dashboard request

### DIFF
--- a/src/__tests__/helpers/db.mock.ts
+++ b/src/__tests__/helpers/db.mock.ts
@@ -74,6 +74,11 @@ function buildPrimers(): Record<string, Mock> {
     listTenants: vi.fn().mockResolvedValue([]),
     updateTenant: vi.fn().mockResolvedValue(null),
     switchToTenant: vi.fn().mockResolvedValue(undefined),
+    // Passthrough so handlers wrapped in runWithTenant actually execute (the
+    // real impl binds the tenant scope then invokes fn). Without this primer
+    // the Proxy auto-mock would return a no-op fn that never calls fn(),
+    // leaving the handler unrun and the route returning an empty 200.
+    runWithTenant: vi.fn(<T>(_tenantDbName: string, fn: () => T | Promise<T>) => fn()),
 
     // Cross-tenant user directory
     registerUserInDirectory: vi.fn().mockResolvedValue(undefined),

--- a/src/server/api/fastify-utils.ts
+++ b/src/server/api/fastify-utils.ts
@@ -330,7 +330,22 @@ export function withApiRequestContext<
           tenantSlug: session?.tenantSlug,
           userId: session?.userId,
         },
-        () => handler(request as TRequest, reply),
+        async () => {
+          // Bind the tenant DB for the whole handler execution so every nested
+          // query resolves to this session's tenant. Without this, cookie/RBAC
+          // (dashboard) requests never establish a tenant scope at request top
+          // and fall back to the process-global tenant binding, which a
+          // concurrent request for another tenant can overwrite — causing
+          // cross-tenant reads/writes (e.g. a provider/model landing in the
+          // wrong tenant DB). Mirrors the client-API (token) path above.
+          const db = await getDatabase();
+          if (session?.tenantDbName && typeof db.runWithTenant === 'function') {
+            return db.runWithTenant(session.tenantDbName, () =>
+              handler(request as TRequest, reply),
+            );
+          }
+          return handler(request as TRequest, reply);
+        },
       );
     } catch (error) {
       return sendRbacError(reply, error)


### PR DESCRIPTION
## Problem
Dashboard (cookie/RBAC) API requests did not establish a tenant scope at request top, so `getTenantDb()` could fall back to the process-global tenant binding, which a concurrent request for another tenant can overwrite. This intermittently caused queries to resolve against the wrong tenant database.

## Fix
Wrap the dashboard handler in `db.runWithTenant(session.tenantDbName, () => handler(...))` inside `withApiRequestContext`, establishing an AsyncLocalStorage tenant scope for the whole handler execution. This mirrors the client-API (token) path already fixed in #159.

## Notes
- Background/cron/SSE paths that don't go through the request wrappers may still need a follow-up audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)