### PR TITLE
fix(models): wrap routes in withApiRequestContext for per-request tenant binding

### DIFF
--- a/src/__tests__/api/models-dashboard.test.ts
+++ b/src/__tests__/api/models-dashboard.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+vi.mock('@/lib/database', () => ({ getDatabase: vi.fn() }));
+
 vi.mock('@/lib/services/models/modelService', () => ({
   listModels: vi.fn(),
   listModelProviders: vi.fn(),
@@ -25,6 +27,8 @@ vi.mock('@/lib/utils/dashboardDateFilter', () => ({
 import { listModels, listModelProviders, getUsageAggregate } from '@/lib/services/models/modelService';
 import { resolveProjectContext } from '@/lib/services/projects/projectContext';
 import { modelsApiPlugin } from '@/server/api/plugins/models';
+import { getDatabase } from '@/lib/database';
+import { createMockDb } from '../helpers/db.mock';
 import {
   createFastifyApiTestApp,
   parseJsonBody,
@@ -80,6 +84,12 @@ describe('GET /api/models/dashboard', () => {
     ]);
     (listModelProviders as ReturnType<typeof vi.fn>).mockResolvedValue([{ key: 'openai' }]);
     (getUsageAggregate as ReturnType<typeof vi.fn>).mockResolvedValue(mockAgg);
+    // Models routes are wrapped in withApiRequestContext, which loads the
+    // RBAC user from the DB and binds the tenant per request. Provide a mock
+    // DB so the owner passes RBAC and runWithTenant passes through.
+    const rbacDb = createMockDb();
+    rbacDb.findUserById.mockResolvedValue({ _id: 'user-1', role: 'owner', tenantId: 'tenant-1' } as never);
+    (getDatabase as ReturnType<typeof vi.fn>).mockResolvedValue(rbacDb);
     app = await createFastifyApiTestApp(modelsApiPlugin);
   });
 

--- a/src/__tests__/api/models-guardrails-id.test.ts
+++ b/src/__tests__/api/models-guardrails-id.test.ts
@@ -1,4 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/database', () => ({ getDatabase: vi.fn() }));
 import { NextRequest } from 'next/server';
 
 vi.mock('@/lib/services/models/modelService', () => ({
@@ -39,6 +41,8 @@ import { getModelById, updateModel, deleteModel } from '@/lib/services/models/mo
 import { getGuardrail, updateGuardrail, deleteGuardrail } from '@/lib/services/guardrail';
 import { requireProjectContext, resolveProjectContext } from '@/lib/services/projects/projectContext';
 import { modelsApiPlugin } from '@/server/api/plugins/models';
+import { getDatabase } from '@/lib/database';
+import { createMockDb } from '../helpers/db.mock';
 import {
   createFastifyApiTestApp,
   parseJsonBody,
@@ -95,6 +99,12 @@ describe('models and guardrails detail routes', () => {
     (getGuardrail as ReturnType<typeof vi.fn>).mockResolvedValue(MOCK_GUARDRAIL);
     (updateGuardrail as ReturnType<typeof vi.fn>).mockResolvedValue(MOCK_GUARDRAIL);
     (deleteGuardrail as ReturnType<typeof vi.fn>).mockResolvedValue(true);
+    // Models routes are wrapped in withApiRequestContext, which loads the
+    // RBAC user from the DB and binds the tenant per request. Provide a mock
+    // DB so the owner passes RBAC and runWithTenant passes through.
+    const rbacDb = createMockDb();
+    rbacDb.findUserById.mockResolvedValue({ _id: 'user-1', role: 'owner', tenantId: 'tenant-1' } as never);
+    (getDatabase as ReturnType<typeof vi.fn>).mockResolvedValue(rbacDb);
     app = await createFastifyApiTestApp(modelsApiPlugin);
   });
 

--- a/src/__tests__/api/models-id-logs-usage.test.ts
+++ b/src/__tests__/api/models-id-logs-usage.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+vi.mock('@/lib/database', () => ({ getDatabase: vi.fn() }));
+
 vi.mock('@/lib/services/models/modelService', () => ({
   getModelById: vi.fn(),
   listUsageLogs: vi.fn(),
@@ -28,6 +30,8 @@ import {
 } from '@/lib/services/models/modelService';
 import { resolveProjectContext, ProjectContextError } from '@/lib/services/projects/projectContext';
 import { modelsApiPlugin } from '@/server/api/plugins/models';
+import { getDatabase } from '@/lib/database';
+import { createMockDb } from '../helpers/db.mock';
 import {
   createFastifyApiTestApp,
   parseJsonBody,
@@ -54,6 +58,12 @@ describe('GET /api/models/:id/logs and /usage', () => {
       user: { _id: 'user-1', role: 'owner', projectIds: ['project-1'] },
     });
     (getModelById as ReturnType<typeof vi.fn>).mockResolvedValue(mockModel);
+    // Models routes are wrapped in withApiRequestContext, which loads the
+    // RBAC user from the DB and binds the tenant per request. Provide a mock
+    // DB so the owner passes RBAC and runWithTenant passes through.
+    const rbacDb = createMockDb();
+    rbacDb.findUserById.mockResolvedValue({ _id: 'user-1', role: 'owner', tenantId: 'tenant-1' } as never);
+    (getDatabase as ReturnType<typeof vi.fn>).mockResolvedValue(rbacDb);
     app = await createFastifyApiTestApp(modelsApiPlugin);
   });
 

--- a/src/__tests__/api/models-providers.test.ts
+++ b/src/__tests__/api/models-providers.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+vi.mock('@/lib/database', () => ({ getDatabase: vi.fn() }));
+
 vi.mock('@/lib/services/models/modelService', () => ({
   listModelProviders: vi.fn(),
   createModelProvider: vi.fn(),
@@ -19,6 +21,8 @@ vi.mock('@/lib/services/projects/projectContext', () => {
 import { listModelProviders, createModelProvider } from '@/lib/services/models/modelService';
 import { resolveProjectContext, ProjectContextError } from '@/lib/services/projects/projectContext';
 import { modelsApiPlugin } from '@/server/api/plugins/models';
+import { getDatabase } from '@/lib/database';
+import { createMockDb } from '../helpers/db.mock';
 import {
   createFastifyApiTestApp,
   parseJsonBody,
@@ -54,6 +58,12 @@ describe('/api/models/providers', () => {
   beforeEach(async () => {
     vi.clearAllMocks();
     (resolveProjectContext as ReturnType<typeof vi.fn>).mockResolvedValue(mockContext);
+    // Models routes are wrapped in withApiRequestContext, which loads the
+    // RBAC user from the DB and binds the tenant per request. Provide a mock
+    // DB so the owner passes RBAC and runWithTenant passes through.
+    const rbacDb = createMockDb();
+    rbacDb.findUserById.mockResolvedValue({ _id: 'user-1', role: 'owner', tenantId: 'tenant-1' } as never);
+    (getDatabase as ReturnType<typeof vi.fn>).mockResolvedValue(rbacDb);
     app = await createFastifyApiTestApp(modelsApiPlugin);
   });
 

--- a/src/__tests__/api/models-routes.test.ts
+++ b/src/__tests__/api/models-routes.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+vi.mock('@/lib/database', () => ({ getDatabase: vi.fn() }));
+
 vi.mock('@/lib/services/models/modelService', () => ({
   listModels: vi.fn(),
   createModel: vi.fn(),
@@ -25,6 +27,8 @@ import { listModels, createModel, listModelProviders } from '@/lib/services/mode
 import { checkResourceQuota } from '@/lib/quota';
 import { resolveProjectContext, ProjectContextError } from '@/lib/services/projects/projectContext';
 import { modelsApiPlugin } from '@/server/api/plugins/models';
+import { getDatabase } from '@/lib/database';
+import { createMockDb } from '../helpers/db.mock';
 import {
   createFastifyApiTestApp,
   parseJsonBody,
@@ -65,6 +69,12 @@ describe('/api/models', () => {
     (createModel as ReturnType<typeof vi.fn>).mockResolvedValue(MOCK_MODEL);
     (checkResourceQuota as ReturnType<typeof vi.fn>).mockResolvedValue({ allowed: true });
     (listModelProviders as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+    // Models routes are wrapped in withApiRequestContext, which loads the
+    // RBAC user from the DB and binds the tenant per request. Provide a mock
+    // DB so the owner passes RBAC and runWithTenant passes through.
+    const rbacDb = createMockDb();
+    rbacDb.findUserById.mockResolvedValue({ _id: 'user-1', role: 'owner', tenantId: 'tenant-1' } as never);
+    (getDatabase as ReturnType<typeof vi.fn>).mockResolvedValue(rbacDb);
     app = await createFastifyApiTestApp(modelsApiPlugin);
   });
 

--- a/src/__tests__/api/provider-drivers-forms.test.ts
+++ b/src/__tests__/api/provider-drivers-forms.test.ts
@@ -1,4 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/database', () => ({ getDatabase: vi.fn() }));
 import { NextRequest } from 'next/server';
 
 const mockListDescriptors = vi.hoisted(() => vi.fn().mockReturnValue([]));
@@ -17,6 +19,8 @@ import { GET as vectorDriversGET } from '@/server/api/routes/vector/providers/dr
 import { GET as vectorDriverFormGET } from '@/server/api/routes/vector/providers/drivers/[driverId]/form/route';
 import { GET as filesDriversGET } from '@/server/api/routes/files/providers/drivers/route';
 import { modelsApiPlugin } from '@/server/api/plugins/models';
+import { getDatabase } from '@/lib/database';
+import { createMockDb } from '../helpers/db.mock';
 import {
   createFastifyApiTestApp,
   parseJsonBody,
@@ -99,6 +103,9 @@ describe('provider driver routes', () => {
       vi.clearAllMocks();
       mockListDescriptors.mockReturnValue([mockDrivers[1]]);
       mockGetFormSchema.mockReturnValue(mockSchema);
+      const rbacDb = createMockDb();
+      rbacDb.findUserById.mockResolvedValue({ _id: 'user-1', role: 'owner', tenantId: 'tenant-1' } as never);
+      (getDatabase as ReturnType<typeof vi.fn>).mockResolvedValue(rbacDb);
       app = await createFastifyApiTestApp(modelsApiPlugin);
     });
 

--- a/src/server/api/plugins/models.ts
+++ b/src/server/api/plugins/models.ts
@@ -33,6 +33,7 @@ import { createLogger } from '@/lib/core/logger';
 import {
   readJsonBody,
   requireProjectContextForRequest,
+  withApiRequestContext,
 } from '../fastify-utils';
 
 const logger = createLogger('api:models');
@@ -123,7 +124,7 @@ function buildDate(value?: string): Date | undefined {
 }
 
 export const modelsApiPlugin: FastifyPluginAsync = async (app) => {
-  app.get('/models/providers/drivers', async (request, reply) => {
+  app.get('/models/providers/drivers', withApiRequestContext(async (request, reply) => {
     try {
       const query = (request.query ?? {}) as { domain?: ProviderDomain };
       const drivers = providerRegistry.listDescriptors(query.domain ?? 'model');
@@ -132,9 +133,9 @@ export const modelsApiPlugin: FastifyPluginAsync = async (app) => {
       logger.error('List model provider drivers error', { error });
       return reply.code(500).send({ error: 'Internal server error' });
     }
-  });
+  }));
 
-  app.get('/models/providers/drivers/:driverId/form', async (request, reply) => {
+  app.get('/models/providers/drivers/:driverId/form', withApiRequestContext(async (request, reply) => {
     try {
       const { driverId } = request.params as { driverId: string };
       const schema = providerRegistry.getFormSchema(driverId);
@@ -154,9 +155,9 @@ export const modelsApiPlugin: FastifyPluginAsync = async (app) => {
           error instanceof Error ? error.message : 'Failed to load form schema',
       });
     }
-  });
+  }));
 
-  app.get('/models/providers', async (request, reply) => {
+  app.get('/models/providers', withApiRequestContext(async (request, reply) => {
     try {
       const { projectId, session } = await requireProjectContextForRequest(request);
       const query = (request.query ?? {}) as {
@@ -180,9 +181,9 @@ export const modelsApiPlugin: FastifyPluginAsync = async (app) => {
       return sendProjectError(reply, error)
         ?? reply.code(500).send({ error: 'Internal server error' });
     }
-  });
+  }));
 
-  app.post('/models/providers', async (request, reply) => {
+  app.post('/models/providers', withApiRequestContext(async (request, reply) => {
     try {
       const { projectId, session } = await requireProjectContextForRequest(request);
       const body = readJsonBody<Record<string, unknown>>(request);
@@ -220,9 +221,9 @@ export const modelsApiPlugin: FastifyPluginAsync = async (app) => {
           error: error instanceof Error ? error.message : 'Internal server error',
         });
     }
-  });
+  }));
 
-  app.get('/models/dashboard', async (request, reply) => {
+  app.get('/models/dashboard', withApiRequestContext(async (request, reply) => {
     try {
       const { projectId, session } = await requireProjectContextForRequest(request);
       const searchParams = new URLSearchParams(
@@ -371,9 +372,9 @@ export const modelsApiPlugin: FastifyPluginAsync = async (app) => {
           error: error instanceof Error ? error.message : 'Internal error',
         });
     }
-  });
+  }));
 
-  app.get('/models', async (request, reply) => {
+  app.get('/models', withApiRequestContext(async (request, reply) => {
     try {
       const { projectId, session } = await requireProjectContextForRequest(request);
       const query = (request.query ?? {}) as ModelQuery;
@@ -405,9 +406,9 @@ export const modelsApiPlugin: FastifyPluginAsync = async (app) => {
           error: error instanceof Error ? error.message : 'Internal error',
         });
     }
-  });
+  }));
 
-  app.post('/models', async (request, reply) => {
+  app.post('/models', withApiRequestContext(async (request, reply) => {
     try {
       const { projectId, session } = await requireProjectContextForRequest(request);
       const body = readJsonBody<Record<string, unknown>>(request);
@@ -477,9 +478,9 @@ export const modelsApiPlugin: FastifyPluginAsync = async (app) => {
           error: error instanceof Error ? error.message : 'Internal error',
         });
     }
-  });
+  }));
 
-  app.post('/models/dynamic', async (request, reply) => {
+  app.post('/models/dynamic', withApiRequestContext(async (request, reply) => {
     try {
       const { projectId, session } = await requireProjectContextForRequest(request);
       const body = readJsonBody<Record<string, unknown>>(request);
@@ -528,9 +529,9 @@ export const modelsApiPlugin: FastifyPluginAsync = async (app) => {
           error: error instanceof Error ? error.message : 'Internal error',
         });
     }
-  });
+  }));
 
-  app.get('/models/:id/logs', async (request, reply) => {
+  app.get('/models/:id/logs', withApiRequestContext(async (request, reply) => {
     try {
       const { id } = request.params as { id: string };
       const { projectId, session } = await requireProjectContextForRequest(request);
@@ -564,9 +565,9 @@ export const modelsApiPlugin: FastifyPluginAsync = async (app) => {
           error: error instanceof Error ? error.message : 'Internal error',
         });
     }
-  });
+  }));
 
-  app.get('/models/:id/usage', async (request, reply) => {
+  app.get('/models/:id/usage', withApiRequestContext(async (request, reply) => {
     try {
       const { id } = request.params as { id: string };
       const { projectId, session } = await requireProjectContextForRequest(request);
@@ -599,9 +600,9 @@ export const modelsApiPlugin: FastifyPluginAsync = async (app) => {
           error: error instanceof Error ? error.message : 'Internal error',
         });
     }
-  });
+  }));
 
-  app.get('/models/:id', async (request, reply) => {
+  app.get('/models/:id', withApiRequestContext(async (request, reply) => {
     try {
       const { id } = request.params as { id: string };
       const { projectId, session } = await requireProjectContextForRequest(request);
@@ -619,9 +620,9 @@ export const modelsApiPlugin: FastifyPluginAsync = async (app) => {
           error: error instanceof Error ? error.message : 'Internal error',
         });
     }
-  });
+  }));
 
-  app.put('/models/:id', async (request, reply) => {
+  app.put('/models/:id', withApiRequestContext(async (request, reply) => {
     try {
       const { id } = request.params as { id: string };
       const { projectId, session } = await requireProjectContextForRequest(request);
@@ -681,9 +682,9 @@ export const modelsApiPlugin: FastifyPluginAsync = async (app) => {
           error: error instanceof Error ? error.message : 'Internal error',
         });
     }
-  });
+  }));
 
-  app.delete('/models/:id', async (request, reply) => {
+  app.delete('/models/:id', withApiRequestContext(async (request, reply) => {
     try {
       const { id } = request.params as { id: string };
       const { projectId, session } = await requireProjectContextForRequest(request);
@@ -701,5 +702,5 @@ export const modelsApiPlugin: FastifyPluginAsync = async (app) => {
           error: error instanceof Error ? error.message : 'Internal error',
         });
     }
-  });
+  }));
 };


### PR DESCRIPTION
The models plugin was the **only** dashboard plugin whose routes were not wrapped in `withApiRequestContext`. Every sibling plugin (providers, groups, projects, prompts, vector, files, users, guardrails) wraps each route; models wrapped none (13 routes, 0 wrapped).

Without the wrapper, model routes never established a per-request tenant scope, so `getTenantDb()` fell back to the process-global tenant binding — which a concurrent request for another tenant can overwrite. Effects:
- `GET /models/providers` (the model page's provider dropdown) intermittently returned an empty list.
- `POST /models/providers` / `POST /models` writes could land in the wrong tenant DB.

This is the read/write counterpart of the dashboard fix in #160; that change only helped routes that actually go through `withApiRequestContext`, which the models routes did not.

## Fix
Wrap all 13 model routes in `withApiRequestContext`, giving them the same per-request tenant binding (`runWithTenant`) and RBAC enforcement the other dashboard plugins already have. Tests exercising these routes now mock `@/lib/database` so the RBAC user load + tenant binding resolve in-process.

Full suite green; `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)