### PR TITLE
feat(sandbox): per-sandbox preview enabled + public/private flags (schema/docs)

### DIFF
--- a/docs/guide/sandbox.md
+++ b/docs/guide/sandbox.md
@@ -48,7 +48,8 @@ Fields:
 5. **Resources** — vCPU / memory (MB) / disk (MB) for this sandbox. Leave a field **blank** to inherit the project default, then the platform default (see [Resource limits](#resource-limits)). Values above the operator cap are clamped on launch.
 6. **Persistent** — when checked, the sandbox survives restarts and is **exempt from idle cleanup**. Ephemeral sandboxes are reaped once idle (see [Idle reaping](#settings)).
 7. **Block all network access** — when checked, all outbound traffic from the container is blocked (preview ports are also disabled).
-8. **Environment variables** — per-sandbox env, merged over the template's defaults.
+8. **Enable port preview** / **Allow public share links** — turn preview on (default) and choose public (session-less share links) vs private (login-only). Both are also editable later from the Preview tab.
+9. **Environment variables** — per-sandbox env, merged over the template's defaults.
 
 Submitting calls `POST /api/sandbox/instances`, which records the sandbox in `pending`, picks a runner, and enqueues a `create-sandbox` command. The runner pulls/starts the container and reports back; the row flips to `Started`.
 
@@ -89,7 +90,12 @@ How it works — and why it needs **no ingress, DNS, or subdomain change**:
 
 Previewing requires the sandbox to be **running** and network **not** blocked. WebSocket upgrades (e.g. Vite HMR) are not proxied — the app still renders; only live-reload over WS is unavailable.
 
-The same proxy is available on the token API for agents: `GET /api/client/v1/sandbox/sandboxes/:id` returns the previewable `ports` (with proxy URLs), and `POST …/:id/preview-tokens` mints a share link.
+**Per-sandbox toggles** (top of the Preview tab, set at create time or live afterwards):
+
+- **Preview enabled** — turn preview on/off for this sandbox. When off, both the authenticated proxy and any share links are refused (applied instantly, no restart).
+- **Public access** — when on, session-less **share links** can be issued; when off the preview is **private**, reachable only through the authenticated proxy (a logged-in project member). Toggling public off immediately revokes already-minted share links. Public links additionally need `SANDBOX_PREVIEW_SECRET` on the server.
+
+The same controls are on the token API for agents: `GET /api/client/v1/sandbox/sandboxes/:id` returns `preview.{enabled,public,ports,sharingEnabled}`, `PATCH …/:id/preview` toggles `{enabled,public}`, and `POST …/:id/preview-tokens` mints a share link (only when the sandbox is enabled + public). Both flags are also accepted on create (`previewEnabled`, `previewPublic`).
 
 ### Terminal
 
@@ -198,7 +204,8 @@ Every screen above is backed by the `/api/sandbox/*` admin API (cookie-authentic
 | `POST /api/sandbox/instances/:id/exec` | Run a shell command, return exit/stdout/stderr |
 | `POST /api/sandbox/instances/:id/code` | Run a code block (`python`/`javascript`/`typescript`/`bash`) |
 | `POST /api/sandbox/instances/:id/terminal` | Open a terminal session (returns a WebSocket path) |
-| `GET /api/sandbox/instances/:id/preview` | List previewable ports + proxy URLs |
+| `GET /api/sandbox/instances/:id/preview` | Preview state: enabled/public + previewable ports |
+| `PATCH /api/sandbox/instances/:id/preview` | Toggle preview `{enabled, public}` |
 | `ALL /api/sandbox/instances/:id/preview/:port/*` | Proxy to a port inside the sandbox (authenticated) |
 | `POST /api/sandbox/instances/:id/preview-tokens` | Mint a session-less share link for a port |
 | `ALL /api/sandbox/preview/:token/*` | Public preview proxy (signed token, no session) |

--- a/src/lib/database/provider/types.extended.ts
+++ b/src/lib/database/provider/types.extended.ts
@@ -588,6 +588,17 @@ export interface ISandboxInstance {
   persist: boolean;
   /** Block all outbound network access from the sandbox container. */
   blockNetwork: boolean;
+  /**
+   * Port preview enabled for this sandbox. When false, the preview proxy (and
+   * share links) refuse access regardless of running state. Defaults to true.
+   */
+  previewEnabled?: boolean;
+  /**
+   * Allow public (session-less, signed share-link) preview access. When false,
+   * preview is private — reachable only through the authenticated proxy (login).
+   * Public links additionally require SANDBOX_PREVIEW_SECRET. Defaults to false.
+   */
+  previewPublic?: boolean;
   /** Per-instance resource limit override ({cpuCores,memoryMb,diskMb,pids}); null = use the template's. */
   resources: Record<string, unknown> | null;
   /** True while this is an unassigned pre-warmed pool container (hidden from users). */

--- a/src/lib/database/sqlite/base.ts
+++ b/src/lib/database/sqlite/base.ts
@@ -432,6 +432,10 @@ export class SQLiteProviderBase {
     // Per-project sandbox resource defaults (added with port preview + resource
     // limits). Safe to ensure on boot for tenants created before the feature.
     this.ensureTableColumn(db, 'sandbox_settings', 'projectResourceDefaults', 'projectResourceDefaults TEXT');
+    // Per-sandbox preview toggles (enabled + public/private). Safe to ensure on
+    // boot; default enabled=on, public=off (private behind login).
+    this.ensureTableColumn(db, 'sandbox_instances', 'previewEnabled', 'previewEnabled INTEGER NOT NULL DEFAULT 1');
+    this.ensureTableColumn(db, 'sandbox_instances', 'previewPublic', 'previewPublic INTEGER NOT NULL DEFAULT 0');
   }
 
   private migrateOcrJobsSchema(db: Database.Database): void {

--- a/src/lib/database/sqlite/schema.ts
+++ b/src/lib/database/sqlite/schema.ts
@@ -1930,6 +1930,8 @@ export const TENANT_SCHEMA_SQL = `
     env TEXT,
     persist INTEGER NOT NULL DEFAULT 0,
     blockNetwork INTEGER NOT NULL DEFAULT 0,
+    previewEnabled INTEGER NOT NULL DEFAULT 1,
+    previewPublic INTEGER NOT NULL DEFAULT 0,
     resources TEXT,
     warm INTEGER NOT NULL DEFAULT 0,
     warmKey TEXT,


### PR DESCRIPTION
Community-side schema + docs for **per-sandbox preview toggles**, follow-up to #170.

- `ISandboxInstance.previewEnabled` (default `true`) — preview on/off per sandbox.
- `ISandboxInstance.previewPublic` (default `false`) — public share links vs private (login-only).
- sqlite columns on `sandbox_instances` + `ensureTableColumn` boot migrations (Mongo schemaless).
- Docs: Preview-tab toggles, create-dialog fields, `PATCH …/preview` endpoint.

Pairs with the EE overlay PR; bump `COMPAT.communityRef` to this PR's merged SHA before the next `-saas` tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)