### PR TITLE
fix(api): bind tenant DB per-request on client inference plugins (cross-tenant race)

### DIFF
--- a/src/server/api/plugins/client-audio-ocr.ts
+++ b/src/server/api/plugins/client-audio-ocr.ts
@@ -4,6 +4,7 @@ import type { LicenseType } from '@/lib/license/license-manager';
 import { createLogger } from '@/lib/core/logger';
 import { isShuttingDown } from '@/lib/core/lifecycle';
 import { runWithRequestContext } from '@/lib/core/requestContext';
+import { getDatabase } from '@/lib/database';
 import {
   ApiTokenAuthError,
   type ApiTokenContext,
@@ -105,7 +106,19 @@ function withClientContext<TRequest extends FastifyRequest = FastifyRequest>(
         tenantSlug: auth.tenantSlug,
         userId: auth.user?._id ? String(auth.user._id) : undefined,
       },
-      () => handler(request as TRequest, reply, auth),
+      async () => {
+        // Bind the tenant DB for the whole request via AsyncLocalStorage so
+        // downstream model/provider lookups can't fall back to the process-global
+        // tenant DB that a concurrent request for another tenant overwrote. See
+        // withOpenAiClientContext for the full rationale.
+        const db = await getDatabase();
+        if (auth.tenantDbName && typeof db.runWithTenant === 'function') {
+          return db.runWithTenant(auth.tenantDbName, () =>
+            handler(request as TRequest, reply, auth),
+          );
+        }
+        return handler(request as TRequest, reply, auth);
+      },
     );
   };
 }

--- a/src/server/api/plugins/client-inference.ts
+++ b/src/server/api/plugins/client-inference.ts
@@ -6,6 +6,7 @@ import type { LicenseType } from '@/lib/license/license-manager';
 import { createLogger } from '@/lib/core/logger';
 import { isShuttingDown } from '@/lib/core/lifecycle';
 import { runWithRequestContext } from '@/lib/core/requestContext';
+import { getDatabase } from '@/lib/database';
 import {
   ApiTokenAuthError,
   type ApiTokenContext,
@@ -183,7 +184,22 @@ function withOpenAiClientContext<
         tenantSlug: auth.tenantSlug,
         userId: auth.user?._id ? String(auth.user._id) : undefined,
       },
-      () => handler(request as TRequest, reply, auth),
+      async () => {
+        // Bind the tenant DB for the entire request via a real AsyncLocalStorage
+        // scope. `requireApiTokenContext` only calls `switchToTenant` (enterWith +
+        // process-global), whose binding does NOT survive `await` boundaries — so
+        // downstream `getTenantDb()` reads can fall back to the global tenant DB
+        // that a concurrent request for another tenant has overwritten, making
+        // model/provider lookups intermittently resolve against the wrong tenant
+        // ("Provider configuration not found."). `runWithTenant` is immune.
+        const db = await getDatabase();
+        if (auth.tenantDbName && typeof db.runWithTenant === 'function') {
+          return db.runWithTenant(auth.tenantDbName, () =>
+            handler(request as TRequest, reply, auth),
+          );
+        }
+        return handler(request as TRequest, reply, auth);
+      },
     );
   };
 }

--- a/src/server/api/plugins/client-ocr-jobs.ts
+++ b/src/server/api/plugins/client-ocr-jobs.ts
@@ -42,6 +42,7 @@ import type {
   OcrJobWebhookEvent,
   OcrOutputKind,
 } from '@/lib/database';
+import { getDatabase } from '@/lib/database';
 import { readJsonBody, requireApiTokenContext } from '../fastify-utils';
 
 const logger = createLogger('api:client-ocr-jobs');
@@ -79,7 +80,17 @@ function withClientContext(
         tenantSlug: auth.tenantSlug,
         userId: auth.user?._id ? String(auth.user._id) : undefined,
       },
-      () => handler(request, reply, auth),
+      async () => {
+        // Bind the tenant DB for the whole request via AsyncLocalStorage so
+        // downstream model/provider lookups can't fall back to the process-global
+        // tenant DB that a concurrent request for another tenant overwrote. See
+        // withOpenAiClientContext (client-inference.ts) for the full rationale.
+        const db = await getDatabase();
+        if (auth.tenantDbName && typeof db.runWithTenant === 'function') {
+          return db.runWithTenant(auth.tenantDbName, () => handler(request, reply, auth));
+        }
+        return handler(request, reply, auth);
+      },
     );
   };
 }


### PR DESCRIPTION
## Incident
Client OpenAI-compatible API calls (`/client/v1/chat/completions`) intermittently return:
```
500 {"error":{"message":"Provider configuration not found.","type":"server_error"}}
```
Confirmed from `model_usage_logs` (prod): the **same** model/project/token alternates success ↔ error within seconds, with the provider correctly assigned — i.e. a non-deterministic race, not a missing config.

## Root cause
`findProviderByKey` → `getTenantDb()` reads `tenantContext.getStore() ?? this.tenantDb`. Requests bind the tenant via `switchToTenant`, which uses `AsyncLocalStorage.enterWith` + sets the process-global `this.tenantDb`. `enterWith`'s binding does **not** propagate past `await` boundaries, so after an await `getStore()` is empty and the read falls back to the **global** `this.tenantDb` — which a **concurrent request for another tenant** has overwritten. The provider/model lookup then runs against the wrong tenant DB and returns `null`.

Dashboard routes were already immune because `withApiRequestContext` wraps the handler in `db.runWithTenant(...)` (a real ALS scope). The client inference plugins used their own wrappers (`withOpenAiClientContext` / `withClientContext`) that only set the logging context — **this is exactly why the UI playground works but the API fails.**

## Fix
Wrap the three client inference plugin handlers in `db.runWithTenant(auth.tenantDbName, …)`, matching the dashboard pattern, so every downstream `getTenantDb()` resolves from the request-scoped ALS store and never the clobberable global:
- `client-inference.ts` — `/client/v1/chat/completions`, `/embeddings`
- `client-audio-ocr.ts` — STT/TTS/OCR
- `client-ocr-jobs.ts` — OCR jobs

## Verification
- `tsc --noEmit` clean; ESLint clean on the three files.
- No behavior change for single-tenant load; eliminates the cross-tenant interleaving failure.

## Immediate mitigation (until deployed)
Client-side retry on the transient 500 succeeds almost immediately; reducing concurrent cross-tenant traffic also lowers occurrence.

Targets a v1.2.12 hotfix + EE `-saas` re-pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)