### PR TITLE
fix(alerts): rename `module` var (Next lint no-assign-module-variable)

### DIFF
--- a/src/app/dashboard/alerts/page.tsx
+++ b/src/app/dashboard/alerts/page.tsx
@@ -176,10 +176,12 @@ export default function AlertsPage() {
   // create form prefilled (used by dashboard report drill-downs).
   useEffect(() => {
     if (searchParams.get('create') !== '1') return;
-    const module = searchParams.get('module');
+    // Note: avoid a variable literally named `module` (Next lint:
+    // @next/next/no-assign-module-variable).
+    const moduleParam = searchParams.get('module');
     const metric = searchParams.get('metric');
     setCreatePrefill({
-      ...(module ? { module } : {}),
+      ...(moduleParam ? { module: moduleParam } : {}),
       ...(metric ? { metric } : {}),
     });
     formControls.open();


### PR DESCRIPTION
Hotfix for the EE prod build failure on tag `v1.0.57-saas`.

`src/app/dashboard/alerts/page.tsx` (from #178) declared `const module = searchParams.get('module')` in the `?create=1&module=` deep-link handler. `next build`'s ESLint rejects a variable named `module` (`@next/next/no-assign-module-variable`) → the EE prod build's `npm run build` failed. `tsc --noEmit` doesn't run lint, so it slipped through locally.

Renamed to `moduleParam` (behavior identical). Verified: full `next build` on the merged overlay now compiles + lints clean (only pre-existing unused-var warnings remain).

After merge: repin console-ee `COMPAT.communityRef` to this PR's main SHA, then re-tag `-saas` for prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GxCZ6F3jCw6Yc69NKqy1TU