### PR TITLE
fix: API-token access + model/provider add hardening, and unify tenant security

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -100,6 +100,7 @@
         "eslint-config-next": "15.5.15",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-prettier": "^5.5.4",
+        "mongodb-memory-server": "^11.2.0",
         "msw": "^2.12.10",
         "prettier": "^3.6.2",
         "tailwindcss": "^4",
@@ -9615,6 +9616,16 @@
       "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
       "license": "MIT"
     },
+    "node_modules/async-mutex": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.5.0.tgz",
+      "integrity": "sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -9740,6 +9751,120 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/bare-events": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.9.1.tgz",
+      "integrity": "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "peerDependencies": {
+        "bare-abort-controller": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-fs": {
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.2.tgz",
+      "integrity": "sha512-aTvMFUWkBmjzKtEQMDGGDNF8bkfpD5N1b/FCwt7A3wrU4t1o/e/85Wzkluh6JlODCjqVESYCkQCdTXqZ9G7VFg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-os": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.9.1.tgz",
+      "integrity": "sha512-6M5XjcnsygQNPMCMPXSK379xrJFiZ/AEMNBmFEmQW8d/789VQATvriyi5r0HYTL9TkQ26rn3kgdTG3aisbrXkQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "bare": ">=1.14.0"
+      }
+    },
+    "node_modules/bare-path": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.1.tgz",
+      "integrity": "sha512-ghj2DSK/2e99a1anTVPCV4m4YIYtrbXhfM7V3D7XZLOTsybnYyaJloymGqssQc8l/or0UoDyRtNQkmkEF/ysgQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-os": "^3.0.1"
+      }
+    },
+    "node_modules/bare-stream": {
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.3.tgz",
+      "integrity": "sha512-Kc+brLqvEqGkjyfiwJmImAOqLZL7OsoLKuavx+hJjgVV3nLTOjloJyPMFxjUPerGGHrNH0fLU06jjykMLWrERQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.8.1",
+        "streamx": "^2.25.0",
+        "teex": "^1.0.1"
+      },
+      "peerDependencies": {
+        "bare-abort-controller": "*",
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        },
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-stream/node_modules/b4a": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.5.tgz",
+      "integrity": "sha512-K+y9xF1tN+CdPu4qWwr0QiK1Al07eFPGYK5M2pDXcmHdMdgC/tT/bpmMe1hrmRHaidKLkXrC+cRNYf3XVDUhSQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-path": "^3.0.0"
+      }
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -10551,6 +10676,13 @@
       "engines": {
         "node": ">=12.20.0"
       }
+    },
+    "node_modules/commondir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -11509,7 +11641,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -12082,6 +12213,16 @@
         "node": ">=0.8.x"
       }
     },
+    "node_modules/events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.7.0"
+      }
+    },
     "node_modules/expand-template": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
@@ -12125,6 +12266,13 @@
       "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fast-glob": {
       "version": "3.3.1",
@@ -12429,6 +12577,40 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/find-cache-dir": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
+      "integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commondir": "^1.0.1",
+        "make-dir": "^3.0.2",
+        "pkg-dir": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/avajs/find-cache-dir?sponsor=1"
+      }
+    },
+    "node_modules/find-cache-dir/node_modules/make-dir": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/find-my-way": {
@@ -16250,6 +16432,167 @@
         "whatwg-url": "^14.1.0 || ^13.0.0"
       }
     },
+    "node_modules/mongodb-memory-server": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/mongodb-memory-server/-/mongodb-memory-server-11.2.0.tgz",
+      "integrity": "sha512-506AD8qvClVx8Raw/WhAUUWBgIXPyi856iC01aa5vAzHmn6WOXC6ulvudkTF7oTMzJxkyA0A84VpD4BpyfqJ9w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "mongodb-memory-server-core": "11.2.0",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/mongodb-memory-server-core": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/mongodb-memory-server-core/-/mongodb-memory-server-core-11.2.0.tgz",
+      "integrity": "sha512-vOoDtn0JiLrHvZY81Rp/UtKXXK0rtJHZGZFVnccvJwYitPLNspO0Ty0grqFQOe7iAET8+GI4zAQcphg+R3vxQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async-mutex": "^0.5.0",
+        "camelcase": "^6.3.0",
+        "debug": "^4.4.3",
+        "find-cache-dir": "^3.3.2",
+        "follow-redirects": "^1.16.0",
+        "https-proxy-agent": "^7.0.6",
+        "mongodb": "^7.2.0",
+        "new-find-package-json": "^2.0.0",
+        "semver": "^7.7.3",
+        "tar-stream": "^3.1.8",
+        "tslib": "^2.8.1",
+        "yauzl": "^3.3.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/mongodb-memory-server-core/node_modules/@types/whatwg-url": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-13.0.0.tgz",
+      "integrity": "sha512-N8WXpbE6Wgri7KUSvrmQcqrMllKZ9uxkYWMt+mCSGwNc0Hsw9VQTW7ApqI4XNrx6/SaM2QQJCzMPDEXE058s+Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/webidl-conversions": "*"
+      }
+    },
+    "node_modules/mongodb-memory-server-core/node_modules/b4a": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mongodb-memory-server-core/node_modules/bson": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-7.3.0.tgz",
+      "integrity": "sha512-WmjjMEwFwZHmGnAb7wn90MhkiT+mTm4x/rLj7dvAPWfwnVWDXhLun2e+UM88MJoDGW624yzZglVX/zTBy9ZZMw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/mongodb-memory-server-core/node_modules/mongodb": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-7.3.0.tgz",
+      "integrity": "sha512-WpCqSx7JAU9vcyjm/SU7ydnHls2YrfU3Y3sx4Ml9D7sPe4mXPlaapndiurDXrQ7/VvJkB4/i7b7WovHb8bd8sg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@mongodb-js/saslprep": "^1.3.0",
+        "bson": "^7.2.0",
+        "mongodb-connection-string-url": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-providers": "^3.806.0",
+        "@mongodb-js/zstd": "^7.0.0",
+        "gcp-metadata": "^7.0.1",
+        "kerberos": "^7.0.0",
+        "mongodb-client-encryption": ">=7.0.0 <7.1.0",
+        "snappy": "^7.3.2",
+        "socks": "^2.8.6"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-providers": {
+          "optional": true
+        },
+        "@mongodb-js/zstd": {
+          "optional": true
+        },
+        "gcp-metadata": {
+          "optional": true
+        },
+        "kerberos": {
+          "optional": true
+        },
+        "mongodb-client-encryption": {
+          "optional": true
+        },
+        "snappy": {
+          "optional": true
+        },
+        "socks": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mongodb-memory-server-core/node_modules/mongodb-connection-string-url": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-7.0.1.tgz",
+      "integrity": "sha512-h0AZ9A7IDVwwHyMxmdMXKy+9oNlF0zFoahHiX3vQ8e3KFcSP3VmsmfvtRSuLPxmyv2vjIDxqty8smTgie/SNRQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/whatwg-url": "^13.0.0",
+        "whatwg-url": "^14.1.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/mongodb-memory-server-core/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/mongodb-memory-server-core/node_modules/tar-stream": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.2.0.tgz",
+      "integrity": "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "bare-fs": "^4.5.5",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
     "node_modules/mongodb/node_modules/bson": {
       "version": "6.10.4",
       "resolved": "https://registry.npmjs.org/bson/-/bson-6.10.4.tgz",
@@ -16524,6 +16867,19 @@
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "license": "MIT"
+    },
+    "node_modules/new-find-package-json": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/new-find-package-json/-/new-find-package-json-2.0.0.tgz",
+      "integrity": "sha512-lDcBsjBSMlj3LXH2v/FW3txlh2pYTjmbOXPYJD93HI5EwuLzI11tdHSIpUMmfq/IOsldj4Ps8M8flhm+pCK4Ew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      }
     },
     "node_modules/next": {
       "version": "15.5.18",
@@ -17136,6 +17492,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/pako": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
@@ -17341,6 +17707,13 @@
         "url": "https://github.com/sponsors/Borewit"
       }
     },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/perfect-debounce": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
@@ -17493,6 +17866,75 @@
       "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
       "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
       "license": "MIT"
+    },
+    "node_modules/pkg-dir": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "find-up": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/playwright": {
       "version": "1.59.1",
@@ -19253,6 +19695,18 @@
       "integrity": "sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==",
       "license": "MIT"
     },
+    "node_modules/streamx": {
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.28.0.tgz",
+      "integrity": "sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "events-universal": "^1.0.0",
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
+      }
+    },
     "node_modules/strict-event-emitter": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
@@ -19696,6 +20150,41 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/teex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "streamx": "^2.12.5"
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
+      }
+    },
+    "node_modules/text-decoder/node_modules/b4a": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
       }
     },
     "node_modules/text-hex": {
@@ -22515,6 +23004,19 @@
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
       "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yauzl": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.4.0.tgz",
+      "integrity": "sha512-jIH9yLR9wqr0wOS0TpBvo/g/2UgZH5qePVbjgRliiF0BYvOZyaBknKsF+x9Iht0O6sqgnB93rCICdOZFecJuDw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pend": "~1.2.0"
+      },
       "engines": {
         "node": ">=12"
       }

--- a/package.json
+++ b/package.json
@@ -115,6 +115,7 @@
     "eslint-config-next": "15.5.15",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.5.4",
+    "mongodb-memory-server": "^11.2.0",
     "msw": "^2.12.10",
     "prettier": "^3.6.2",
     "tailwindcss": "^4",

--- a/src/__tests__/api/auth-misc.test.ts
+++ b/src/__tests__/api/auth-misc.test.ts
@@ -107,9 +107,12 @@ describe('auth misc routes', () => {
       expect(body.mustChangePassword).toBe(true);
     });
 
-    it('switches to tenant database before user lookup', async () => {
+    it('binds the tenant database (runWithTenant) before user lookup', async () => {
       await session(validHeaders);
-      expect(db.switchToTenant).toHaveBeenCalledWith('tenant_acme');
+      // The session wrapper binds the tenant for the whole handler via
+      // runWithTenant (immune to the concurrent process-global race) rather
+      // than a bare switchToTenant.
+      expect(db.runWithTenant).toHaveBeenCalledWith('tenant_acme', expect.any(Function));
     });
 
     it('returns 500 on unexpected error', async () => {

--- a/src/__tests__/api/client-api-context.test.ts
+++ b/src/__tests__/api/client-api-context.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Tests for the SINGLE canonical client (API-token) request wrapper.
+ *
+ * Every token-authenticated route now funnels through
+ * `withClientApiRequestContext` / `withOpenAiApiRequestContext` in
+ * fastify-utils. These tests lock the contract that all of them inherit:
+ *   - missing/invalid token → 401 (correct envelope per error style)
+ *   - valid token → handler runs with `auth` and the tenant DB bound via runWithTenant
+ *   - RBAC enforced for mapped paths (closing the historical chat/embeddings/
+ *     ocr-jobs bypass); skippable via `{ rbac: false }`
+ *   - OpenAI error envelope for `withOpenAiApiRequestContext`
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ── Mocks ───────────────────────────────────────────────────────────────────
+vi.mock('@/lib/services/apiTokenAuth', () => {
+  class ApiTokenAuthError extends Error {
+    status: number;
+    constructor(message: string, status = 401) {
+      super(message);
+      this.name = 'ApiTokenAuthError';
+      this.status = status;
+    }
+  }
+  return {
+    ApiTokenAuthError,
+    requireApiTokenFromHeader: vi.fn(),
+  };
+});
+
+vi.mock('@/lib/database', () => ({
+  getDatabase: vi.fn(),
+}));
+
+vi.mock('@/lib/security/rbac', () => ({
+  getPermissionServiceForPath: vi.fn(),
+  authorizeServiceRequest: vi.fn(),
+}));
+
+vi.mock('@/lib/core/lifecycle', () => ({
+  isShuttingDown: vi.fn().mockReturnValue(false),
+}));
+
+import { requireApiTokenFromHeader, ApiTokenAuthError } from '@/lib/services/apiTokenAuth';
+import { getDatabase } from '@/lib/database';
+import { getPermissionServiceForPath, authorizeServiceRequest } from '@/lib/security/rbac';
+import {
+  withClientApiRequestContext,
+  withOpenAiApiRequestContext,
+} from '@/server/api/fastify-utils';
+import { createFastifyApiTestApp, parseJsonBody } from '../helpers/fastify-api';
+
+const AUTH_CTX = {
+  token: 'tok_abc',
+  tokenRecord: { _id: 'tok-1', userId: 'user-1' },
+  tenant: { licenseType: 'STARTER' },
+  tenantId: 'tenant-1',
+  tenantSlug: 'acme',
+  tenantDbName: 'tenant_acme',
+  projectId: 'proj-1',
+  user: { _id: 'user-1', role: 'user', tenantId: 'tenant-1' },
+};
+
+const runWithTenant = vi.fn(<T>(_db: string, fn: () => T | Promise<T>) => fn());
+
+async function buildApp() {
+  return createFastifyApiTestApp(async (app) => {
+    app.get(
+      '/client/v1/probe',
+      withClientApiRequestContext(async (_req, reply, auth) =>
+        reply.send({ ok: true, tenant: auth.tenantDbName, userId: auth.tokenRecord.userId }),
+      ),
+    );
+    app.get(
+      '/client/v1/probe-norbac',
+      withClientApiRequestContext(
+        async (_req, reply) => reply.send({ ok: true }),
+        { rbac: false },
+      ),
+    );
+    app.get(
+      '/client/v1/chat/probe',
+      withOpenAiApiRequestContext(async (_req, reply) => reply.send({ ok: true })),
+    );
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  (requireApiTokenFromHeader as ReturnType<typeof vi.fn>).mockResolvedValue(AUTH_CTX);
+  (getDatabase as ReturnType<typeof vi.fn>).mockResolvedValue({ runWithTenant });
+  (getPermissionServiceForPath as ReturnType<typeof vi.fn>).mockReturnValue(null); // unmapped by default
+  (authorizeServiceRequest as ReturnType<typeof vi.fn>).mockReturnValue({ allowed: true });
+});
+
+describe('withClientApiRequestContext (canonical token wrapper)', () => {
+  it('rejects a missing/invalid token with 401 and a JSON error envelope', async () => {
+    (requireApiTokenFromHeader as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new ApiTokenAuthError('Invalid API token', 401),
+    );
+    const app = await buildApp();
+    const res = await app.inject({ method: 'GET', url: '/api/client/v1/probe' });
+    expect(res.statusCode).toBe(401);
+    expect(parseJsonBody<{ error: string }>(res.body).error).toMatch(/invalid api token/i);
+  });
+
+  it('runs the handler with auth and binds the tenant via runWithTenant', async () => {
+    const app = await buildApp();
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/client/v1/probe',
+      headers: { authorization: 'Bearer tok_abc' },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = parseJsonBody<{ tenant: string; userId: string }>(res.body);
+    expect(body.tenant).toBe('tenant_acme');
+    expect(body.userId).toBe('user-1');
+    expect(runWithTenant).toHaveBeenCalledWith('tenant_acme', expect.any(Function));
+  });
+
+  it('enforces RBAC: a mapped path the token user is not allowed → 403', async () => {
+    (getPermissionServiceForPath as ReturnType<typeof vi.fn>).mockReturnValue('models');
+    (authorizeServiceRequest as ReturnType<typeof vi.fn>).mockReturnValue({
+      allowed: false,
+      service: 'models',
+      required: 'write',
+    });
+    const app = await buildApp();
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/client/v1/probe',
+      headers: { authorization: 'Bearer tok_abc' },
+    });
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('allows a mapped path when the token user IS authorized', async () => {
+    (getPermissionServiceForPath as ReturnType<typeof vi.fn>).mockReturnValue('models');
+    (authorizeServiceRequest as ReturnType<typeof vi.fn>).mockReturnValue({ allowed: true });
+    const app = await buildApp();
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/client/v1/probe',
+      headers: { authorization: 'Bearer tok_abc' },
+    });
+    expect(res.statusCode).toBe(200);
+  });
+
+  it('skips RBAC when { rbac: false } even on a mapped path', async () => {
+    (getPermissionServiceForPath as ReturnType<typeof vi.fn>).mockReturnValue('models');
+    (authorizeServiceRequest as ReturnType<typeof vi.fn>).mockReturnValue({ allowed: false });
+    const app = await buildApp();
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/client/v1/probe-norbac',
+      headers: { authorization: 'Bearer tok_abc' },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(authorizeServiceRequest).not.toHaveBeenCalled();
+  });
+});
+
+describe('withOpenAiApiRequestContext (OpenAI error envelope)', () => {
+  it('emits the OpenAI error shape on auth failure', async () => {
+    (requireApiTokenFromHeader as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new ApiTokenAuthError('Invalid API token', 401),
+    );
+    const app = await buildApp();
+    const res = await app.inject({ method: 'GET', url: '/api/client/v1/chat/probe' });
+    expect(res.statusCode).toBe(401);
+    const body = parseJsonBody<{ error: { message: string; type: string } }>(res.body);
+    expect(body.error.message).toMatch(/invalid api token/i);
+    expect(body.error.type).toBe('invalid_request_error');
+  });
+
+  it('still binds the tenant and runs the handler on success', async () => {
+    const app = await buildApp();
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/client/v1/chat/probe',
+      headers: { authorization: 'Bearer tok_abc' },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(runWithTenant).toHaveBeenCalledWith('tenant_acme', expect.any(Function));
+  });
+});

--- a/src/__tests__/api/models-providers.test.ts
+++ b/src/__tests__/api/models-providers.test.ts
@@ -135,4 +135,24 @@ describe('/api/models/providers', () => {
     });
     expect(res.statusCode).toBe(400);
   });
+
+  it('returns 409 (not 500) when the provider key already exists', async () => {
+    (createModelProvider as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error('Provider with key "openai-1" already exists.'),
+    );
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/models/providers',
+      headers: HEADERS,
+      payload: JSON.stringify({
+        key: 'openai-1',
+        label: 'OpenAI Main',
+        driver: 'openai',
+        credentials: {},
+      }),
+    });
+    expect(res.statusCode).toBe(409);
+    const body = parseJsonBody<{ error: string }>(res.body);
+    expect(body.error).toMatch(/already exists/i);
+  });
 });

--- a/src/__tests__/api/tenant-security-consolidation.test.ts
+++ b/src/__tests__/api/tenant-security-consolidation.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Architecture guard — keeps tenant security managed from ONE place.
+ *
+ * Every per-request auth + tenant-binding + RBAC concern must go through the
+ * canonical wrappers in `src/server/api/fastify-utils.ts`
+ * (`withApiRequestContext` for session routes, `withClientApiRequestContext` /
+ * `withOpenAiApiRequestContext` for token routes). Plugins must NOT hand-roll
+ * their own wrappers or call the low-level token primitives directly — that is
+ * exactly how clones drifted and silently dropped RBAC on chat/embeddings/
+ * ocr-jobs. This test fails loudly if a new clone is introduced.
+ */
+import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+
+const PLUGINS_DIR = path.join(process.cwd(), 'src/server/api/plugins');
+
+function pluginFiles(): string[] {
+  return readdirSync(PLUGINS_DIR)
+    .filter((f) => f.endsWith('.ts') && !f.endsWith('.test.ts'))
+    .map((f) => path.join(PLUGINS_DIR, f));
+}
+
+function read(file: string): string {
+  return readFileSync(file, 'utf8');
+}
+
+describe('tenant-security consolidation guards', () => {
+  it('no plugin calls the low-level token primitives directly (use a canonical wrapper)', () => {
+    const offenders: string[] = [];
+    for (const file of pluginFiles()) {
+      const src = read(file);
+      // Calls (not imports) of the raw token-context resolvers. The canonical
+      // wrappers are the only sanctioned callers.
+      if (/\brequireApiTokenContext\s*\(/.test(src) || /\brequireApiTokenFromHeader\s*\(/.test(src)) {
+        offenders.push(path.basename(file));
+      }
+    }
+    expect(offenders, `These plugins resolve the API token themselves instead of using a canonical wrapper: ${offenders.join(', ')}`).toEqual([]);
+  });
+
+  it('no plugin defines its own request-context wrapper (no clones)', () => {
+    const offenders: string[] = [];
+    const localWrapperDef = /(?:function|const)\s+with[A-Za-z]*(?:Client|OpenAi|Context)[A-Za-z]*\s*(?:<|=|\()/;
+    for (const file of pluginFiles()) {
+      const src = read(file);
+      if (localWrapperDef.test(src)) {
+        offenders.push(path.basename(file));
+      }
+    }
+    expect(offenders, `These plugins define a local context wrapper (clone). Move the logic into fastify-utils and pass options instead: ${offenders.join(', ')}`).toEqual([]);
+  });
+
+  it('the retired clone names never reappear', () => {
+    const banned = ['withOpenAiClientContext', 'withClientContext'];
+    const offenders: string[] = [];
+    for (const file of pluginFiles()) {
+      const src = read(file);
+      for (const name of banned) {
+        if (src.includes(name)) offenders.push(`${path.basename(file)}:${name}`);
+      }
+    }
+    expect(offenders, `Retired clone wrappers reintroduced: ${offenders.join(', ')}`).toEqual([]);
+  });
+
+  it('every client-* plugin authenticates via a canonical token wrapper', () => {
+    const missing: string[] = [];
+    for (const file of pluginFiles()) {
+      const base = path.basename(file);
+      if (!base.startsWith('client-')) continue;
+      const src = read(file);
+      const usesCanonical =
+        src.includes('withClientApiRequestContext') || src.includes('withOpenAiApiRequestContext');
+      if (!usesCanonical) missing.push(base);
+    }
+    expect(missing, `These client plugins do not use a canonical token wrapper: ${missing.join(', ')}`).toEqual([]);
+  });
+
+  it('the canonical wrappers are all exported from the single fastify-utils module', () => {
+    const utils = read(path.join(process.cwd(), 'src/server/api/fastify-utils.ts'));
+    expect(utils).toMatch(/export function withApiRequestContext/);
+    expect(utils).toMatch(/export function withClientApiRequestContext/);
+    expect(utils).toMatch(/export function withOpenAiApiRequestContext/);
+  });
+});

--- a/src/__tests__/integration/api-token-auth.test.ts
+++ b/src/__tests__/integration/api-token-auth.test.ts
@@ -103,6 +103,41 @@ describe('requireApiToken', () => {
     });
   });
 
+  describe('token expiry', () => {
+    it('throws 401 when the token has an expiresAt in the past', async () => {
+      // Distinct token value so the auth cache cannot serve a non-expired entry.
+      const expiredToken = {
+        ...API_TOKEN_VALID,
+        token: 'sk-test-expired-token-xyz789',
+        expiresAt: new Date(Date.now() - 60_000),
+      };
+      mockDb.findApiTokenByHash.mockResolvedValue(expiredToken);
+      mockDb.findTenantById.mockResolvedValue(TENANT_ACME);
+
+      const req = buildRequest(`Bearer ${expiredToken.token}`);
+      await expect(requireApiToken(req)).rejects.toMatchObject({
+        name: 'ApiTokenAuthError',
+        status: 401,
+        message: expect.stringMatching(/expired/i),
+      });
+    });
+
+    it('authenticates when expiresAt is in the future', async () => {
+      const futureToken = {
+        ...API_TOKEN_VALID,
+        token: 'sk-test-future-token-xyz789',
+        expiresAt: new Date(Date.now() + 3_600_000),
+      };
+      mockDb.findApiTokenByHash.mockResolvedValue(futureToken);
+      mockDb.findTenantById.mockResolvedValue(TENANT_ACME);
+      mockDb.findUserById.mockResolvedValue(USER_ALICE);
+
+      const req = buildRequest(`Bearer ${futureToken.token}`);
+      const ctx = await requireApiToken(req);
+      expect(ctx.tenantId).toBe(TENANT_ACME._id);
+    });
+  });
+
   describe('successful authentication', () => {
     beforeEach(() => {
       mockDb.findApiTokenByHash.mockResolvedValue(API_TOKEN_VALID);

--- a/src/__tests__/integration/db-parity.test.ts
+++ b/src/__tests__/integration/db-parity.test.ts
@@ -161,3 +161,130 @@ describeForEachProvider('User + Project + UserProject', (getDb) => {
     expect(await db.listUserProjectsByUser(String(user._id))).toHaveLength(0);
   });
 });
+
+describeForEachProvider('Provider + Model CRUD + malformed-id safety', (getDb) => {
+  let slug: string;
+  let dbName: string;
+  let tenantId: string;
+  let projectId: string;
+
+  beforeEach(async () => {
+    slug = `acme-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    dbName = `tenant_${slug}`;
+    const db = getDb();
+    const tenant = await db.createTenant({
+      companyName: 'Acme',
+      slug,
+      dbName,
+      licenseType: 'FREE',
+      ownerId: 'pending',
+    });
+    tenantId = String(tenant._id);
+    await db.switchToTenant(dbName);
+    const project = await db.createProject({
+      tenantId,
+      key: 'project-a',
+      name: 'Project A',
+      createdBy: 'tester',
+    });
+    projectId = String(project._id);
+  });
+
+  it('creates, finds, updates and deletes a provider by id', async () => {
+    const db = getDb();
+    const provider = await db.createProvider({
+      key: 'my-openai',
+      driver: 'openai',
+      type: 'model',
+      label: 'My OpenAI',
+      tenantId,
+      projectIds: [projectId],
+      credentialsEnc: JSON.stringify({ apiKey: 'sk-test' }),
+      settings: {},
+      status: 'active',
+      createdBy: 'tester',
+    });
+    const id = String(provider._id);
+
+    expect((await db.findProviderById(id))?.key).toBe('my-openai');
+    expect((await db.updateProvider(id, { label: 'Renamed' }))?.label).toBe('Renamed');
+    expect(await db.deleteProvider(id)).toBe(true);
+  });
+
+  // Regression: malformed (non-ObjectId) ids must resolve to "not found" on BOTH
+  // backends — never throw a BSONError. On Mongo (SaaS) an unguarded
+  // `new ObjectId(id)` would 500; SQLite (on-prem) returns null. They must match.
+  it('treats a malformed provider id as not-found (no throw) on every backend', async () => {
+    const db = getDb();
+    await expect(db.findProviderById('not-a-valid-id')).resolves.toBeNull();
+    await expect(db.updateProvider('not-a-valid-id', { label: 'x' })).resolves.toBeNull();
+    await expect(db.deleteProvider('not-a-valid-id')).resolves.toBe(false);
+  });
+
+  it('creates, finds, updates and deletes a model by id', async () => {
+    const db = getDb();
+    const model = await db.createModel({
+      key: 'gpt-4o',
+      name: 'GPT-4o',
+      providerKey: 'openai',
+      providerDriver: 'openai',
+      category: 'llm',
+      modelId: 'gpt-4o',
+      projectId,
+      tenantId,
+      settings: {},
+      pricing: { inputTokenPer1M: 0, outputTokenPer1M: 0 },
+    });
+    const id = String(model._id);
+
+    expect((await db.findModelById(id))?.key).toBe('gpt-4o');
+    expect((await db.updateModel(id, { name: 'GPT-4o v2' }))?.name).toBe('GPT-4o v2');
+    expect(await db.deleteModel(id)).toBe(true);
+  });
+
+  it('treats a malformed model id as not-found (no throw) on every backend', async () => {
+    const db = getDb();
+    await expect(db.findModelById('not-a-valid-id')).resolves.toBeNull();
+    await expect(db.updateModel('not-a-valid-id', { name: 'x' })).resolves.toBeNull();
+    await expect(db.deleteModel('not-a-valid-id')).resolves.toBe(false);
+  });
+
+  // Regression: a duplicate provider key must be rejected at the DB layer on
+  // BOTH backends (SQLite has idx_providers_key; Mongo gets the same unique
+  // index lazily). This closes the concurrent-create race window.
+  it('rejects a duplicate provider key at the DB layer on every backend', async () => {
+    const db = getDb();
+    const base = {
+      key: 'dup-openai',
+      driver: 'openai',
+      type: 'model' as const,
+      label: 'A',
+      tenantId,
+      projectIds: [projectId],
+      credentialsEnc: JSON.stringify({ apiKey: 'sk' }),
+      settings: {},
+      status: 'active' as const,
+      createdBy: 'tester',
+    };
+    await db.createProvider(base);
+    await expect(db.createProvider({ ...base, label: 'B' })).rejects.toBeTruthy();
+  });
+
+  it('rejects a duplicate model key at the DB layer on every backend', async () => {
+    const db = getDb();
+    const base = {
+      key: 'dup-gpt',
+      name: 'GPT',
+      providerKey: 'openai',
+      providerDriver: 'openai',
+      category: 'llm' as const,
+      modelId: 'gpt-4o',
+      projectId,
+      tenantId,
+      settings: {},
+      pricing: { inputTokenPer1M: 0, outputTokenPer1M: 0 },
+    };
+    await db.createModel(base);
+    await expect(db.createModel({ ...base, name: 'GPT2' })).rejects.toBeTruthy();
+  });
+});

--- a/src/__tests__/integration/tenant-db-concurrency.test.ts
+++ b/src/__tests__/integration/tenant-db-concurrency.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Integration test — tenant-DB binding under concurrent multi-tenant load.
+ *
+ * Production runs many tenants through one process. The danger is cross-tenant
+ * leakage: a write meant for tenant A landing in tenant B's database because a
+ * concurrent request for B overwrote the process-global tenant binding.
+ *
+ * `getTenantDb()` resolves `tenantContext.getStore() ?? this.tenantDb`. The
+ * AsyncLocalStorage store (set by `switchToTenant`'s `enterWith` and by
+ * `runWithTenant`'s `run`) is per-async-context and survives `await`
+ * boundaries within the same continuation; only code that reads `getTenantDb()`
+ * with NO tenant bound in its own async ancestry falls back to the mutable
+ * `this.tenantDb` global and is racy.
+ *
+ * This test pins that invariant: detached writers that each call
+ * `switchToTenant` in their own continuation (the shape of `logModelUsage`,
+ * tracing/MCP/tool logging, etc.) must NEVER leak across tenants, even when
+ * hundreds of them interleave. If someone refactors a writer to read the
+ * ambient DB without binding its own tenant, this test fails.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { SQLiteProvider } from '@/lib/database/sqlite.provider';
+
+let db: SQLiteProvider;
+let tmpDir: string;
+
+beforeAll(async () => {
+  tmpDir = mkdtempSync(path.join(tmpdir(), 'cognipeer-tenant-conc-'));
+  db = new SQLiteProvider(tmpDir, 'conc_main');
+  await db.connect();
+  // Pre-open both tenant DBs (schema + connection cached).
+  await db.switchToTenant('tenant_a');
+  await db.switchToTenant('tenant_b');
+});
+
+afterAll(async () => {
+  await db.disconnect();
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+// Mirrors the detached-writer shape: resolve db, bind tenant, (optionally yield)
+// then write — all relying on the ambient binding for the actual query.
+async function detachedWrite(dbName: string, tenantId: string, key: string, yieldFirst: boolean) {
+  await db.switchToTenant(dbName);
+  if (yieldFirst) await new Promise((r) => setTimeout(r, 0));
+  await db.createProject({
+    tenantId, key, name: 'x', description: 'x', createdBy: 'u', updatedBy: 'u',
+  } as never);
+}
+
+async function countLeaks(yieldFirst: boolean, iterations: number) {
+  const tag = yieldFirst ? 'y' : 'n';
+  const tasks: Promise<unknown>[] = [];
+  for (let i = 0; i < iterations; i++) {
+    tasks.push(detachedWrite('tenant_a', 'tenant-a-id', `a-${tag}-${i}`, yieldFirst));
+    tasks.push(detachedWrite('tenant_b', 'tenant-b-id', `b-${tag}-${i}`, yieldFirst));
+  }
+  await Promise.all(tasks);
+
+  const aProjects = await db.runWithTenant('tenant_a', () => db.listProjects('tenant-a-id'));
+  const bProjects = await db.runWithTenant('tenant_b', () => db.listProjects('tenant-b-id'));
+  const inRound = (arr: { key: string }[], p: string) =>
+    arr.filter((x) => x.key.startsWith(p) && x.key.includes(`-${tag}-`));
+  return {
+    aLeakedToB: inRound(bProjects, 'a-').length,
+    bLeakedToA: inRound(aProjects, 'b-').length,
+  };
+}
+
+describe('tenant DB isolation under concurrent detached writes', () => {
+  it('no cross-tenant leak when switch and write share a continuation', async () => {
+    const r = await countLeaks(false, 300);
+    expect(r.aLeakedToB + r.bLeakedToA).toBe(0);
+  });
+
+  it('no cross-tenant leak even with an await between switch and write', async () => {
+    const r = await countLeaks(true, 300);
+    expect(r.aLeakedToB + r.bLeakedToA).toBe(0);
+  });
+});

--- a/src/__tests__/unit/provider-service.test.ts
+++ b/src/__tests__/unit/provider-service.test.ts
@@ -117,6 +117,26 @@ describe('createProviderConfig', () => {
     ).rejects.toThrow('Provider with key "openai-main" already exists.');
   });
 
+  it('maps a concurrent duplicate-key insert (race) to an "already exists" error', async () => {
+    // Pre-check passes (no existing), but the insert loses the race and the DB
+    // rejects with a unique-constraint violation.
+    db.findProviderByKey.mockResolvedValue(null);
+    db.createProvider.mockRejectedValue(
+      Object.assign(new Error('E11000 duplicate key error'), { code: 11000 }),
+    );
+
+    await expect(
+      createProviderConfig(TENANT_DB, TENANT_ID, {
+        key: 'openai-main',
+        type: 'model',
+        driver: 'openai',
+        label: 'OpenAI',
+        credentials: {},
+        createdBy: USER_ID,
+      }),
+    ).rejects.toThrow('Provider with key "openai-main" already exists.');
+  });
+
   it('defaults status to active when not provided', async () => {
     db.findProviderByKey.mockResolvedValue(null);
     db.createProvider.mockResolvedValue(makeProviderRecord());
@@ -187,6 +207,36 @@ describe('updateProviderConfig', () => {
     });
 
     expect(encryptObject).not.toHaveBeenCalled();
+  });
+
+  it('preserves the existing API key when an unrelated credential field is edited (no key wipe)', async () => {
+    // Existing provider has an encrypted apiKey; decryptObject mock returns it.
+    db.findProviderById.mockResolvedValue(makeProviderRecord());
+    (decryptObject as ReturnType<typeof vi.fn>).mockReturnValueOnce({ apiKey: 'secret-key-123' });
+    db.updateProvider.mockResolvedValue(makeProviderRecord());
+
+    // User edits baseUrl and leaves the apiKey field blank (UI re-inits secrets to '').
+    await updateProviderConfig(TENANT_DB, 'prov-1', {
+      credentials: { baseUrl: 'https://proxy.example.com', apiKey: '' },
+    });
+
+    // Blank apiKey must NOT wipe the stored one; baseUrl is merged in.
+    expect(encryptObject).toHaveBeenCalledWith({
+      apiKey: 'secret-key-123',
+      baseUrl: 'https://proxy.example.com',
+    });
+  });
+
+  it('overwrites the API key only when a non-empty value is supplied', async () => {
+    db.findProviderById.mockResolvedValue(makeProviderRecord());
+    (decryptObject as ReturnType<typeof vi.fn>).mockReturnValueOnce({ apiKey: 'old-key' });
+    db.updateProvider.mockResolvedValue(makeProviderRecord());
+
+    await updateProviderConfig(TENANT_DB, 'prov-1', {
+      credentials: { apiKey: 'new-key' },
+    });
+
+    expect(encryptObject).toHaveBeenCalledWith({ apiKey: 'new-key' });
   });
 
   it('updates status when provided', async () => {

--- a/src/lib/database/mongodb/model.mixin.ts
+++ b/src/lib/database/mongodb/model.mixin.ts
@@ -4,7 +4,7 @@
  * Includes model CRUD, usage logging, and usage aggregation.
  */
 
-import { ObjectId } from 'mongodb';
+import { ObjectId, type Filter } from 'mongodb';
 import type {
   IModel,
   IModelUsageLog,
@@ -14,15 +14,40 @@ import type {
   ModelProviderType,
 } from '../provider.interface';
 import type { Constructor } from './types';
-import { MongoDBProviderBase, COLLECTIONS } from './base';
+import { MongoDBProviderBase, COLLECTIONS, logger } from './base';
 
 export function ModelMixin<TBase extends Constructor<MongoDBProviderBase>>(Base: TBase) {
   return class ModelOps extends Base {
+    private modelIndexesReady = new Set<string>();
+
     // ── Model CRUD ───────────────────────────────────────────────────
+
+    /**
+     * Best-effort: create the unique `key` index so duplicate model keys fail
+     * at the DB layer (matching the SQLite schema's `idx_models_key`). Never
+     * throws — pre-existing duplicates are logged and the index is skipped.
+     */
+    private async ensureModelIndexes(): Promise<void> {
+      const db = this.getTenantDb();
+      const dbName = db.databaseName;
+      if (this.modelIndexesReady.has(dbName)) return;
+      this.modelIndexesReady.add(dbName);
+      try {
+        await db
+          .collection(COLLECTIONS.models)
+          .createIndex({ key: 1 }, { unique: true, name: 'uniq_model_key' });
+      } catch (error) {
+        logger.warn('Could not ensure unique model key index (pre-existing duplicates?)', {
+          dbName,
+          error,
+        });
+      }
+    }
 
     async createModel(
       model: Omit<IModel, '_id' | 'createdAt' | 'updatedAt'>,
     ): Promise<IModel> {
+      await this.ensureModelIndexes();
       const db = this.getTenantDb();
       const now = new Date();
       const pricing = {
@@ -70,10 +95,15 @@ export function ModelMixin<TBase extends Constructor<MongoDBProviderBase>>(Base:
         updateData.provider = data.providerDriver as ModelProviderType;
       }
 
+      // Malformed ids must resolve to "not found", never throw a BSONError
+      // (matches the SQLite provider used on-prem).
+      const idFilter: Filter<IModel> = ObjectId.isValid(id)
+        ? { _id: new ObjectId(id) }
+        : { _id: id };
       const result = await db
         .collection<IModel>(COLLECTIONS.models)
         .findOneAndUpdate(
-          { _id: new ObjectId(id) },
+          idFilter,
           { $set: updateData },
           { returnDocument: 'after' },
         );
@@ -90,9 +120,12 @@ export function ModelMixin<TBase extends Constructor<MongoDBProviderBase>>(Base:
 
     async deleteModel(id: string): Promise<boolean> {
       const db = this.getTenantDb();
+      const idFilter: Filter<IModel> = ObjectId.isValid(id)
+        ? { _id: new ObjectId(id) }
+        : { _id: id };
       const result = await db
-        .collection(COLLECTIONS.models)
-        .deleteOne({ _id: new ObjectId(id) });
+        .collection<IModel>(COLLECTIONS.models)
+        .deleteOne(idFilter);
       return result.deletedCount === 1;
     }
 
@@ -140,7 +173,9 @@ export function ModelMixin<TBase extends Constructor<MongoDBProviderBase>>(Base:
 
     async findModelById(id: string, projectId?: string): Promise<IModel | null> {
       const db = this.getTenantDb();
-      const query: Record<string, unknown> = { _id: new ObjectId(id) };
+      const query: Record<string, unknown> = {
+        _id: ObjectId.isValid(id) ? new ObjectId(id) : id,
+      };
       if (projectId) {
         query.projectId = projectId;
       }

--- a/src/lib/database/mongodb/provider-record.mixin.ts
+++ b/src/lib/database/mongodb/provider-record.mixin.ts
@@ -7,15 +7,43 @@
 import { ObjectId, type Filter } from 'mongodb';
 import type { IProviderRecord, ProviderDomain } from '../provider.interface';
 import type { Constructor } from './types';
-import { MongoDBProviderBase, COLLECTIONS } from './base';
+import { MongoDBProviderBase, COLLECTIONS, logger } from './base';
 
 export function ProviderRecordMixin<TBase extends Constructor<MongoDBProviderBase>>(Base: TBase) {
   return class ProviderRecordOps extends Base {
+    // Per-tenant-DB memo so the unique-index ensure runs at most once per
+    // process per database, regardless of success.
+    private providerIndexesReady = new Set<string>();
+
     // ── Provider CRUD ────────────────────────────────────────────────
+
+    /**
+     * Best-effort: create the unique (tenantId, key) index so concurrent
+     * duplicate creates fail at the DB layer (matching the SQLite schema's
+     * `idx_providers_key`). Never throws — if pre-existing duplicates block the
+     * index it is logged and skipped so provider creation still works.
+     */
+    private async ensureProviderIndexes(): Promise<void> {
+      const db = this.getTenantDb();
+      const dbName = db.databaseName;
+      if (this.providerIndexesReady.has(dbName)) return;
+      this.providerIndexesReady.add(dbName);
+      try {
+        await db
+          .collection(COLLECTIONS.providers)
+          .createIndex({ tenantId: 1, key: 1 }, { unique: true, name: 'uniq_provider_tenant_key' });
+      } catch (error) {
+        logger.warn('Could not ensure unique provider key index (pre-existing duplicates?)', {
+          dbName,
+          error,
+        });
+      }
+    }
 
     async createProvider(
       provider: Omit<IProviderRecord, '_id' | 'createdAt' | 'updatedAt'>,
     ): Promise<IProviderRecord> {
+      await this.ensureProviderIndexes();
       const db = this.getTenantDb();
       const now = new Date();
       const document: Omit<IProviderRecord, '_id'> & {
@@ -42,11 +70,16 @@ export function ProviderRecordMixin<TBase extends Constructor<MongoDBProviderBas
       data: Partial<Omit<IProviderRecord, 'tenantId' | 'key'>>,
     ): Promise<IProviderRecord | null> {
       const db = this.getTenantDb();
-      const objectId = new ObjectId(id);
+      // A malformed (non-ObjectId) id must resolve to "not found", never throw a
+      // BSONError. Mirror the string-id fallback used by the project/prompt
+      // mixins so behaviour matches the SQLite provider (on-prem) exactly.
+      const idFilter: Filter<IProviderRecord> = ObjectId.isValid(id)
+        ? { _id: new ObjectId(id) }
+        : { _id: id };
 
       const existing = await db
         .collection<IProviderRecord>(COLLECTIONS.providers)
-        .findOne({ _id: objectId });
+        .findOne(idFilter);
 
       if (!existing) {
         return null;
@@ -63,7 +96,7 @@ export function ProviderRecordMixin<TBase extends Constructor<MongoDBProviderBas
       const result = await db
         .collection<IProviderRecord>(COLLECTIONS.providers)
         .findOneAndUpdate(
-          { _id: objectId },
+          idFilter,
           { $set: payload },
           { returnDocument: 'after' },
         );
@@ -80,9 +113,12 @@ export function ProviderRecordMixin<TBase extends Constructor<MongoDBProviderBas
 
     async findProviderById(id: string): Promise<IProviderRecord | null> {
       const db = this.getTenantDb();
+      const idFilter: Filter<IProviderRecord> = ObjectId.isValid(id)
+        ? { _id: new ObjectId(id) }
+        : { _id: id };
       const provider = await db
         .collection<IProviderRecord>(COLLECTIONS.providers)
-        .findOne({ _id: new ObjectId(id) });
+        .findOne(idFilter);
 
       if (!provider) {
         return null;
@@ -162,9 +198,12 @@ export function ProviderRecordMixin<TBase extends Constructor<MongoDBProviderBas
 
     async deleteProvider(id: string): Promise<boolean> {
       const db = this.getTenantDb();
+      const idFilter: Filter<IProviderRecord> = ObjectId.isValid(id)
+        ? { _id: new ObjectId(id) }
+        : { _id: id };
       const result = await db
         .collection<IProviderRecord>(COLLECTIONS.providers)
-        .deleteOne({ _id: new ObjectId(id) });
+        .deleteOne(idFilter);
 
       return result.deletedCount > 0;
     }

--- a/src/lib/database/sqlite/base.ts
+++ b/src/lib/database/sqlite/base.ts
@@ -449,6 +449,38 @@ export class SQLiteProviderBase {
       CREATE INDEX IF NOT EXISTS idx_tracing_sessions_project_agent_startedAt
         ON ${TABLES.agentTracingSessions}(projectId, agentName, startedAt DESC);
     `);
+
+    // Enforce unique provider/model keys at the DB layer so a concurrent
+    // create race cannot insert duplicates (matches the MongoDB unique
+    // indexes). The base schema creates these as plain indexes; upgrade them
+    // in place, best-effort — skipped if pre-existing duplicates would violate
+    // the constraint, and never leaving the table without an index.
+    this.upgradeToUniqueIndex(db, 'idx_models_key', TABLES.models, '(key)');
+    this.upgradeToUniqueIndex(db, 'idx_providers_key', TABLES.providers, '(key)');
+  }
+
+  private upgradeToUniqueIndex(
+    db: Database.Database,
+    indexName: string,
+    tableName: string,
+    columns: string,
+  ): void {
+    const uniqueName = `${indexName}_uniq`;
+    const already = db
+      .prepare(`SELECT 1 FROM sqlite_master WHERE type='index' AND name=?`)
+      .get(uniqueName);
+    if (already) return;
+    try {
+      db.exec(
+        `CREATE UNIQUE INDEX IF NOT EXISTS ${uniqueName} ON ${tableName}${columns};` +
+          `DROP INDEX IF EXISTS ${indexName};`,
+      );
+    } catch (error) {
+      logger.warn(`Could not upgrade ${indexName} to unique (pre-existing duplicates?)`, {
+        tableName,
+        error,
+      });
+    }
   }
 
   private ensureTableColumn(

--- a/src/lib/services/apiTokenAuth.ts
+++ b/src/lib/services/apiTokenAuth.ts
@@ -87,6 +87,16 @@ export async function requireApiTokenFromHeader(
     } catch { /* best-effort cache write */ }
   }
 
+  // Reject expired tokens. Checked on every request (not cached on the token
+  // record alone) so an expiry that elapses within the auth-cache window still
+  // takes effect on the next call.
+  if (tokenRecord.expiresAt) {
+    const expiresAtMs = new Date(tokenRecord.expiresAt).getTime();
+    if (Number.isFinite(expiresAtMs) && expiresAtMs <= Date.now()) {
+      throw new ApiTokenAuthError('API token has expired');
+    }
+  }
+
   const effectiveLicense = LicenseManager.getEffectiveLicenseForTenant(tenant);
   tenant = {
     ...tenant,

--- a/src/lib/services/providers/providerService.ts
+++ b/src/lib/services/providers/providerService.ts
@@ -53,6 +53,21 @@ async function withTenantDb(tenantDbName: string) {
   return db;
 }
 
+/**
+ * True when a DB write failed because a unique constraint was violated —
+ * MongoDB duplicate-key (E11000) or SQLite `UNIQUE constraint failed`. Used to
+ * turn a concurrent-create race (two requests passing the pre-check, both
+ * inserting) into a clean 409 instead of a 500.
+ */
+function isDuplicateKeyError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') return false;
+  const code = (error as { code?: unknown }).code;
+  if (code === 11000) return true; // MongoDB
+  if (typeof code === 'string' && code.startsWith('SQLITE_CONSTRAINT')) return true;
+  const message = (error as { message?: unknown }).message;
+  return typeof message === 'string' && /unique constraint/i.test(message);
+}
+
 export async function createProviderConfig(
   tenantDbName: string,
   tenantId: string,
@@ -66,22 +81,32 @@ export async function createProviderConfig(
     throw new Error(`Provider with key "${payload.key}" already exists.`);
   }
 
-  const record = await db.createProvider({
-    tenantId,
-    projectIds: payload.projectId ? [payload.projectId] : undefined,
-    key: payload.key,
-    type: payload.type,
-    driver: payload.driver,
-    label: payload.label,
-    description: payload.description,
-    status: payload.status ?? 'active',
-    credentialsEnc: encryptObject(payload.credentials),
-    settings: payload.settings ?? {},
-    capabilitiesOverride: payload.capabilitiesOverride ?? undefined,
-    metadata: payload.metadata ?? undefined,
-    createdBy: payload.createdBy,
-    updatedBy: payload.createdBy,
-  });
+  let record: IProviderRecord;
+  try {
+    record = await db.createProvider({
+      tenantId,
+      projectIds: payload.projectId ? [payload.projectId] : undefined,
+      key: payload.key,
+      type: payload.type,
+      driver: payload.driver,
+      label: payload.label,
+      description: payload.description,
+      status: payload.status ?? 'active',
+      credentialsEnc: encryptObject(payload.credentials),
+      settings: payload.settings ?? {},
+      capabilitiesOverride: payload.capabilitiesOverride ?? undefined,
+      metadata: payload.metadata ?? undefined,
+      createdBy: payload.createdBy,
+      updatedBy: payload.createdBy,
+    });
+  } catch (error) {
+    // Lost the create race: another request inserted the same key between the
+    // findProviderByKey check above and this insert. Surface it as a conflict.
+    if (isDuplicateKeyError(error)) {
+      throw new Error(`Provider with key "${payload.key}" already exists.`);
+    }
+    throw error;
+  }
 
   return sanitize(record);
 }
@@ -123,7 +148,24 @@ export async function updateProviderConfig(
   }
 
   if (payload.credentials !== undefined) {
-    updates.credentialsEnc = encryptObject(payload.credentials);
+    // Merge incoming credentials over the existing decrypted set instead of
+    // replacing wholesale. A blank/undefined value means "leave this field
+    // unchanged" — the edit UI re-initialises secret fields (e.g. apiKey) to
+    // '' because the backend never returns the secret, so a wholesale replace
+    // would silently wipe the API key whenever an unrelated field (baseUrl,
+    // region, …) is edited.
+    const existing = await db.findProviderById(providerId);
+    const current = existing?.credentialsEnc
+      ? (decryptObject(existing.credentialsEnc) as Record<string, unknown>)
+      : {};
+    const merged: Record<string, unknown> = { ...current };
+    for (const [field, value] of Object.entries(payload.credentials)) {
+      if (value === '' || value === undefined || value === null) {
+        continue;
+      }
+      merged[field] = value;
+    }
+    updates.credentialsEnc = encryptObject(merged);
   }
 
   if (payload.updatedBy) {

--- a/src/server/api/fastify-utils.ts
+++ b/src/server/api/fastify-utils.ts
@@ -385,25 +385,117 @@ export function sendApiTokenError(
   return null;
 }
 
+/** Error envelope styles for the client (token) API. */
+export type ClientApiErrorStyle = 'json' | 'openai';
+
+export interface ClientApiContextOptions {
+  /**
+   * Response envelope on error. `'json'` → `{ error: string }` (the default,
+   * used by most client routes). `'openai'` → `{ error: { message, type } }`
+   * for OpenAI-SDK-compatible routes (chat/completions, embeddings, audio).
+   */
+  errorStyle?: ClientApiErrorStyle;
+  /**
+   * Enforce API-token RBAC for paths that map to a permission service. Defaults
+   * to `true`. Only set `false` for routes that are intentionally open to any
+   * valid token regardless of the token owner's service permissions. (RBAC is a
+   * no-op for paths with no permission-service mapping, so leaving it on is
+   * safe and is what closes accidental bypasses.)
+   */
+  rbac?: boolean;
+}
+
+function openAiErrorBody(message: string, type: string) {
+  return { error: { message, type } };
+}
+
+/**
+ * Single error responder for the client (token) API. Maps the well-known error
+ * types to the right status + envelope so every token route reports failures
+ * identically. Returns the reply (never null) so callers can `return` it.
+ */
+function sendClientApiError(
+  reply: FastifyReply,
+  error: unknown,
+  style: ClientApiErrorStyle,
+) {
+  if (error instanceof ApiTokenAuthError) {
+    if (style === 'openai') {
+      // OpenAI SDKs treat auth failures as 401 regardless of the finer status.
+      return reply.code(401).send(openAiErrorBody(error.message, 'invalid_request_error'));
+    }
+    return reply.code(error.status).send({ error: error.message });
+  }
+
+  if (error instanceof RbacAuthorizationError) {
+    if (style === 'openai') {
+      return reply.code(error.status).send(openAiErrorBody(error.message, 'permission_error'));
+    }
+    return reply.code(error.status).send({ error: error.message });
+  }
+
+  if (style === 'openai') {
+    return reply.code(500).send(openAiErrorBody('Internal server error', 'server_error'));
+  }
+  return reply
+    .code(500)
+    .send({ error: error instanceof Error ? error.message : 'Internal server error' });
+}
+
+/**
+ * THE canonical wrapper for every API-token ("client") route. It is the single
+ * source of truth for the token request lifecycle:
+ *   1. shutdown guard (503),
+ *   2. authenticate the Bearer token → ApiTokenContext (stored on the request),
+ *   3. enforce API-token RBAC (unless `rbac: false`; no-op for unmapped paths),
+ *   4. bind the tenant DB for the WHOLE handler via `runWithTenant` (immune to
+ *      the cross-tenant process-global race under concurrent load),
+ *   5. uniform error responses (`errorStyle`).
+ * The resolved `auth` context is passed as the handler's third argument.
+ *
+ * Do not hand-roll this per plugin — pass options instead. Local clones drift
+ * (e.g. silently skipping RBAC on chat/embeddings/ocr-jobs).
+ */
 export function withClientApiRequestContext<
   TRequest extends FastifyRequest = FastifyRequest,
 >(
-  handler: (request: TRequest, reply: FastifyReply) => Promise<unknown> | unknown,
+  handler: (
+    request: TRequest,
+    reply: FastifyReply,
+    auth: ApiTokenContext,
+  ) => Promise<unknown> | unknown,
+  options: ClientApiContextOptions = {},
 ) {
+  const errorStyle: ClientApiErrorStyle = options.errorStyle ?? 'json';
+  const enforceRbac = options.rbac ?? true;
+
   return async (request: FastifyRequest, reply: FastifyReply) => {
     if (isShuttingDown()) {
+      if (errorStyle === 'openai') {
+        return reply
+          .code(503)
+          .header('Retry-After', '5')
+          .send(openAiErrorBody('Service is shutting down', 'server_error'));
+      }
       return reply
         .code(503)
         .header('Retry-After', '5')
         .send({ error: 'Service is shutting down' });
     }
 
+    let apiToken: ApiTokenContext;
     try {
-      const apiToken = await requireApiTokenContext(request);
+      apiToken = await requireApiTokenContext(request);
       request.apiTokenContext = apiToken;
-      enforceApiTokenRbac(request, apiToken);
+      if (enforceRbac) {
+        enforceApiTokenRbac(request, apiToken);
+      }
+    } catch (error) {
+      return sendClientApiError(reply, error, errorStyle);
+    }
 
-      return runWithRequestContext(
+    try {
+      return await runWithRequestContext(
         {
           requestId: request.apiRequestId,
           tenantId: apiToken.tenantId,
@@ -416,26 +508,41 @@ export function withClientApiRequestContext<
           // (token) requests never establish a tenant scope at request top and
           // fall back to the process-global tenant binding, which a concurrent
           // request for another tenant can overwrite — causing cross-tenant
-          // reads/writes (e.g. sandbox rows landing in the wrong tenant DB).
-          // Mirrors the cookie/RBAC path, which binds the tenant per request.
+          // reads/writes. Mirrors the cookie/RBAC path.
           const db = await getDatabase();
           if (typeof db.runWithTenant === 'function') {
             return db.runWithTenant(apiToken.tenantDbName, () =>
-              handler(request as TRequest, reply),
+              handler(request as TRequest, reply, apiToken),
             );
           }
           await db.switchToTenant(apiToken.tenantDbName);
-          return handler(request as TRequest, reply);
+          return handler(request as TRequest, reply, apiToken);
         },
       );
     } catch (error) {
-      return sendApiTokenError(reply, error)
-        ?? sendRbacError(reply, error)
-        ?? reply.code(500).send({
-          error: error instanceof Error ? error.message : 'Internal server error',
-        });
+      return sendClientApiError(reply, error, errorStyle);
     }
   };
+}
+
+/**
+ * Convenience for OpenAI-SDK-compatible token routes (chat/completions,
+ * embeddings, audio/*, ocr). Identical to {@link withClientApiRequestContext}
+ * but emits the OpenAI `{ error: { message, type } }` envelope. RBAC stays on
+ * by default (no-op for paths without a permission service) — this is what
+ * closes the historical bypasses on the routes that DO map to a service.
+ */
+export function withOpenAiApiRequestContext<
+  TRequest extends FastifyRequest = FastifyRequest,
+>(
+  handler: (
+    request: TRequest,
+    reply: FastifyReply,
+    auth: ApiTokenContext,
+  ) => Promise<unknown> | unknown,
+  options: Omit<ClientApiContextOptions, 'errorStyle'> = {},
+) {
+  return withClientApiRequestContext(handler, { ...options, errorStyle: 'openai' });
 }
 
 export function clearSessionCookies(reply: FastifyReply): void {

--- a/src/server/api/plugins/auth.ts
+++ b/src/server/api/plugins/auth.ts
@@ -29,6 +29,7 @@ import {
   getSessionContext,
   readJsonBody,
   setSessionCookies,
+  withApiRequestContext,
 } from '../fastify-utils';
 
 const logger = createLogger('api:auth');
@@ -491,15 +492,16 @@ export const authApiPlugin: FastifyPluginAsync = async (app) => {
     return reply.code(200).send({ message: 'Logged out successfully' });
   });
 
-  app.get('/auth/session', async (request, reply) => {
+  app.get('/auth/session', withApiRequestContext(async (request, reply) => {
     try {
       const session = getSessionContext(request);
       if (!session) {
         return reply.code(401).send({ error: 'Unauthorized' });
       }
 
+      // Tenant DB is bound for the whole handler by withApiRequestContext
+      // (runWithTenant) — no manual switchToTenant needed.
       const db = await getDatabase();
-      await db.switchToTenant(session.tenantDbName);
 
       const user = await db.findUserById(session.userId);
       if (!user || String(user.tenantId) !== String(session.tenantId)) {
@@ -524,9 +526,9 @@ export const authApiPlugin: FastifyPluginAsync = async (app) => {
       logger.error('Session endpoint error', { error });
       return reply.code(500).send({ error: 'Internal server error' });
     }
-  });
+  }));
 
-  app.post('/auth/change-password', async (request, reply) => {
+  app.post('/auth/change-password', withApiRequestContext(async (request, reply) => {
     try {
       const session = getSessionContext(request);
       if (!session) {
@@ -551,8 +553,8 @@ export const authApiPlugin: FastifyPluginAsync = async (app) => {
         });
       }
 
+      // Tenant DB is bound by withApiRequestContext (runWithTenant).
       const db = await getDatabase();
-      await db.switchToTenant(session.tenantDbName);
 
       const user = await db.findUserById(session.userId);
       if (!user || String(user.tenantId) !== String(session.tenantId)) {
@@ -584,7 +586,7 @@ export const authApiPlugin: FastifyPluginAsync = async (app) => {
       logger.error('Change password error', { error });
       return reply.code(500).send({ error: 'Internal server error' });
     }
-  });
+  }));
 
   app.post('/auth/forgot-password', async (request, reply) => {
     // Constant-time response: always wait at least this long before responding,

--- a/src/server/api/plugins/client-audio-ocr.ts
+++ b/src/server/api/plugins/client-audio-ocr.ts
@@ -1,14 +1,8 @@
 import crypto from 'node:crypto';
-import type { FastifyPluginAsync, FastifyReply, FastifyRequest } from 'fastify';
+import type { FastifyPluginAsync, FastifyRequest } from 'fastify';
 import type { LicenseType } from '@/lib/license/license-manager';
 import { createLogger } from '@/lib/core/logger';
-import { isShuttingDown } from '@/lib/core/lifecycle';
-import { runWithRequestContext } from '@/lib/core/requestContext';
-import { getDatabase } from '@/lib/database';
-import {
-  ApiTokenAuthError,
-  type ApiTokenContext,
-} from '@/lib/services/apiTokenAuth';
+import { type ApiTokenContext } from '@/lib/services/apiTokenAuth';
 import {
   handleOcrRequest,
   handleSpeechRequest,
@@ -21,7 +15,7 @@ import {
   checkPerRequestLimits,
   checkRateLimit,
 } from '@/lib/quota/quotaGuard';
-import { readJsonBody, requireApiTokenContext } from '../fastify-utils';
+import { readJsonBody, withOpenAiApiRequestContext } from '../fastify-utils';
 import type {
   OcrExtractInput,
   OcrFeature,
@@ -53,10 +47,6 @@ const VALID_TTS_FORMATS: TtsOutputFormat[] = [
   'pcm',
 ];
 
-function unauthorizedPayload(message = 'Invalid API token') {
-  return { error: { message, type: 'invalid_request_error' } };
-}
-
 function quotaExceededPayload(message = 'Quota exceeded') {
   return { error: { message, type: 'rate_limit_error' } };
 }
@@ -70,57 +60,6 @@ function sanitize(value: unknown, max = 20_000) {
   } catch {
     return '[unserializable]';
   }
-}
-
-function withClientContext<TRequest extends FastifyRequest = FastifyRequest>(
-  handler: (
-    request: TRequest,
-    reply: FastifyReply,
-    auth: ApiTokenContext,
-  ) => Promise<unknown> | unknown,
-) {
-  return async (request: FastifyRequest, reply: FastifyReply) => {
-    if (isShuttingDown()) {
-      return reply
-        .code(503)
-        .header('Retry-After', '5')
-        .send({ error: { message: 'Service is shutting down', type: 'server_error' } });
-    }
-
-    let auth: ApiTokenContext;
-    try {
-      auth = await requireApiTokenContext(request);
-      request.apiTokenContext = auth;
-    } catch (error) {
-      if (error instanceof ApiTokenAuthError) {
-        return reply.code(401).send(unauthorizedPayload(error.message));
-      }
-      logger.error('Audio/OCR auth error', { error });
-      return reply.code(401).send(unauthorizedPayload());
-    }
-
-    return runWithRequestContext(
-      {
-        requestId: request.apiRequestId,
-        tenantId: auth.tenantId,
-        tenantSlug: auth.tenantSlug,
-        userId: auth.user?._id ? String(auth.user._id) : undefined,
-      },
-      async () => {
-        // Bind the tenant DB for the whole request via AsyncLocalStorage so
-        // downstream model/provider lookups can't fall back to the process-global
-        // tenant DB that a concurrent request for another tenant overwrote. See
-        // withOpenAiClientContext for the full rationale.
-        const db = await getDatabase();
-        if (auth.tenantDbName && typeof db.runWithTenant === 'function') {
-          return db.runWithTenant(auth.tenantDbName, () =>
-            handler(request as TRequest, reply, auth),
-          );
-        }
-        return handler(request as TRequest, reply, auth);
-      },
-    );
-  };
 }
 
 function getContentType(request: FastifyRequest): string {
@@ -382,7 +321,7 @@ export const clientAudioOcrApiPlugin: FastifyPluginAsync = async (app) => {
   // ─── POST /client/v1/audio/transcriptions ───────────────────────────
   app.post(
     '/client/v1/audio/transcriptions',
-    withClientContext(async (request, reply, auth) => {
+    withOpenAiApiRequestContext(async (request, reply, auth) => {
       const startedAt = Date.now();
       let modelKey = '';
       try {
@@ -436,7 +375,7 @@ export const clientAudioOcrApiPlugin: FastifyPluginAsync = async (app) => {
   // ─── POST /client/v1/audio/translations ─────────────────────────────
   app.post(
     '/client/v1/audio/translations',
-    withClientContext(async (request, reply, auth) => {
+    withOpenAiApiRequestContext(async (request, reply, auth) => {
       const startedAt = Date.now();
       let modelKey = '';
       try {
@@ -498,7 +437,7 @@ export const clientAudioOcrApiPlugin: FastifyPluginAsync = async (app) => {
   // ─── POST /client/v1/audio/speech ───────────────────────────────────
   app.post(
     '/client/v1/audio/speech',
-    withClientContext(async (request, reply, auth) => {
+    withOpenAiApiRequestContext(async (request, reply, auth) => {
       const startedAt = Date.now();
       let modelKey = '';
       try {
@@ -590,7 +529,7 @@ export const clientAudioOcrApiPlugin: FastifyPluginAsync = async (app) => {
   // ─── POST /client/v1/ocr ────────────────────────────────────────────
   app.post(
     '/client/v1/ocr',
-    withClientContext(async (request, reply, auth) => {
+    withOpenAiApiRequestContext(async (request, reply, auth) => {
       const startedAt = Date.now();
       let modelKey = '';
       try {

--- a/src/server/api/plugins/client-inference.ts
+++ b/src/server/api/plugins/client-inference.ts
@@ -1,16 +1,9 @@
 import crypto from 'node:crypto';
 import { Readable } from 'node:stream';
 import type { ReadableStream as NodeReadableStream } from 'node:stream/web';
-import type { FastifyPluginAsync, FastifyReply, FastifyRequest } from 'fastify';
+import type { FastifyPluginAsync, FastifyReply } from 'fastify';
 import type { LicenseType } from '@/lib/license/license-manager';
 import { createLogger } from '@/lib/core/logger';
-import { isShuttingDown } from '@/lib/core/lifecycle';
-import { runWithRequestContext } from '@/lib/core/requestContext';
-import { getDatabase } from '@/lib/database';
-import {
-  ApiTokenAuthError,
-  type ApiTokenContext,
-} from '@/lib/services/apiTokenAuth';
 import {
   GuardrailBlockError,
   handleChatCompletion,
@@ -28,7 +21,7 @@ import {
 } from '@/lib/quota/quotaGuard';
 import {
   readJsonBody,
-  requireApiTokenContext,
+  withOpenAiApiRequestContext,
 } from '../fastify-utils';
 
 const logger = createLogger('api:client-inference');
@@ -52,10 +45,6 @@ type EmbeddingRequest = {
   model?: string;
   request_id?: string;
 };
-
-function unauthorizedPayload(message = 'Invalid API token') {
-  return { error: { message, type: 'invalid_request_error' } };
-}
 
 function quotaExceededPayload(message = 'Quota exceeded') {
   return { error: { message, type: 'rate_limit_error' } };
@@ -147,65 +136,8 @@ function invalidJson(reply: FastifyReply) {
   });
 }
 
-function withOpenAiClientContext<
-  TRequest extends FastifyRequest = FastifyRequest,
->(
-  handler: (
-    request: TRequest,
-    reply: FastifyReply,
-    auth: ApiTokenContext,
-  ) => Promise<unknown> | unknown,
-) {
-  return async (request: FastifyRequest, reply: FastifyReply) => {
-    if (isShuttingDown()) {
-      return reply
-        .code(503)
-        .header('Retry-After', '5')
-        .send({ error: { message: 'Service is shutting down', type: 'server_error' } });
-    }
-
-    let auth: ApiTokenContext;
-    try {
-      auth = await requireApiTokenContext(request);
-      request.apiTokenContext = auth;
-    } catch (error) {
-      if (error instanceof ApiTokenAuthError) {
-        return reply.code(401).send(unauthorizedPayload(error.message));
-      }
-
-      logger.error('Client inference auth error', { error });
-      return reply.code(401).send(unauthorizedPayload());
-    }
-
-    return runWithRequestContext(
-      {
-        requestId: request.apiRequestId,
-        tenantId: auth.tenantId,
-        tenantSlug: auth.tenantSlug,
-        userId: auth.user?._id ? String(auth.user._id) : undefined,
-      },
-      async () => {
-        // Bind the tenant DB for the entire request via a real AsyncLocalStorage
-        // scope. `requireApiTokenContext` only calls `switchToTenant` (enterWith +
-        // process-global), whose binding does NOT survive `await` boundaries — so
-        // downstream `getTenantDb()` reads can fall back to the global tenant DB
-        // that a concurrent request for another tenant has overwritten, making
-        // model/provider lookups intermittently resolve against the wrong tenant
-        // ("Provider configuration not found."). `runWithTenant` is immune.
-        const db = await getDatabase();
-        if (auth.tenantDbName && typeof db.runWithTenant === 'function') {
-          return db.runWithTenant(auth.tenantDbName, () =>
-            handler(request as TRequest, reply, auth),
-          );
-        }
-        return handler(request as TRequest, reply, auth);
-      },
-    );
-  };
-}
-
 export const clientInferenceApiPlugin: FastifyPluginAsync = async (app) => {
-  app.post('/client/v1/chat/completions', withOpenAiClientContext(async (request, reply, auth) => {
+  app.post('/client/v1/chat/completions', withOpenAiApiRequestContext(async (request, reply, auth) => {
     const startedAt = Date.now();
     let body: ChatCompletionRequest = {};
     let modelKey = '';
@@ -393,7 +325,7 @@ export const clientInferenceApiPlugin: FastifyPluginAsync = async (app) => {
     }
   }));
 
-  app.post('/client/v1/embeddings', withOpenAiClientContext(async (request, reply, auth) => {
+  app.post('/client/v1/embeddings', withOpenAiApiRequestContext(async (request, reply, auth) => {
     const startedAt = Date.now();
     let body: EmbeddingRequest = {};
     let modelKey = '';

--- a/src/server/api/plugins/client-ocr-jobs.ts
+++ b/src/server/api/plugins/client-ocr-jobs.ts
@@ -12,9 +12,7 @@
 import type { FastifyPluginAsync, FastifyReply, FastifyRequest } from 'fastify';
 import type { LicenseType } from '@/lib/license/license-manager';
 import { createLogger } from '@/lib/core/logger';
-import { isShuttingDown } from '@/lib/core/lifecycle';
-import { runWithRequestContext } from '@/lib/core/requestContext';
-import { ApiTokenAuthError, type ApiTokenContext } from '@/lib/services/apiTokenAuth';
+import { type ApiTokenContext } from '@/lib/services/apiTokenAuth';
 import {
   checkBudget,
   checkPerRequestLimits,
@@ -42,57 +40,15 @@ import type {
   OcrJobWebhookEvent,
   OcrOutputKind,
 } from '@/lib/database';
-import { getDatabase } from '@/lib/database';
-import { readJsonBody, requireApiTokenContext } from '../fastify-utils';
+import { readJsonBody, withOpenAiApiRequestContext } from '../fastify-utils';
 
 const logger = createLogger('api:client-ocr-jobs');
 
 const VALID_OUTPUTS: OcrOutputKind[] = ['full_text', 'summary', 'structured'];
 const VALID_EVENTS: OcrJobWebhookEvent[] = ['item.succeeded', 'item.failed'];
 
-function unauthorizedPayload(message = 'Invalid API token') {
-  return { error: { message, type: 'invalid_request_error' } };
-}
 function quotaExceededPayload(message = 'Quota exceeded') {
   return { error: { message, type: 'rate_limit_error' } };
-}
-
-function withClientContext(
-  handler: (request: FastifyRequest, reply: FastifyReply, auth: ApiTokenContext) => Promise<unknown> | unknown,
-) {
-  return async (request: FastifyRequest, reply: FastifyReply) => {
-    if (isShuttingDown()) {
-      return reply.code(503).header('Retry-After', '5').send({ error: { message: 'Service is shutting down', type: 'server_error' } });
-    }
-    let auth: ApiTokenContext;
-    try {
-      auth = await requireApiTokenContext(request);
-      request.apiTokenContext = auth;
-    } catch (error) {
-      if (error instanceof ApiTokenAuthError) return reply.code(401).send(unauthorizedPayload(error.message));
-      logger.error('OCR jobs auth error', { error });
-      return reply.code(401).send(unauthorizedPayload());
-    }
-    return runWithRequestContext(
-      {
-        requestId: request.apiRequestId,
-        tenantId: auth.tenantId,
-        tenantSlug: auth.tenantSlug,
-        userId: auth.user?._id ? String(auth.user._id) : undefined,
-      },
-      async () => {
-        // Bind the tenant DB for the whole request via AsyncLocalStorage so
-        // downstream model/provider lookups can't fall back to the process-global
-        // tenant DB that a concurrent request for another tenant overwrote. See
-        // withOpenAiClientContext (client-inference.ts) for the full rationale.
-        const db = await getDatabase();
-        if (auth.tenantDbName && typeof db.runWithTenant === 'function') {
-          return db.runWithTenant(auth.tenantDbName, () => handler(request, reply, auth));
-        }
-        return handler(request, reply, auth);
-      },
-    );
-  };
 }
 
 async function runQuotaGuard(auth: ApiTokenContext, modelKey: string): Promise<string | null> {
@@ -293,7 +249,7 @@ function notFound(reply: FastifyReply) {
 
 export const clientOcrJobsApiPlugin: FastifyPluginAsync = async (app) => {
   // ── Create job (container) ────────────────────────────────────────
-  app.post('/client/v1/ocr-jobs', withClientContext(async (request, reply, auth) => {
+  app.post('/client/v1/ocr-jobs', withOpenAiApiRequestContext(async (request, reply, auth) => {
     try {
       const input = buildCreateInput(readJsonBody<Record<string, unknown>>(request));
       const job = await createOcrJob(ctxFromAuth(auth), input);
@@ -305,20 +261,20 @@ export const clientOcrJobsApiPlugin: FastifyPluginAsync = async (app) => {
     }
   }));
 
-  app.get('/client/v1/ocr-jobs', withClientContext(async (request, reply, auth) => {
+  app.get('/client/v1/ocr-jobs', withOpenAiApiRequestContext(async (request, reply, auth) => {
     const query = (request.query ?? {}) as { status?: string; limit?: string };
     const jobs = await listOcrJobs(ctxFromAuth(auth), { status: query.status, limit: query.limit ? Number(query.limit) : undefined });
     return reply.code(200).send({ jobs: jobs.map(serializeJob) });
   }));
 
-  app.get('/client/v1/ocr-jobs/:id', withClientContext(async (request, reply, auth) => {
+  app.get('/client/v1/ocr-jobs/:id', withOpenAiApiRequestContext(async (request, reply, auth) => {
     const { id } = request.params as { id: string };
     const job = await getOcrJob(auth, id);
     if (!job) return notFound(reply);
     return reply.code(200).send({ job: serializeJob(job) });
   }));
 
-  app.patch('/client/v1/ocr-jobs/:id', withClientContext(async (request, reply, auth) => {
+  app.patch('/client/v1/ocr-jobs/:id', withOpenAiApiRequestContext(async (request, reply, auth) => {
     try {
       const { id } = request.params as { id: string };
       const body = readJsonBody<Record<string, unknown>>(request);
@@ -345,7 +301,7 @@ export const clientOcrJobsApiPlugin: FastifyPluginAsync = async (app) => {
     }
   }));
 
-  app.delete('/client/v1/ocr-jobs/:id', withClientContext(async (request, reply, auth) => {
+  app.delete('/client/v1/ocr-jobs/:id', withOpenAiApiRequestContext(async (request, reply, auth) => {
     const { id } = request.params as { id: string };
     const ok = await deleteOcrJob(auth, id);
     if (!ok) return notFound(reply);
@@ -353,7 +309,7 @@ export const clientOcrJobsApiPlugin: FastifyPluginAsync = async (app) => {
   }));
 
   // ── Send files to a job ───────────────────────────────────────────
-  app.post('/client/v1/ocr-jobs/:id/files', withClientContext(async (request, reply, auth) => {
+  app.post('/client/v1/ocr-jobs/:id/files', withOpenAiApiRequestContext(async (request, reply, auth) => {
     try {
       const { id } = request.params as { id: string };
       const job = await getOcrJob(auth, id);
@@ -374,14 +330,14 @@ export const clientOcrJobsApiPlugin: FastifyPluginAsync = async (app) => {
     }
   }));
 
-  app.post('/client/v1/ocr-jobs/:id/pause', withClientContext(async (request, reply, auth) => {
+  app.post('/client/v1/ocr-jobs/:id/pause', withOpenAiApiRequestContext(async (request, reply, auth) => {
     const { id } = request.params as { id: string };
     const job = await setOcrJobStatus(auth, id, 'paused');
     if (!job) return notFound(reply);
     return reply.code(200).send({ job: serializeJob(job) });
   }));
 
-  app.post('/client/v1/ocr-jobs/:id/resume', withClientContext(async (request, reply, auth) => {
+  app.post('/client/v1/ocr-jobs/:id/resume', withOpenAiApiRequestContext(async (request, reply, auth) => {
     const { id } = request.params as { id: string };
     const job = await setOcrJobStatus(auth, id, 'active');
     if (!job) return notFound(reply);
@@ -389,7 +345,7 @@ export const clientOcrJobsApiPlugin: FastifyPluginAsync = async (app) => {
   }));
 
   // ── Items ─────────────────────────────────────────────────────────
-  app.get('/client/v1/ocr-jobs/:id/items', withClientContext(async (request, reply, auth) => {
+  app.get('/client/v1/ocr-jobs/:id/items', withOpenAiApiRequestContext(async (request, reply, auth) => {
     const { id } = request.params as { id: string };
     const { limit, skip, status } = (request.query ?? {}) as { limit?: string; skip?: string; status?: string };
     const items = await getOcrJobItems(auth, id, { limit: limit ? Number(limit) : undefined, skip: skip ? Number(skip) : undefined, status });
@@ -397,7 +353,7 @@ export const clientOcrJobsApiPlugin: FastifyPluginAsync = async (app) => {
     return reply.code(200).send({ items: items.map(serializeItem) });
   }));
 
-  app.get('/client/v1/ocr-jobs/:id/items/:itemId', withClientContext(async (request, reply, auth) => {
+  app.get('/client/v1/ocr-jobs/:id/items/:itemId', withOpenAiApiRequestContext(async (request, reply, auth) => {
     const { id, itemId } = request.params as { id: string; itemId: string };
     const item = await getOcrJobItem(auth, id, itemId);
     if (!item) return notFound(reply);
@@ -405,7 +361,7 @@ export const clientOcrJobsApiPlugin: FastifyPluginAsync = async (app) => {
   }));
 
   // ── Usage (aggregate token + cost) ────────────────────────────────
-  app.get('/client/v1/ocr-jobs/:id/usage', withClientContext(async (request, reply, auth) => {
+  app.get('/client/v1/ocr-jobs/:id/usage', withOpenAiApiRequestContext(async (request, reply, auth) => {
     const { id } = request.params as { id: string };
     const job = await getOcrJob(auth, id);
     if (!job) return notFound(reply);
@@ -429,7 +385,7 @@ export const clientOcrJobsApiPlugin: FastifyPluginAsync = async (app) => {
   }));
 
   // ── Export ────────────────────────────────────────────────────────
-  app.get('/client/v1/ocr-jobs/:id/export', withClientContext(async (request, reply, auth) => {
+  app.get('/client/v1/ocr-jobs/:id/export', withOpenAiApiRequestContext(async (request, reply, auth) => {
     const { id } = request.params as { id: string };
     const { format: formatRaw } = (request.query ?? {}) as { format?: string };
     const format = (formatRaw ?? 'json').toLowerCase();

--- a/src/server/api/plugins/metrics.ts
+++ b/src/server/api/plugins/metrics.ts
@@ -1,21 +1,18 @@
 import type { FastifyPluginAsync } from 'fastify';
 import { createLogger } from '@/lib/core/logger';
-import { requireApiTokenFromHeader, ApiTokenAuthError } from '@/lib/services/apiTokenAuth';
 import { collectPrometheusMetrics } from '@/lib/services/metrics/prometheusExporter';
-import {
-  getHeaderValue,
-  withApiRequestContext,
-} from '../fastify-utils';
+import { withClientApiRequestContext } from '../fastify-utils';
 
 const logger = createLogger('metrics');
 
 export const metricsApiPlugin: FastifyPluginAsync = async (app) => {
-  app.get('/metrics', withApiRequestContext(async (request, reply) => {
+  // Token-authenticated route → the canonical client wrapper authenticates the
+  // Bearer token, binds the tenant DB via runWithTenant, and hands us `auth`.
+  // (Previously used the session wrapper, which never established a tenant
+  // scope for a token request.)
+  app.get('/metrics', withClientApiRequestContext(async (request, reply, auth) => {
     try {
-      const ctx = await requireApiTokenFromHeader(
-        getHeaderValue(request, 'authorization'),
-      );
-      const body = await collectPrometheusMetrics(ctx.tenantDbName, ctx.tenantId);
+      const body = await collectPrometheusMetrics(auth.tenantDbName, auth.tenantId);
 
       return reply
         .code(200)
@@ -23,10 +20,6 @@ export const metricsApiPlugin: FastifyPluginAsync = async (app) => {
         .type('text/plain; version=0.0.4; charset=utf-8')
         .send(body);
     } catch (error) {
-      if (error instanceof ApiTokenAuthError) {
-        return reply.code(error.status).send({ error: error.message });
-      }
-
       logger.error('Collection error', { error });
       return reply.code(500).send({ error: 'Failed to collect metrics' });
     }

--- a/src/server/api/plugins/models.ts
+++ b/src/server/api/plugins/models.ts
@@ -216,6 +216,11 @@ export const modelsApiPlugin: FastifyPluginAsync = async (app) => {
       return reply.code(201).send({ provider });
     } catch (error) {
       logger.error('Create model provider error', { error });
+      // A duplicate provider key is a client conflict, not a server error —
+      // mirror the generic POST /providers route which returns 409.
+      if (error instanceof Error && error.message.includes('already exists')) {
+        return reply.code(409).send({ error: error.message });
+      }
       return sendProjectError(reply, error)
         ?? reply.code(500).send({
           error: error instanceof Error ? error.message : 'Internal server error',


### PR DESCRIPTION
## Summary
Two related streams that harden the flows users hit errors on (API-token access and adding a model/provider), for both on-prem (SQLite) and SaaS (MongoDB).

### 1. Token / model-provider flow hardening (`f1aa47ded`)
- **Mongo ObjectId guard**: `find/update/delete` of provider & model no longer throw `BSONError` (→ 500 on SaaS) for malformed ids; they return not-found like SQLite. Mirrors the project/prompt mixin pattern.
- **Credential merge on update**: editing an unrelated provider field with the API-key box blank no longer wipes the stored key.
- **Duplicate-key → 409**: both the route layer and native `E11000`/`SQLITE_CONSTRAINT` now map to 409 instead of 500.
- **DB-level unique keys** on providers/models on both backends (Mongo lazy unique index; SQLite best-effort unique-index upgrade), closing the concurrent-create race. Both are no-throw if pre-existing duplicates exist.
- **Token expiry** is now enforced (`expiresAt` was previously ignored).

### 2. Tenant-security consolidation (`0ced7e2e0`)
- All per-request **auth + tenant-DB binding + RBAC** funnel through the canonical wrappers in `fastify-utils` (`withApiRequestContext`, `withClientApiRequestContext`, new `withOpenAiApiRequestContext`).
- **Deleted 3 drifted clones** that silently skipped RBAC → **closed a real RBAC bypass** on `/client/v1/chat/completions`, `/embeddings` (service `models`) and `/client/v1/ocr-jobs` (service `ocr`).
- **metrics**: switched a token route off the session wrapper (it never bound the tenant via `runWithTenant`).
- **auth**: `/auth/session` + `/auth/change-password` now bind the tenant via `runWithTenant`.

## Tests
- `db-parity` now runs provider/model CRUD + malformed-id + dup-key across **both SQLite and MongoDB** (adds `mongodb-memory-server` dev dep).
- New: canonical-wrapper behavioral tests, an architecture guard preventing new clones, a tenant-DB concurrency guard, provider credential-merge/dup-race, token expiry, models dup 409.
- Full suite: **2303 passing**, tsc + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)