### PR TITLE
feat(models): surface reasoning_content across stream, API, agents and UI

### DIFF
--- a/src/__tests__/unit/openai-adapter.test.ts
+++ b/src/__tests__/unit/openai-adapter.test.ts
@@ -146,6 +146,24 @@ describe('toOpenAIChatResponse', () => {
     const b = toOpenAIChatResponse(msg, baseOptions);
     expect(a.id).not.toBe(b.id);
   });
+
+  it('surfaces reasoning_content from additional_kwargs on the message', () => {
+    const msg = new AIMessage({
+      content: 'The answer is 42.',
+      additional_kwargs: { reasoning_content: 'Thought about it carefully.' },
+    });
+    const result = toOpenAIChatResponse(msg, baseOptions);
+    const message = result.choices[0].message as Record<string, unknown>;
+    expect(message.reasoning_content).toBe('Thought about it carefully.');
+    expect(message.content).toBe('The answer is 42.');
+  });
+
+  it('omits reasoning_content when the model does not emit it', () => {
+    const msg = makeAIMessage('plain answer');
+    const result = toOpenAIChatResponse(msg, baseOptions);
+    const message = result.choices[0].message as Record<string, unknown>;
+    expect('reasoning_content' in message).toBe(false);
+  });
 });
 
 // ── toOpenAIStreamChunk ───────────────────────────────────────────────────────
@@ -172,6 +190,25 @@ describe('toOpenAIStreamChunk', () => {
     const chunk = new AIMessageChunk({ content: 'y' });
     const result = toOpenAIStreamChunk(chunk, { model: 'gpt-4o' });
     expect(result.usage).toBeUndefined();
+  });
+
+  it('surfaces reasoning_content from additional_kwargs in the delta', () => {
+    const chunk = new AIMessageChunk({
+      content: '',
+      additional_kwargs: { reasoning_content: 'Let me think…' },
+    });
+    const result = toOpenAIStreamChunk(chunk, { model: 'gpt-4o', stream: true });
+    expect(
+      (result.choices[0].delta as Record<string, unknown>).reasoning_content,
+    ).toBe('Let me think…');
+  });
+
+  it('omits reasoning_content when not present', () => {
+    const chunk = new AIMessageChunk({ content: 'hi' });
+    const result = toOpenAIStreamChunk(chunk, { model: 'gpt-4o' });
+    expect(
+      'reasoning_content' in (result.choices[0].delta as Record<string, unknown>),
+    ).toBe(false);
   });
 });
 

--- a/src/components/agents/AgentDetailPage.tsx
+++ b/src/components/agents/AgentDetailPage.tsx
@@ -46,6 +46,7 @@ import {
   IconTrash,
   IconCalendar,
   IconRefresh,
+  IconBrain,
   IconChevronDown,
   IconChevronRight,
   IconSettings,
@@ -121,6 +122,8 @@ interface AgentVersion {
 interface ChatMessage {
   role: string;
   content: string;
+  /** Reasoning / "thinking" trace for assistant messages from reasoning models. */
+  reasoning?: string;
 }
 
 interface Model {
@@ -568,7 +571,13 @@ export default function AgentDetailPage() {
       const data = await res.json();
       setChatMessages([
         ...updatedMessages,
-        { role: 'assistant', content: data.content },
+        {
+          role: 'assistant',
+          content: data.content,
+          ...(typeof data.reasoning === 'string' && data.reasoning
+            ? { reasoning: data.reasoning }
+            : {}),
+        },
       ]);
     } catch (err: unknown) {
       const errMsg = err instanceof Error ? err.message : 'Unknown error';
@@ -1037,6 +1046,9 @@ export default function AgentDetailPage() {
                             >
                               {msg.role === 'assistant' ? (
                                 <Box className={classes.chatMarkdown}>
+                                  {msg.reasoning ? (
+                                    <ReasoningDisclosure reasoning={msg.reasoning} />
+                                  ) : null}
                                   <ReactMarkdown remarkPlugins={[remarkGfm]}>
                                     {msg.content}
                                   </ReactMarkdown>
@@ -1708,4 +1720,42 @@ function computeJsonDiff(
   }
 
   return diffs;
+}
+
+/** Collapsible "thinking" trace shown above an assistant reply from a reasoning model. */
+function ReasoningDisclosure({ reasoning }: { reasoning: string }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <Box mb="xs">
+      <UnstyledButton
+        onClick={() => setOpen((v) => !v)}
+        style={{ display: 'flex', alignItems: 'center', gap: 4 }}
+      >
+        <IconBrain size={13} color="var(--mantine-color-violet-6)" />
+        <Text size="xs" fw={500} c="violet.6">
+          Reasoning
+        </Text>
+        {open ? (
+          <IconChevronDown size={12} color="var(--mantine-color-violet-6)" />
+        ) : (
+          <IconChevronRight size={12} color="var(--mantine-color-violet-6)" />
+        )}
+      </UnstyledButton>
+      <Collapse in={open}>
+        <Text
+          size="xs"
+          c="dimmed"
+          mt={4}
+          pl="xs"
+          style={{
+            whiteSpace: 'pre-wrap',
+            wordBreak: 'break-word',
+            borderLeft: '2px solid var(--mantine-color-violet-2)',
+          }}
+        >
+          {reasoning}
+        </Text>
+      </Collapse>
+    </Box>
+  );
 }

--- a/src/components/playground/ModelPlayground.tsx
+++ b/src/components/playground/ModelPlayground.tsx
@@ -25,9 +25,13 @@ export default function ModelPlayground({
   const [system, setSystem] = useState(defaultSystem);
   const [user, setUser] = useState(defaultUser);
   const [output, setOutput] = useState('');
+  const [reasoning, setReasoning] = useState('');
+  const [reasoningOpen, setReasoningOpen] = useState(true);
   const [running, setRunning] = useState(false);
   const [temperature, setTemperature] = useState(0.2);
-  const [maxTokens, setMaxTokens] = useState(512);
+  // Reasoning models spend a large share of the budget on the thinking trace
+  // before emitting any answer, so default generously and allow a high ceiling.
+  const [maxTokens, setMaxTokens] = useState(1024);
   const [topP, setTopP] = useState(1);
   const [responseFormat, setResponseFormat] = useState<'text' | 'json_object'>(
     'text',
@@ -41,11 +45,14 @@ export default function ModelPlayground({
     if (!user.trim() || running) return;
     setRunning(true);
     setOutput('');
+    setReasoning('');
+    setReasoningOpen(true);
     setStats(null);
     const abort = new AbortController();
     abortRef.current = abort;
     const t0 = performance.now();
     let full = '';
+    let fullReasoning = '';
 
     try {
       const messages: Array<{ role: string; content: string }> = [];
@@ -88,10 +95,18 @@ export default function ModelPlayground({
           if (data === '[DONE]') continue;
           try {
             const parsed = JSON.parse(data);
-            const delta = parsed.choices?.[0]?.delta?.content ?? '';
+            const choiceDelta = parsed.choices?.[0]?.delta ?? {};
+            const reasoningDelta = extractReasoningDelta(choiceDelta);
+            if (reasoningDelta) {
+              fullReasoning += reasoningDelta;
+              setReasoning(fullReasoning);
+            }
+            const delta = choiceDelta.content ?? '';
             if (delta) {
               full += delta;
               setOutput(full);
+              // Collapse the thinking trace once the final answer starts.
+              if (fullReasoning) setReasoningOpen(false);
             }
           } catch {
             /* skip */
@@ -120,6 +135,7 @@ export default function ModelPlayground({
 
   const clear = () => {
     setOutput('');
+    setReasoning('');
     setStats(null);
   };
 
@@ -261,6 +277,54 @@ export default function ModelPlayground({
           </CopyButton>
         </div>
         <div className="ds-playground-output">
+          {reasoning ? (
+            <div
+              style={{
+                marginBottom: output ? 12 : 0,
+                borderLeft: '2px solid var(--ds-accent, #7c3aed)',
+                paddingLeft: 10,
+              }}
+            >
+              <button
+                type="button"
+                onClick={() => setReasoningOpen((v) => !v)}
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 4,
+                  background: 'none',
+                  border: 'none',
+                  padding: 0,
+                  cursor: 'pointer',
+                  color: 'var(--ds-accent, #7c3aed)',
+                  fontSize: 11.5,
+                  fontWeight: 600,
+                  letterSpacing: 0.3,
+                  textTransform: 'uppercase',
+                }}
+              >
+                {running && !output ? 'Thinking…' : 'Reasoning'}
+                <span style={{ fontSize: 10 }}>{reasoningOpen ? '▾' : '▸'}</span>
+              </button>
+              {reasoningOpen ? (
+                <div
+                  className="ds-faint"
+                  style={{
+                    fontSize: 12,
+                    lineHeight: 1.55,
+                    whiteSpace: 'pre-wrap',
+                    wordBreak: 'break-word',
+                    marginTop: 6,
+                  }}
+                >
+                  {reasoning}
+                  {running && !output ? (
+                    <span className="ds-playground-cursor" aria-hidden="true" />
+                  ) : null}
+                </div>
+              ) : null}
+            </div>
+          ) : null}
           {output ? (
             <div
               style={{
@@ -275,7 +339,7 @@ export default function ModelPlayground({
                 <span className="ds-playground-cursor" aria-hidden="true" />
               ) : null}
             </div>
-          ) : (
+          ) : !reasoning ? (
             <div
               className="ds-faint"
               style={{ fontSize: 13, fontStyle: 'italic' }}
@@ -284,7 +348,7 @@ export default function ModelPlayground({
                 ? 'Waiting for first token…'
                 : 'Click "Run" to send a request.'}
             </div>
-          )}
+          ) : null}
         </div>
       </div>
 
@@ -305,7 +369,7 @@ export default function ModelPlayground({
           label="Max tokens"
           value={maxTokens}
           min={64}
-          max={4096}
+          max={16384}
           step={64}
           onChange={setMaxTokens}
           format={(v) => String(Math.round(v))}
@@ -384,4 +448,34 @@ function approxTokens(text: string): number {
   if (!text) return 0;
   // Rough heuristic: ~4 chars/token
   return Math.max(1, Math.round(text.length / 4));
+}
+
+/**
+ * Reasoning models stream their chain-of-thought as `delta.reasoning_content`
+ * (OpenAI-compatible) — and some emit `delta.reasoning` as a string or object.
+ * Normalize to a plain string delta.
+ */
+function extractReasoningDelta(delta: Record<string, unknown>): string {
+  const reasoningContent = delta.reasoning_content;
+  if (typeof reasoningContent === 'string') return reasoningContent;
+
+  const reasoning = delta.reasoning;
+  if (typeof reasoning === 'string') return reasoning;
+  if (reasoning && typeof reasoning === 'object') {
+    const r = reasoning as Record<string, unknown>;
+    if (typeof r.text === 'string') return r.text;
+    if (typeof r.summary === 'string') return r.summary;
+    if (Array.isArray(r.summary)) {
+      return r.summary
+        .map((s) =>
+          typeof s === 'string'
+            ? s
+            : s && typeof s === 'object' && typeof (s as Record<string, unknown>).text === 'string'
+              ? ((s as Record<string, unknown>).text as string)
+              : '',
+        )
+        .join('');
+    }
+  }
+  return '';
 }

--- a/src/components/playground/Playground.tsx
+++ b/src/components/playground/Playground.tsx
@@ -7,6 +7,7 @@ import {
   Box,
   Button,
   Center,
+  Collapse,
   Group,
   Loader,
   Paper,
@@ -17,8 +18,12 @@ import {
   Textarea,
   ThemeIcon,
   Tooltip,
+  UnstyledButton,
 } from '@mantine/core';
 import {
+  IconBrain,
+  IconChevronDown,
+  IconChevronRight,
   IconPlayerStop,
   IconRefresh,
   IconSend,
@@ -40,6 +45,8 @@ export interface ModelOption {
 export interface PlaygroundMessage {
   role: 'user' | 'assistant' | 'system';
   content: string;
+  /** Reasoning / "thinking" trace emitted by reasoning models alongside content */
+  reasoning?: string;
 }
 
 export interface PlaygroundProps {
@@ -77,6 +84,7 @@ export function Playground({
   const [inputValue, setInputValue] = useState('');
   const [isGenerating, setIsGenerating] = useState(false);
   const [streamingContent, setStreamingContent] = useState('');
+  const [streamingReasoning, setStreamingReasoning] = useState('');
   const abortControllerRef = useRef<AbortController | null>(null);
   const scrollAreaRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
@@ -155,6 +163,7 @@ export function Playground({
     setInputValue('');
     setIsGenerating(true);
     setStreamingContent('');
+    setStreamingReasoning('');
 
     const abortController = new AbortController();
     abortControllerRef.current = abortController;
@@ -189,6 +198,7 @@ export function Playground({
 
       const decoder = new TextDecoder();
       let fullContent = '';
+      let fullReasoning = '';
 
       while (true) {
         const { done, value } = await reader.read();
@@ -204,7 +214,13 @@ export function Playground({
 
             try {
               const parsed = JSON.parse(data);
-              const delta = parsed.choices?.[0]?.delta?.content ?? '';
+              const choiceDelta = parsed.choices?.[0]?.delta ?? {};
+              const reasoningDelta = extractReasoningDelta(choiceDelta);
+              if (reasoningDelta) {
+                fullReasoning += reasoningDelta;
+                setStreamingReasoning(fullReasoning);
+              }
+              const delta = choiceDelta.content ?? '';
               if (delta) {
                 fullContent += delta;
                 setStreamingContent(fullContent);
@@ -217,8 +233,15 @@ export function Playground({
       }
 
       // Add completed assistant message
-      if (fullContent) {
-        setMessages((prev) => [...prev, { role: 'assistant', content: fullContent }]);
+      if (fullContent || fullReasoning) {
+        setMessages((prev) => [
+          ...prev,
+          {
+            role: 'assistant',
+            content: fullContent,
+            reasoning: fullReasoning || undefined,
+          },
+        ]);
       }
     } catch (error) {
       if ((error as Error).name !== 'AbortError') {
@@ -232,6 +255,7 @@ export function Playground({
     } finally {
       setIsGenerating(false);
       setStreamingContent('');
+      setStreamingReasoning('');
       abortControllerRef.current = null;
       inputRef.current?.focus();
     }
@@ -241,11 +265,13 @@ export function Playground({
     abortControllerRef.current?.abort();
     setIsGenerating(false);
     setStreamingContent('');
+    setStreamingReasoning('');
   };
 
   const clearConversation = () => {
     setMessages([]);
     setStreamingContent('');
+    setStreamingReasoning('');
     inputRef.current?.focus();
   };
 
@@ -337,7 +363,7 @@ export function Playground({
         >
           <ScrollArea h={chatHeight} ref={scrollAreaRef} type="auto" offsetScrollbars>
             <Stack gap={0} p="sm">
-              {messages.length === 0 && !streamingContent ? (
+              {messages.length === 0 && !streamingContent && !streamingReasoning ? (
                 <Center py="xl">
                   <Stack gap="xs" align="center">
                     <ThemeIcon variant="light" color="gray" size="xl" radius="xl">
@@ -356,9 +382,13 @@ export function Playground({
                   {messages.map((msg, idx) => (
                     <MessageBubble key={idx} message={msg} />
                   ))}
-                  {streamingContent && (
+                  {(streamingContent || streamingReasoning) && (
                     <MessageBubble
-                      message={{ role: 'assistant', content: streamingContent }}
+                      message={{
+                        role: 'assistant',
+                        content: streamingContent,
+                        reasoning: streamingReasoning || undefined,
+                      }}
                       isStreaming
                     />
                   )}
@@ -426,6 +456,11 @@ interface MessageBubbleProps {
 function MessageBubble({ message, isStreaming }: MessageBubbleProps) {
   const isUser = message.role === 'user';
   const isSystem = message.role === 'system';
+  const hasReasoning = !isUser && !isSystem && Boolean(message.reasoning?.trim());
+  // While streaming, keep the thinking trace open; collapse it once the answer arrives.
+  const [reasoningOpen, setReasoningOpen] = useState(
+    Boolean(isStreaming && !message.content),
+  );
 
   return (
     <Box
@@ -453,14 +488,81 @@ function MessageBubble({ message, isStreaming }: MessageBubbleProps) {
           <Loader size={12} />
         )}
       </Group>
-      <Text
-        size="sm"
-        style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}
-      >
-        {message.content}
-      </Text>
+
+      {hasReasoning && (
+        <Box mb={message.content ? 6 : 0}>
+          <UnstyledButton
+            onClick={() => setReasoningOpen((v) => !v)}
+            style={{ display: 'flex', alignItems: 'center', gap: 4 }}
+          >
+            <IconBrain size={13} style={{ color: 'var(--mantine-color-violet-6)' }} />
+            <Text size="xs" c="violet.6" fw={500}>
+              {isStreaming && !message.content ? 'Thinking…' : 'Reasoning'}
+            </Text>
+            {reasoningOpen ? (
+              <IconChevronDown size={12} style={{ color: 'var(--mantine-color-violet-6)' }} />
+            ) : (
+              <IconChevronRight size={12} style={{ color: 'var(--mantine-color-violet-6)' }} />
+            )}
+          </UnstyledButton>
+          <Collapse in={reasoningOpen}>
+            <Text
+              size="xs"
+              c="dimmed"
+              mt={4}
+              pl="xs"
+              style={{
+                whiteSpace: 'pre-wrap',
+                wordBreak: 'break-word',
+                borderLeft: '2px solid var(--mantine-color-violet-2)',
+              }}
+            >
+              {message.reasoning}
+            </Text>
+          </Collapse>
+        </Box>
+      )}
+
+      {message.content && (
+        <Text
+          size="sm"
+          style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}
+        >
+          {message.content}
+        </Text>
+      )}
     </Box>
   );
+}
+
+/**
+ * Reasoning models stream their chain-of-thought as `delta.reasoning_content`
+ * (OpenAI-compatible) — and some emit `delta.reasoning` either as a plain string
+ * or as `{ summary?: string|[], text?: string }`. Normalize to a string delta.
+ */
+function extractReasoningDelta(delta: Record<string, unknown>): string {
+  const reasoningContent = delta.reasoning_content;
+  if (typeof reasoningContent === 'string') return reasoningContent;
+
+  const reasoning = delta.reasoning;
+  if (typeof reasoning === 'string') return reasoning;
+  if (reasoning && typeof reasoning === 'object') {
+    const r = reasoning as Record<string, unknown>;
+    if (typeof r.text === 'string') return r.text;
+    if (typeof r.summary === 'string') return r.summary;
+    if (Array.isArray(r.summary)) {
+      return r.summary
+        .map((s) =>
+          typeof s === 'string'
+            ? s
+            : s && typeof s === 'object' && typeof (s as Record<string, unknown>).text === 'string'
+              ? ((s as Record<string, unknown>).text as string)
+              : '',
+        )
+        .join('');
+    }
+  }
+  return '';
 }
 
 export default Playground;

--- a/src/lib/database/provider/types.domain.ts
+++ b/src/lib/database/provider/types.domain.ts
@@ -1006,6 +1006,8 @@ export interface IAgentConversation {
   messages: Array<{
     role: string;
     content: string;
+    /** Reasoning / "thinking" trace for assistant messages from reasoning models. */
+    reasoning?: string;
     timestamp: Date;
   }>;
   metadata?: Record<string, unknown>;

--- a/src/lib/services/agents/agentService.ts
+++ b/src/lib/services/agents/agentService.ts
@@ -84,6 +84,32 @@ function createConsoleAgentState(messages: AgentSdkMessage[]): AgentSdkSmartStat
     };
 }
 
+/**
+ * Reasoning ("thinking") models expose their chain-of-thought separately from the
+ * final answer. The agent SDK keeps it on the assistant message's
+ * `additional_kwargs.reasoning_content` (our SDK LangChain integration maps the
+ * OpenAI-compatible `reasoning_content` field there). Pull the reasoning trace from
+ * the final assistant message so callers can surface it alongside the answer.
+ */
+function extractAgentReasoning(result: AgentSdkInvokeResult): string | undefined {
+    const messages = (result.messages ?? []) as Array<{
+        getType?: () => string;
+        _getType?: () => string;
+        additional_kwargs?: Record<string, unknown>;
+    }>;
+    for (let i = messages.length - 1; i >= 0; i -= 1) {
+        const msg = messages[i];
+        const type = msg?.getType?.() ?? msg?._getType?.();
+        if (type && type !== 'ai') continue;
+        const reasoning = msg?.additional_kwargs?.['reasoning_content'];
+        if (typeof reasoning === 'string' && reasoning.length > 0) {
+            return reasoning;
+        }
+        if (type === 'ai') break;
+    }
+    return undefined;
+}
+
 function createConsoleSdkAgent(
     createSmartAgentFn: typeof import('@cognipeer/agent-sdk').createSmartAgent,
     input: CreateConsoleSdkAgentInput,
@@ -801,6 +827,15 @@ export interface ResponseOutputMessage {
     content: ResponseOutputText[];
 }
 
+/** OpenAI Responses API–compatible reasoning ("thinking") output item */
+export interface ResponseReasoningItem {
+    id: string;
+    type: 'reasoning';
+    summary: Array<{ type: 'summary_text'; text: string }>;
+}
+
+export type ResponseOutputItem = ResponseReasoningItem | ResponseOutputMessage;
+
 /** OpenAI Responses API–compatible usage */
 export interface ResponseUsage {
     input_tokens: number;
@@ -813,7 +848,7 @@ export interface AgentChatResponse {
     id: string;
     object: 'response';
     model: string;
-    output: ResponseOutputMessage[];
+    output: ResponseOutputItem[];
     status: 'completed' | 'failed';
     usage: ResponseUsage;
     created_at: number;
@@ -821,7 +856,7 @@ export interface AgentChatResponse {
     /** Version used for this response (null if not versioned) */
     version: number | null;
     /** Conversation messages for dashboard playgrounds */
-    _conversation_messages?: Array<{ role: string; content: string; timestamp: Date }>;
+    _conversation_messages?: Array<{ role: string; content: string; reasoning?: string; timestamp: Date }>;
 }
 
 export async function executeAgentChat(
@@ -1058,6 +1093,7 @@ export async function executeAgentChatLocal(
         const result: AgentSdkInvokeResult = await sdkAgent.invoke(createConsoleAgentState(inputMessages));
 
         const assistantContent = result.content || '';
+        const assistantReasoning = extractAgentReasoning(result);
 
         // 7b. Output guardrail check
         if (config.outputGuardrailKey && assistantContent) {
@@ -1078,7 +1114,12 @@ export async function executeAgentChatLocal(
         const updatedMessages = [
             ...(conversation.messages || []),
             { role: 'user', content: userMessage, timestamp: now },
-            { role: 'assistant', content: assistantContent, timestamp: new Date() },
+            {
+                role: 'assistant',
+                content: assistantContent,
+                ...(assistantReasoning ? { reasoning: assistantReasoning } : {}),
+                timestamp: new Date(),
+            },
         ];
 
         await db.updateAgentConversation(conversationId, {
@@ -1096,12 +1137,28 @@ export async function executeAgentChatLocal(
 
         const responseId = `resp_${conversationId}`;
         const msgId = `msg_${Date.now().toString(36)}`;
+        const reasoningId = `rs_${Date.now().toString(36)}`;
 
         return {
             id: responseId,
             object: 'response' as const,
             model: agent.name,
             output: [
+                // OpenAI Responses convention: reasoning item precedes the message.
+                ...(assistantReasoning
+                    ? [
+                          {
+                              id: reasoningId,
+                              type: 'reasoning' as const,
+                              summary: [
+                                  {
+                                      type: 'summary_text' as const,
+                                      text: assistantReasoning,
+                                  },
+                              ],
+                          },
+                      ]
+                    : []),
                 {
                     id: msgId,
                     type: 'message' as const,
@@ -1136,7 +1193,7 @@ export async function executeAgentChatLocal(
  */
 export async function executePlaygroundChat(
     request: AgentPlaygroundChatRequest,
-): Promise<{ content: string }> {
+): Promise<{ content: string; reasoning?: string }> {
     return routeInstanceCall(
         {
             entityType: 'agent',
@@ -1151,7 +1208,7 @@ export async function executePlaygroundChat(
 /** Local (non-routed) implementation. Exported so the queue consumer can call it. */
 export async function executePlaygroundChatLocal(
     request: AgentPlaygroundChatRequest,
-): Promise<{ content: string }> {
+): Promise<{ content: string; reasoning?: string }> {
     const { tenantDbName, tenantId, projectId, agentKey, userMessage, history } = request;
 
     const db = await getDatabase();
@@ -1289,6 +1346,7 @@ export async function executePlaygroundChatLocal(
     try {
         const result: AgentSdkInvokeResult = await sdkAgent.invoke(createConsoleAgentState(inputMessages));
         const assistantContent = result.content || '';
+        const assistantReasoning = extractAgentReasoning(result);
 
         // Output guardrail check
         if (config.outputGuardrailKey && assistantContent) {
@@ -1307,7 +1365,10 @@ export async function executePlaygroundChatLocal(
 
         logger.info('Playground chat completed', { agentKey });
 
-        return { content: assistantContent };
+        return {
+            content: assistantContent,
+            ...(assistantReasoning ? { reasoning: assistantReasoning } : {}),
+        };
     } finally {
         await runBoundToolCleanup(cleanupTasks, { agentKey, mode: 'playground' });
     }

--- a/src/lib/services/models/openaiAdapter.ts
+++ b/src/lib/services/models/openaiAdapter.ts
@@ -254,6 +254,34 @@ function extractUsage(message: AIMessage | AIMessageChunk): UsageMetrics {
   };
 }
 
+/**
+ * Reasoning ("thinking") models emit their chain-of-thought separately from the
+ * final answer. Over the OpenAI-compatible Chat Completions wire this arrives as
+ * `delta.reasoning_content` / `message.reasoning_content`, which LangChain stores
+ * under `additional_kwargs.reasoning_content` (string) — and for the Responses /
+ * o-series shape under `additional_kwargs.reasoning` (object). We surface both so
+ * downstream consumers (playground, SDK, agents) can render the thinking stream.
+ */
+function extractReasoning(message: { additional_kwargs?: unknown }): {
+  reasoningContent?: string;
+  reasoning?: unknown;
+} {
+  const additional =
+    (message.additional_kwargs as Record<string, unknown> | undefined) || {};
+
+  const rawReasoningContent = additional['reasoning_content'];
+  const reasoningContent =
+    typeof rawReasoningContent === 'string' && rawReasoningContent.length > 0
+      ? rawReasoningContent
+      : undefined;
+
+  const rawReasoning = additional['reasoning'];
+  const reasoning =
+    rawReasoning !== undefined && rawReasoning !== null ? rawReasoning : undefined;
+
+  return { reasoningContent, reasoning };
+}
+
 export function toOpenAIChatResponse(
   message: AIMessage,
   options: ChatTransformOptions,
@@ -314,6 +342,14 @@ export function toOpenAIChatResponse(
     annotations,
   };
 
+  const { reasoningContent, reasoning } = extractReasoning(message);
+  if (reasoningContent !== undefined) {
+    assistantMessage.reasoning_content = reasoningContent;
+  }
+  if (reasoning !== undefined) {
+    assistantMessage.reasoning = reasoning;
+  }
+
   if (normalizedToolCalls) {
     assistantMessage.tool_calls = normalizedToolCalls;
   }
@@ -347,6 +383,14 @@ export function toOpenAIStreamChunk(
     delta.content = chunk.content;
   } else if (Array.isArray(chunk.content)) {
     delta.content = chunk.content;
+  }
+
+  const { reasoningContent, reasoning } = extractReasoning(chunk);
+  if (reasoningContent !== undefined) {
+    delta.reasoning_content = reasoningContent;
+  }
+  if (reasoning !== undefined) {
+    delta.reasoning = reasoning;
   }
 
   const chunkWithTools = chunk as AIMessageChunk & { tool_calls?: unknown };


### PR DESCRIPTION
## Problem
Reasoning/"thinking" models (e.g. `mlx-community/Qwen3.6-35B-A3B-8bit` via an OpenAI-compatible provider) emit their chain-of-thought as `delta.reasoning_content` instead of `delta.content`. No layer in the pipeline read that field, so the playground "streaming" appeared broken — it sat on *Waiting for first token…* and ended empty because the whole token budget was spent on the (dropped) reasoning channel.

## Changes
- **`openaiAdapter`** — new `extractReasoning()` reads `additional_kwargs.reasoning_content` / `reasoning` and emits `delta.reasoning_content` (stream) + `message.reasoning_content` (non-stream). Public **Chat Completions**, **playground** and **Responses** routes inherit it via pass-through.
- **`agentService`** — `extractAgentReasoning()` pulls the trace from the final assistant message. Responses output gains an OpenAI-style `{ type: 'reasoning', summary }` item; playground chat returns `{ content, reasoning }`; conversation history persists `reasoning`. New `ResponseReasoningItem` / `ResponseOutputItem` types.
- **UI** — `Playground`, `ModelPlayground`, `AgentDetailPage` render a collapsible **Thinking/Reasoning** disclosure (auto-collapses once the answer streams). `ModelPlayground` `max_tokens` default 512→1024, ceiling 4096→16384 so reasoning models actually reach the answer.
- **Tests** — adapter stream + non-stream reasoning coverage (28/28 pass).

## Verification
- Confirmed against the live provider that it streams `reasoning_content`-only deltas.
- `tsc --noEmit` clean; ESLint clean on changed files; adapter + provider-contract suites green.

## Deliberately unchanged
- console-ee realtime/voice session reads `delta.content` only — not voicing the chain-of-thought is the correct behavior.

Companion SDK PR: `Cognipeer/cgate-sdk` `feat/reasoning-content`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)