### PR TITLE
feat(mcp,tools): OpenAPI YAML + Postman import, spec import UI, MCP playground

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -77,7 +77,8 @@
         "remark-gfm": "^4.0.1",
         "slugify": "^1.6.6",
         "winston": "^3.19.0",
-        "xlsx": "^0.18.5"
+        "xlsx": "^0.18.5",
+        "yaml": "^2.8.3"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,8 @@
     "remark-gfm": "^4.0.1",
     "slugify": "^1.6.6",
     "winston": "^3.19.0",
-    "xlsx": "^0.18.5"
+    "xlsx": "^0.18.5",
+    "yaml": "^2.8.3"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/src/__tests__/unit/spec-import.test.ts
+++ b/src/__tests__/unit/spec-import.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Unit tests — Spec Import & Normalization
+ * Tests: normalizeApiSpec (OpenAPI JSON/YAML pass-through, Postman conversion),
+ *        convertPostmanToOpenApi (paths, params, body, base URL resolution).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { normalizeApiSpec, convertPostmanToOpenApi } from '@/lib/services/specImport';
+
+describe('normalizeApiSpec', () => {
+  it('passes through OpenAPI JSON', () => {
+    const raw = JSON.stringify({
+      openapi: '3.0.0',
+      info: { title: 'T', version: '1' },
+      paths: { '/x': { get: { operationId: 'getX' } } },
+    });
+    const { openApiJson, detectedFormat } = normalizeApiSpec(raw);
+    expect(detectedFormat).toBe('openapi-json');
+    expect(JSON.parse(openApiJson).paths['/x'].get.operationId).toBe('getX');
+  });
+
+  it('parses OpenAPI YAML into JSON', () => {
+    const yaml = [
+      'openapi: 3.0.0',
+      'info:',
+      '  title: Pets',
+      '  version: "1"',
+      'servers:',
+      '  - url: https://api.pets.com',
+      'paths:',
+      '  /pets/{id}:',
+      '    get:',
+      '      operationId: getPet',
+      '      parameters:',
+      '        - name: id',
+      '          in: path',
+      '          required: true',
+      '          schema: { type: string }',
+    ].join('\n');
+    const { openApiJson, detectedFormat } = normalizeApiSpec(yaml);
+    expect(detectedFormat).toBe('openapi-yaml');
+    const spec = JSON.parse(openApiJson);
+    expect(spec.paths['/pets/{id}'].get.operationId).toBe('getPet');
+    expect(spec.servers[0].url).toBe('https://api.pets.com');
+  });
+
+  it('auto-detects and converts a Postman collection', () => {
+    const postman = {
+      info: {
+        _postman_id: 'abc',
+        name: 'My API',
+        schema: 'https://schema.getpostman.com/json/collection/v2.1.0/collection.json',
+      },
+      variable: [{ key: 'baseUrl', value: 'https://api.example.com' }],
+      item: [
+        {
+          name: 'Get user',
+          request: {
+            method: 'GET',
+            url: {
+              raw: '{{baseUrl}}/users/:id?verbose=true',
+              host: ['{{baseUrl}}'],
+              path: ['users', ':id'],
+              query: [{ key: 'verbose', value: 'true' }],
+              variable: [{ key: 'id' }],
+            },
+          },
+        },
+        {
+          name: 'Create user',
+          request: {
+            method: 'POST',
+            url: { host: ['{{baseUrl}}'], path: ['users'] },
+            body: { mode: 'raw', raw: '{"name":"a","age":3}', options: { raw: { language: 'json' } } },
+          },
+        },
+      ],
+    };
+    const { openApiJson, detectedFormat } = normalizeApiSpec(JSON.stringify(postman));
+    expect(detectedFormat).toBe('postman');
+    const spec = JSON.parse(openApiJson);
+
+    // Base URL variable resolved without doubling the scheme.
+    expect(spec.servers[0].url).toBe('https://api.example.com');
+
+    // `:id` becomes an OpenAPI path parameter.
+    const getParams = spec.paths['/users/{id}'].get.parameters;
+    expect(getParams).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: 'id', in: 'path', required: true }),
+        expect.objectContaining({ name: 'verbose', in: 'query' }),
+      ]),
+    );
+
+    // Raw JSON body becomes a typed request-body schema.
+    const bodyProps = spec.paths['/users'].post.requestBody.content['application/json'].schema.properties;
+    expect(bodyProps.name.type).toBe('string');
+    expect(bodyProps.age.type).toBe('integer');
+  });
+
+  it('resolves plain host arrays and bare hostnames to https origins', () => {
+    const spec = convertPostmanToOpenApi({
+      info: { _postman_id: 'x', name: 't' },
+      item: [{ name: 'g', request: { method: 'GET', url: { host: ['api', 'example', 'com'], path: ['ping'] } } }],
+    });
+    expect((spec.servers as Array<{ url: string }>)[0].url).toBe('https://api.example.com');
+  });
+
+  it('throws on unrecognized / unparseable input', () => {
+    expect(() => normalizeApiSpec('%%% not : valid : [')).toThrow();
+    expect(() => normalizeApiSpec(JSON.stringify({ hello: 'world' }))).toThrow(/Unrecognized/);
+    expect(() => normalizeApiSpec('')).toThrow();
+  });
+});

--- a/src/app/dashboard/mcp/[id]/page.tsx
+++ b/src/app/dashboard/mcp/[id]/page.tsx
@@ -39,6 +39,7 @@ import {
   IconDots,
   IconEdit,
   IconList,
+  IconPlayerPlay,
   IconPlugConnected,
   IconTrash,
 } from '@tabler/icons-react';
@@ -71,7 +72,7 @@ export default function McpDetailPage() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const tabParam = searchParams.get('tab');
-  const initialTab = ['overview', 'usage', 'tools', 'logs'].includes(tabParam ?? '')
+  const initialTab = ['overview', 'usage', 'tools', 'playground', 'logs'].includes(tabParam ?? '')
     ? (tabParam as string)
     : 'overview';
 
@@ -96,6 +97,13 @@ export default function McpDetailPage() {
   const [overviewLoading, setOverviewLoading] = useState(false);
   const [overviewAggregate, setOverviewAggregate] = useState<McpAggregateView | null>(null);
   const [todaySummary, setTodaySummary] = useState({ total: 0, success: 0, error: 0 });
+
+  // ── Playground state ──
+  const [pgTool, setPgTool] = useState<string | null>(null);
+  const [pgArgs, setPgArgs] = useState('{}');
+  const [pgResult, setPgResult] = useState<string>('');
+  const [pgLatency, setPgLatency] = useState<number | null>(null);
+  const [pgRunning, setPgRunning] = useState(false);
 
   const form = useForm({
     initialValues: {
@@ -326,6 +334,48 @@ export default function McpDetailPage() {
     }
   };
 
+  const handleRunPlayground = async () => {
+    if (!pgTool) return;
+    setPgRunning(true);
+    setPgResult('');
+    setPgLatency(null);
+    try {
+      let args: unknown = {};
+      if (pgArgs.trim()) {
+        try {
+          args = JSON.parse(pgArgs);
+        } catch {
+          setPgResult('Error: Arguments must be valid JSON');
+          setPgRunning(false);
+          return;
+        }
+      }
+
+      const res = await fetch(`/api/mcp/${params.id}/execute`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ tool: pgTool, arguments: args }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        setPgResult(`Error: ${data.error || 'Execution failed'}`);
+      } else {
+        setPgLatency(typeof data.latencyMs === 'number' ? data.latencyMs : null);
+        setPgResult(
+          typeof data.result === 'string'
+            ? data.result
+            : JSON.stringify(data.result, null, 2),
+        );
+      }
+    } catch (err) {
+      setPgResult(`Error: ${err instanceof Error ? err.message : 'Failed to execute'}`);
+    } finally {
+      setPgRunning(false);
+    }
+  };
+
+  const selectedPgTool = server?.tools?.find((t) => t.name === pgTool) ?? null;
+
   if (loading) {
     return (
       <Center p="xl" mt="xl">
@@ -446,6 +496,9 @@ export default function McpDetailPage() {
           </Tabs.Tab>
           <Tabs.Tab value="tools" leftSection={<IconCode size={14} />}>
             Tools ({server.tools?.length ?? 0})
+          </Tabs.Tab>
+          <Tabs.Tab value="playground" leftSection={<IconPlayerPlay size={14} />}>
+            Playground
           </Tabs.Tab>
           <Tabs.Tab value="logs" leftSection={<IconList size={14} />}>
             Request Logs
@@ -845,6 +898,84 @@ async with sse_client(
               </Table>
             )}
           </Paper>
+        </Tabs.Panel>
+
+        {/* ── Playground Tab ── */}
+        <Tabs.Panel value="playground">
+          <SimpleGrid cols={{ base: 1, md: 2 }} spacing="md">
+            <Paper withBorder radius="md" p="md">
+              <Stack gap="md">
+                <Text fw={600} size="sm">Try a tool</Text>
+                <Select
+                  label="Tool"
+                  placeholder={server.tools?.length ? 'Select a tool to run' : 'No tools available'}
+                  disabled={!server.tools?.length}
+                  data={(server.tools ?? []).map((t) => ({
+                    value: t.name,
+                    label: `${t.name} · ${t.httpMethod} ${t.httpPath}`,
+                  }))}
+                  value={pgTool}
+                  onChange={(v) => {
+                    setPgTool(v);
+                    setPgResult('');
+                    setPgLatency(null);
+                  }}
+                  searchable
+                />
+
+                {selectedPgTool?.description && (
+                  <Text size="sm" c="dimmed">{selectedPgTool.description}</Text>
+                )}
+
+                <JsonInput
+                  label="Arguments (JSON)"
+                  description="Path/query params at top level; request body under a &quot;body&quot; key."
+                  placeholder='{"id": "123", "body": {"name": "example"}}'
+                  minRows={5}
+                  maxRows={14}
+                  autosize
+                  formatOnBlur
+                  value={pgArgs}
+                  onChange={setPgArgs}
+                />
+
+                <Group>
+                  <Button
+                    leftSection={<IconPlayerPlay size={14} />}
+                    loading={pgRunning}
+                    disabled={!pgTool}
+                    onClick={handleRunPlayground}
+                  >
+                    Run
+                  </Button>
+                  {pgLatency !== null && (
+                    <Badge variant="light" color="gray">{pgLatency} ms</Badge>
+                  )}
+                </Group>
+              </Stack>
+            </Paper>
+
+            <Stack gap="md">
+              {selectedPgTool?.inputSchema && (
+                <Paper withBorder radius="md" p="md">
+                  <Text fw={600} size="sm" mb="xs">Input schema</Text>
+                  <Code block style={{ maxHeight: 220, overflow: 'auto', fontSize: 12 }}>
+                    {JSON.stringify(selectedPgTool.inputSchema, null, 2)}
+                  </Code>
+                </Paper>
+              )}
+              <Paper withBorder radius="md" p="md">
+                <Text fw={600} size="sm" mb="xs">Result</Text>
+                {pgResult ? (
+                  <Code block style={{ maxHeight: 400, overflow: 'auto', whiteSpace: 'pre-wrap' }}>
+                    {pgResult}
+                  </Code>
+                ) : (
+                  <Text size="sm" c="dimmed">Run a tool to see its response here.</Text>
+                )}
+              </Paper>
+            </Stack>
+          </SimpleGrid>
         </Tabs.Panel>
 
         {/* ── Logs Tab ── */}

--- a/src/app/dashboard/tools/[id]/page.tsx
+++ b/src/app/dashboard/tools/[id]/page.tsx
@@ -751,7 +751,7 @@ export default function ToolDetailPage() {
             Usage
           </Tabs.Tab>
           <Tabs.Tab value="test" leftSection={<IconCode size={14} />}>
-            Test
+            Playground
           </Tabs.Tab>
         </Tabs.List>
 

--- a/src/components/common/SpecImportField.tsx
+++ b/src/components/common/SpecImportField.tsx
@@ -1,0 +1,212 @@
+'use client';
+
+/**
+ * SpecImportField
+ *
+ * Shared importer for API specifications used by the "New MCP server" and
+ * "New tool" dialogs. Accepts an OpenAPI document (JSON or YAML) or a Postman
+ * collection through three input methods:
+ *
+ *   - Paste     — drop the spec text directly
+ *   - Upload    — read a local .json / .yaml / .yml file
+ *   - From URL  — fetch the spec server-side (SSRF-guarded) via /api/specs/fetch
+ *
+ * The raw text and a format hint are lifted to the parent form; the backend
+ * normalizes YAML / Postman into canonical OpenAPI on submit.
+ */
+
+import { useRef, useState } from 'react';
+import {
+  Button,
+  FileButton,
+  Group,
+  Loader,
+  Select,
+  Text,
+  Textarea,
+  TextInput,
+} from '@mantine/core';
+import { notifications } from '@mantine/notifications';
+import {
+  IconClipboard,
+  IconLink,
+  IconUpload,
+} from '@tabler/icons-react';
+import { ChipPicker } from '@/components/common/ui/FormShell';
+
+export type SpecFormat = 'auto' | 'openapi' | 'postman';
+
+type ImportMethod = 'paste' | 'upload' | 'url';
+
+const FORMAT_OPTIONS = [
+  { value: 'auto', label: 'Auto-detect' },
+  { value: 'openapi', label: 'OpenAPI / Swagger (JSON or YAML)' },
+  { value: 'postman', label: 'Postman collection' },
+];
+
+const FORMAT_LABEL: Record<string, string> = {
+  'openapi-json': 'OpenAPI (JSON)',
+  'openapi-yaml': 'OpenAPI (YAML)',
+  postman: 'Postman collection',
+};
+
+interface SpecImportFieldProps {
+  value: string;
+  onChange: (value: string) => void;
+  format: SpecFormat;
+  onFormatChange: (format: SpecFormat) => void;
+  /** Placeholder for the paste textarea. */
+  placeholder?: string;
+  minRows?: number;
+}
+
+export default function SpecImportField({
+  value,
+  onChange,
+  format,
+  onFormatChange,
+  placeholder = '{ "openapi": "3.0.0", ... }  — or YAML, or a Postman collection',
+  minRows = 12,
+}: SpecImportFieldProps) {
+  const [method, setMethod] = useState<ImportMethod>('paste');
+  const [url, setUrl] = useState('');
+  const [fetching, setFetching] = useState(false);
+  const [fileName, setFileName] = useState<string | null>(null);
+  const resetFileRef = useRef<() => void>(null);
+
+  const handleFile = async (file: File | null) => {
+    if (!file) return;
+    try {
+      const text = await file.text();
+      onChange(text);
+      setFileName(file.name);
+      notifications.show({
+        title: 'File loaded',
+        message: `Loaded ${file.name} (${text.length.toLocaleString()} chars)`,
+        color: 'teal',
+      });
+    } catch {
+      notifications.show({
+        title: 'Error',
+        message: 'Could not read the selected file',
+        color: 'red',
+      });
+    } finally {
+      resetFileRef.current?.();
+    }
+  };
+
+  const handleFetchUrl = async () => {
+    if (!url.trim()) return;
+    setFetching(true);
+    try {
+      const res = await fetch('/api/specs/fetch', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ url: url.trim(), format }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        throw new Error(data.error || 'Failed to fetch specification');
+      }
+      onChange(data.content ?? '');
+      notifications.show({
+        title: 'Specification fetched',
+        message: data.detectedFormat
+          ? `Detected: ${FORMAT_LABEL[data.detectedFormat] ?? data.detectedFormat}`
+          : 'Fetched successfully',
+        color: 'teal',
+      });
+    } catch (err) {
+      notifications.show({
+        title: 'Error',
+        message: err instanceof Error ? err.message : 'Failed to fetch specification',
+        color: 'red',
+      });
+    } finally {
+      setFetching(false);
+    }
+  };
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+      <ChipPicker<ImportMethod>
+        options={[
+          { value: 'paste', label: 'Paste', icon: <IconClipboard size={14} /> },
+          { value: 'upload', label: 'Upload file', icon: <IconUpload size={14} /> },
+          { value: 'url', label: 'From URL', icon: <IconLink size={14} /> },
+        ]}
+        value={method}
+        onChange={(v) => setMethod(v as ImportMethod)}
+      />
+
+      <Group grow align="flex-end" gap="sm">
+        <Select
+          label="Format"
+          data={FORMAT_OPTIONS}
+          value={format}
+          onChange={(v) => onFormatChange((v as SpecFormat) || 'auto')}
+          comboboxProps={{ withinPortal: true }}
+        />
+      </Group>
+
+      {method === 'upload' && (
+        <Group gap="sm" align="center">
+          <FileButton
+            resetRef={resetFileRef}
+            accept=".json,.yaml,.yml,application/json,application/yaml,text/yaml"
+            onChange={handleFile}
+          >
+            {(props) => (
+              <Button {...props} variant="light" leftSection={<IconUpload size={14} />}>
+                Choose file…
+              </Button>
+            )}
+          </FileButton>
+          {fileName && <Text size="sm" c="dimmed">{fileName}</Text>}
+        </Group>
+      )}
+
+      {method === 'url' && (
+        <Group gap="sm" align="flex-end">
+          <TextInput
+            style={{ flex: 1 }}
+            label="Specification URL"
+            placeholder="https://api.example.com/openapi.yaml"
+            value={url}
+            onChange={(e) => setUrl(e.currentTarget.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault();
+                handleFetchUrl();
+              }
+            }}
+          />
+          <Button
+            onClick={handleFetchUrl}
+            disabled={!url.trim() || fetching}
+            leftSection={fetching ? <Loader size={14} /> : <IconLink size={14} />}
+          >
+            Fetch
+          </Button>
+        </Group>
+      )}
+
+      <Textarea
+        label={method === 'paste' ? 'Specification' : 'Specification (editable)'}
+        description={
+          method === 'paste'
+            ? 'Paste an OpenAPI (JSON/YAML) document or a Postman collection.'
+            : 'Loaded content — you can review or edit before creating.'
+        }
+        placeholder={placeholder}
+        value={value}
+        onChange={(e) => onChange(e.currentTarget.value)}
+        autosize
+        minRows={minRows}
+        maxRows={20}
+        styles={{ input: { fontFamily: 'var(--mantine-font-family-monospace)', fontSize: 12 } }}
+      />
+    </div>
+  );
+}

--- a/src/components/mcp/CreateMcpModal.tsx
+++ b/src/components/mcp/CreateMcpModal.tsx
@@ -2,7 +2,6 @@
 
 import { useEffect, useMemo, useState } from 'react';
 import {
-  JsonInput,
   PasswordInput,
   Textarea,
   TextInput,
@@ -19,6 +18,7 @@ import FormShell, {
   SummaryGroup,
   SummaryKV,
 } from '@/components/common/ui/FormShell';
+import SpecImportField, { type SpecFormat } from '@/components/common/SpecImportField';
 import type { McpServerView } from '@/lib/services/mcp';
 
 interface CreateMcpModalProps {
@@ -40,6 +40,7 @@ interface FormValues {
   authUsername: string;
   authPassword: string;
   openApiSpec: string;
+  specFormat: SpecFormat;
 }
 
 export default function CreateMcpModal({
@@ -61,6 +62,7 @@ export default function CreateMcpModal({
       authUsername: '',
       authPassword: '',
       openApiSpec: '',
+      specFormat: 'auto',
     },
     validate: (values) => {
       const errors: Partial<Record<keyof FormValues, string>> = {};
@@ -77,13 +79,7 @@ export default function CreateMcpModal({
         if (!values.authPassword.trim()) errors.authPassword = 'Password is required';
       }
       if (!values.openApiSpec.trim()) {
-        errors.openApiSpec = 'OpenAPI specification is required';
-      } else {
-        try {
-          JSON.parse(values.openApiSpec);
-        } catch {
-          errors.openApiSpec = 'Invalid JSON format';
-        }
+        errors.openApiSpec = 'A specification is required';
       }
       return errors;
     },
@@ -122,6 +118,7 @@ export default function CreateMcpModal({
           name: values.name,
           description: values.description || undefined,
           openApiSpec: values.openApiSpec,
+          specFormat: values.specFormat,
           upstreamBaseUrl: values.upstreamBaseUrl || undefined,
           upstreamAuth,
         }),
@@ -158,21 +155,15 @@ export default function CreateMcpModal({
     if (v.authType === 'basic') return Boolean(v.authUsername.trim() && v.authPassword.trim());
     return true;
   })();
-  const validSpec = useMemo(() => {
-    const raw = form.values.openApiSpec.trim();
-    if (!raw) return false;
-    try {
-      JSON.parse(raw);
-      return true;
-    } catch {
-      return false;
-    }
-  }, [form.values.openApiSpec]);
+  const validSpec = useMemo(
+    () => Boolean(form.values.openApiSpec.trim()),
+    [form.values.openApiSpec],
+  );
 
   const checklist = [
     { id: 1, label: 'Name provided', done: validIdentity },
     { id: 2, label: 'Authentication configured', done: validAuth },
-    { id: 3, label: 'OpenAPI spec valid JSON', done: validSpec },
+    { id: 3, label: 'Specification provided', done: validSpec },
   ];
 
   const authLabel: Record<AuthType, string> = {
@@ -348,19 +339,16 @@ export default function CreateMcpModal({
 
       <FormSection
         number={3}
-        title="OpenAPI specification"
-        description="Paste the OpenAPI (Swagger) JSON. Paths and operations will be exposed as MCP tools automatically."
+        title="API specification"
+        description="Import an OpenAPI (Swagger) document as JSON or YAML, or a Postman collection. Paths and operations are exposed as MCP tools automatically."
         done={validSpec}
       >
-        <FormField label="Specification (JSON)" required>
-          <JsonInput
-            placeholder='{ "openapi": "3.0.0", "info": { ... }, "paths": { ... } }'
-            minRows={12}
-            maxRows={20}
-            autosize
-            validationError="Invalid JSON"
-            formatOnBlur
-            {...form.getInputProps('openApiSpec')}
+        <FormField label="Specification" required>
+          <SpecImportField
+            value={form.values.openApiSpec}
+            onChange={(v) => form.setFieldValue('openApiSpec', v)}
+            format={form.values.specFormat}
+            onFormatChange={(v) => form.setFieldValue('specFormat', v)}
           />
         </FormField>
       </FormSection>

--- a/src/components/tools/CreateToolModal.tsx
+++ b/src/components/tools/CreateToolModal.tsx
@@ -2,7 +2,6 @@
 
 import { useEffect, useState } from 'react';
 import {
-  JsonInput,
   PasswordInput,
   Select,
   Textarea,
@@ -25,6 +24,7 @@ import FormShell, {
   SummaryGroup,
   SummaryKV,
 } from '@/components/common/ui/FormShell';
+import SpecImportField, { type SpecFormat } from '@/components/common/SpecImportField';
 import type { ToolView } from '@/lib/services/tools';
 
 interface CreateToolModalProps {
@@ -39,6 +39,7 @@ interface FormValues {
   type: 'openapi' | 'mcp';
   // OpenAPI fields
   openApiSpec: string;
+  specFormat: SpecFormat;
   upstreamBaseUrl: string;
   // MCP fields
   mcpEndpoint: string;
@@ -91,6 +92,7 @@ export default function CreateToolModal({
       description: '',
       type: 'openapi',
       openApiSpec: '',
+      specFormat: 'auto',
       upstreamBaseUrl: '',
       mcpEndpoint: '',
       mcpTransport: 'streamable-http',
@@ -116,14 +118,7 @@ export default function CreateToolModal({
         if (!values.authPassword.trim()) errors.authPassword = 'Password is required';
       }
       if (values.type === 'openapi') {
-        if (!values.openApiSpec.trim()) errors.openApiSpec = 'OpenAPI specification is required';
-        else {
-          try {
-            JSON.parse(values.openApiSpec);
-          } catch {
-            errors.openApiSpec = 'Invalid JSON format';
-          }
-        }
+        if (!values.openApiSpec.trim()) errors.openApiSpec = 'A specification is required';
       } else {
         if (!values.mcpEndpoint.trim()) errors.mcpEndpoint = 'MCP endpoint URL is required';
         else {
@@ -175,6 +170,7 @@ export default function CreateToolModal({
 
       if (values.type === 'openapi') {
         body.openApiSpec = values.openApiSpec;
+        body.specFormat = values.specFormat;
         body.upstreamBaseUrl = values.upstreamBaseUrl || undefined;
       } else {
         body.mcpEndpoint = values.mcpEndpoint;
@@ -226,13 +222,7 @@ export default function CreateToolModal({
 
   const validSource = (() => {
     if (formValues.type === 'openapi') {
-      if (!formValues.openApiSpec.trim()) return false;
-      try {
-        JSON.parse(formValues.openApiSpec);
-        return true;
-      } catch {
-        return false;
-      }
+      return Boolean(formValues.openApiSpec.trim());
     }
     if (!formValues.mcpEndpoint.trim()) return false;
     try {
@@ -433,15 +423,15 @@ export default function CreateToolModal({
       {formValues.type === 'openapi' ? (
         <FormSection
           number={4}
-          title="OpenAPI specification"
-          description="Paste the spec JSON and optionally override the base URL."
+          title="API specification"
+          description="Import an OpenAPI document (JSON or YAML) or a Postman collection, and optionally override the base URL."
           done={validSource}
         >
           <FormRow cols={1}>
             <FormField
               label="Upstream base URL"
               optional
-              hint="Override the base URL from the OpenAPI spec servers array."
+              hint="Override the base URL from the spec's servers array."
             >
               <TextInput
                 placeholder="https://api.example.com"
@@ -450,14 +440,13 @@ export default function CreateToolModal({
             </FormField>
           </FormRow>
           <FormRow cols={1}>
-            <FormField label="OpenAPI specification" required>
-              <JsonInput
-                placeholder='{"openapi": "3.0.0", ...}'
+            <FormField label="Specification" required>
+              <SpecImportField
+                value={formValues.openApiSpec}
+                onChange={(v) => setFieldValue('openApiSpec', v)}
+                format={formValues.specFormat}
+                onFormatChange={(v) => setFieldValue('specFormat', v)}
                 minRows={10}
-                maxRows={20}
-                autosize
-                formatOnBlur
-                {...form.getInputProps('openApiSpec')}
               />
             </FormField>
           </FormRow>

--- a/src/lib/security/rbac.ts
+++ b/src/lib/security/rbac.ts
@@ -173,6 +173,8 @@ const ROUTE_PREFIXES: Array<{ prefix: string; service: PermissionService }> = [
   { prefix: '/api/pii', service: 'pii' },
   { prefix: '/api/mcp', service: 'mcp' },
   { prefix: '/api/tools', service: 'tools' },
+  // Spec import helper (URL fetch) used by the MCP/Tool create dialogs.
+  { prefix: '/api/specs', service: 'tools' },
   { prefix: '/api/browser', service: 'browser' },
   { prefix: '/api/crawler', service: 'crawler' },
   { prefix: '/api/websearch', service: 'websearch' },

--- a/src/lib/services/mcp/mcpService.ts
+++ b/src/lib/services/mcp/mcpService.ts
@@ -11,6 +11,7 @@ import type {
 } from './types';
 import { createLogger } from '@/lib/core/logger';
 import { safeFetch } from '@/lib/security/outboundFetch';
+import { normalizeApiSpec, type SpecFormatHint } from '@/lib/services/specImport';
 import { routeInstanceCall } from '@/lib/core/cluster';
 import type { QueuePayload } from '@/lib/core/queue';
 import { mcpEntityId } from './mcpEntityId';
@@ -74,14 +75,19 @@ function generateEndpointSlug(): string {
 
 // ── OpenAPI Parsing ───────────────────────────────────────────────────────
 
-export function parseOpenApiSpec(specString: string): {
+export function parseOpenApiSpec(specString: string, format: SpecFormatHint = 'auto'): {
   spec: OpenApiSpec;
   tools: IMcpTool[];
   baseUrl: string;
+  /** Canonical OpenAPI JSON string (YAML/Postman inputs are converted). */
+  normalizedSpec: string;
 } {
+  // Accept OpenAPI JSON/YAML or a Postman collection; normalize to OpenAPI JSON.
+  const { openApiJson } = normalizeApiSpec(specString, format);
+
   let spec: OpenApiSpec;
   try {
-    spec = JSON.parse(specString);
+    spec = JSON.parse(openApiJson);
   } catch {
     throw new Error('Invalid JSON: could not parse OpenAPI specification');
   }
@@ -155,7 +161,7 @@ export function parseOpenApiSpec(specString: string): {
     throw new Error('No operations found in the OpenAPI specification');
   }
 
-  return { spec, tools, baseUrl };
+  return { spec, tools, baseUrl, normalizedSpec: openApiJson };
 }
 
 // ── CRUD ──────────────────────────────────────────────────────────────────
@@ -167,7 +173,10 @@ export async function createMcpServer(
   projectId: string | undefined,
   input: CreateMcpServerInput,
 ): Promise<IMcpServer> {
-  const { tools, baseUrl: specBaseUrl } = parseOpenApiSpec(input.openApiSpec);
+  const { tools, baseUrl: specBaseUrl, normalizedSpec } = parseOpenApiSpec(
+    input.openApiSpec,
+    input.specFormat,
+  );
 
   const key = await generateUniqueKey(tenantDbName, projectId, input.name);
   const endpointSlug = generateEndpointSlug();
@@ -186,7 +195,7 @@ export async function createMcpServer(
     key,
     name: input.name.trim(),
     description: input.description?.trim(),
-    openApiSpec: input.openApiSpec,
+    openApiSpec: normalizedSpec,
     tools,
     upstreamBaseUrl,
     upstreamAuth: input.upstreamAuth as IMcpAuthConfig,
@@ -219,8 +228,11 @@ export async function updateMcpServer(
 
   // Re-parse spec if updated
   if (input.openApiSpec !== undefined) {
-    const { tools, baseUrl: specBaseUrl } = parseOpenApiSpec(input.openApiSpec);
-    updateData.openApiSpec = input.openApiSpec;
+    const { tools, baseUrl: specBaseUrl, normalizedSpec } = parseOpenApiSpec(
+      input.openApiSpec,
+      input.specFormat,
+    );
+    updateData.openApiSpec = normalizedSpec;
     updateData.tools = tools;
     if (!input.upstreamBaseUrl && specBaseUrl) {
       updateData.upstreamBaseUrl = specBaseUrl;

--- a/src/lib/services/mcp/types.ts
+++ b/src/lib/services/mcp/types.ts
@@ -1,4 +1,5 @@
 import type { IMcpTool, IMcpAuthConfig, McpAuthType } from '@/lib/database';
+import type { SpecFormatHint } from '@/lib/services/specImport';
 
 // ── View types ──────────────────────────────────────────────────────────
 
@@ -40,7 +41,10 @@ export interface McpRequestLogView {
 export interface CreateMcpServerInput {
   name: string;
   description?: string;
+  /** OpenAPI JSON/YAML or a Postman collection. */
   openApiSpec: string;
+  /** How to interpret `openApiSpec` (default: auto-detect). */
+  specFormat?: SpecFormatHint;
   upstreamBaseUrl?: string;
   upstreamAuth: {
     type: McpAuthType;
@@ -56,6 +60,7 @@ export interface UpdateMcpServerInput {
   name?: string;
   description?: string;
   openApiSpec?: string;
+  specFormat?: SpecFormatHint;
   upstreamBaseUrl?: string;
   upstreamAuth?: IMcpAuthConfig;
   status?: string;

--- a/src/lib/services/specImport/index.ts
+++ b/src/lib/services/specImport/index.ts
@@ -1,0 +1,361 @@
+/**
+ * Spec Import & Normalization
+ *
+ * Turns a variety of API descriptions into a single canonical OpenAPI 3.0
+ * JSON string that the MCP / Tool OpenAPI parsers can consume:
+ *
+ *   - OpenAPI / Swagger as JSON            → passed through (re-serialized)
+ *   - OpenAPI / Swagger as YAML            → parsed and re-serialized to JSON
+ *   - Postman Collection v2.x (JSON/YAML)  → converted to an OpenAPI 3.0 spec
+ *
+ * Auto-detection is used by default; callers may pass a hint to disambiguate.
+ * The whole pipeline is pure (no network) so it is safe to run server-side on
+ * user-supplied content.
+ */
+
+import YAML from 'yaml';
+import slugify from 'slugify';
+
+export type SpecFormatHint = 'auto' | 'openapi' | 'postman';
+export type DetectedFormat = 'openapi-json' | 'openapi-yaml' | 'postman';
+
+export interface NormalizeResult {
+  /** Canonical OpenAPI 3.0 specification serialized as JSON. */
+  openApiJson: string;
+  /** How the input was interpreted. */
+  detectedFormat: DetectedFormat;
+}
+
+const SLUG_OPTIONS = { lower: true, strict: true, trim: true };
+
+// ── Flexible parsing (JSON first, then YAML) ────────────────────────────────
+
+function parseFlexible(raw: string): { obj: Record<string, unknown>; wasYaml: boolean } {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    throw new Error('Specification is empty');
+  }
+
+  // JSON is a strict subset of YAML, but parse it directly first so we can
+  // report the source format accurately and give crisp JSON errors.
+  try {
+    const obj = JSON.parse(trimmed);
+    if (obj && typeof obj === 'object') return { obj, wasYaml: false };
+  } catch {
+    // fall through to YAML
+  }
+
+  try {
+    const obj = YAML.parse(trimmed);
+    if (obj && typeof obj === 'object') return { obj: obj as Record<string, unknown>, wasYaml: true };
+    throw new Error('Specification did not parse to an object');
+  } catch (err) {
+    throw new Error(
+      `Could not parse specification as JSON or YAML: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}
+
+// ── Detection ───────────────────────────────────────────────────────────────
+
+function looksLikePostman(obj: Record<string, unknown>): boolean {
+  if (Array.isArray(obj.item)) {
+    const info = obj.info as Record<string, unknown> | undefined;
+    if (info) {
+      if (info._postman_id) return true;
+      if (typeof info.schema === 'string' && info.schema.includes('getpostman.com')) return true;
+    }
+    // A top-level `item` array with no OpenAPI markers is almost certainly Postman.
+    if (!obj.openapi && !obj.swagger && !obj.paths) return true;
+  }
+  return false;
+}
+
+// ── Public API ──────────────────────────────────────────────────────────────
+
+export function normalizeApiSpec(raw: string, hint: SpecFormatHint = 'auto'): NormalizeResult {
+  const { obj, wasYaml } = parseFlexible(raw);
+
+  const isPostman =
+    hint === 'postman' || (hint === 'auto' && looksLikePostman(obj));
+
+  if (isPostman) {
+    const spec = convertPostmanToOpenApi(obj);
+    return { openApiJson: JSON.stringify(spec), detectedFormat: 'postman' };
+  }
+
+  // OpenAPI / Swagger path.
+  if (!obj.openapi && !obj.swagger && !obj.paths) {
+    throw new Error(
+      'Unrecognized specification: expected an OpenAPI/Swagger document (with "openapi"/"swagger"/"paths") or a Postman collection (with "item").',
+    );
+  }
+
+  return {
+    openApiJson: JSON.stringify(obj),
+    detectedFormat: wasYaml ? 'openapi-yaml' : 'openapi-json',
+  };
+}
+
+// ── Postman → OpenAPI conversion ────────────────────────────────────────────
+
+interface PostmanUrlObject {
+  raw?: string;
+  protocol?: string;
+  host?: string[] | string;
+  path?: Array<string | { value?: string }> | string;
+  query?: Array<{ key?: string; value?: string; description?: string; disabled?: boolean }>;
+  variable?: Array<{ key?: string; value?: string; description?: string }>;
+}
+
+interface PostmanRequest {
+  method?: string;
+  url?: PostmanUrlObject | string;
+  description?: string;
+  header?: Array<{ key?: string; value?: string; description?: string; disabled?: boolean }>;
+  body?: {
+    mode?: string;
+    raw?: string;
+    options?: { raw?: { language?: string } };
+  };
+}
+
+interface PostmanItem {
+  name?: string;
+  description?: string;
+  item?: PostmanItem[];
+  request?: PostmanRequest | string;
+}
+
+type OpenApiOperation = Record<string, unknown>;
+
+function resolveVariables(input: string, vars: Record<string, string>): string {
+  return input.replace(/\{\{([^}]+)\}\}/g, (match, name) => {
+    const key = String(name).trim();
+    return Object.prototype.hasOwnProperty.call(vars, key) ? vars[key] : match;
+  });
+}
+
+function normalizeUrl(
+  url: PostmanUrlObject | string | undefined,
+  vars: Record<string, string>,
+): { baseUrl: string; path: string; query: Array<{ key: string; value?: string; description?: string }>; pathVars: Record<string, string | undefined> } {
+  const pathVars: Record<string, string | undefined> = {};
+  const query: Array<{ key: string; value?: string; description?: string }> = [];
+
+  const obj: PostmanUrlObject =
+    typeof url === 'string' ? { raw: url } : url ?? {};
+
+  // Collect declared path-variable descriptions.
+  for (const v of obj.variable ?? []) {
+    if (v.key) pathVars[v.key] = v.description;
+  }
+  for (const q of obj.query ?? []) {
+    if (q.key && !q.disabled) query.push({ key: q.key, value: q.value, description: q.description });
+  }
+
+  // Determine host/protocol.
+  let baseUrl = '';
+  let segments: string[] = [];
+
+  const hostStr = Array.isArray(obj.host) ? obj.host.join('.') : obj.host;
+  if (hostStr) {
+    // A host segment can be a `{{baseUrl}}` variable that already resolves to a
+    // full origin (scheme + host); only prepend a protocol when it is absent.
+    const resolvedHost = resolveVariables(hostStr, vars).replace(/\/+$/, '');
+    baseUrl = /^[a-z][a-z0-9+.-]*:\/\//i.test(resolvedHost)
+      ? resolvedHost
+      : `${obj.protocol || 'https'}://${resolvedHost}`;
+    const rawSegs = Array.isArray(obj.path)
+      ? obj.path.map((s) => (typeof s === 'string' ? s : s?.value ?? ''))
+      : typeof obj.path === 'string'
+        ? obj.path.split('/')
+        : [];
+    segments = rawSegs.filter((s) => s !== '');
+  } else if (obj.raw) {
+    // Parse the raw URL string (may contain {{vars}}).
+    const resolved = resolveVariables(obj.raw, vars);
+    const withoutQuery = resolved.split('?')[0];
+    try {
+      const u = new URL(withoutQuery);
+      baseUrl = `${u.protocol}//${u.host}`;
+      segments = u.pathname.split('/').filter((s) => s !== '');
+    } catch {
+      // Relative or template base (e.g. "{{baseUrl}}/users/:id" left unresolved).
+      const parts = withoutQuery.split('/').filter((s) => s !== '');
+      // First segment is treated as the base if it still looks like a host/template.
+      if (parts.length && (parts[0].includes('{{') || parts[0].includes('.') || parts[0].includes('://'))) {
+        baseUrl = parts.shift() ?? '';
+      }
+      segments = parts;
+    }
+  }
+
+  // Convert `:param` segments to `{param}` and register path params.
+  const pathSegments = segments.map((seg) => {
+    if (seg.startsWith(':')) {
+      const name = seg.slice(1);
+      if (!(name in pathVars)) pathVars[name] = undefined;
+      return `{${name}}`;
+    }
+    return seg;
+  });
+
+  const path = '/' + pathSegments.join('/');
+  return { baseUrl, path: path === '/' ? '/' : path, query, pathVars };
+}
+
+function buildRequestBodySchema(body: PostmanRequest['body']): Record<string, unknown> | undefined {
+  if (!body || !body.raw) return undefined;
+  const lang = body.options?.raw?.language;
+  if (body.mode !== 'raw') return { type: 'object', description: 'Request body' };
+
+  if (lang === 'json' || !lang) {
+    try {
+      const parsed = JSON.parse(body.raw);
+      const example = parsed;
+      const schema: Record<string, unknown> = { type: 'object', description: 'Request body' };
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        schema.properties = Object.fromEntries(
+          Object.keys(parsed).map((k) => [k, { type: inferJsonType((parsed as Record<string, unknown>)[k]) }]),
+        );
+      }
+      schema.example = example;
+      return schema;
+    } catch {
+      return { type: 'string', description: 'Raw request body' };
+    }
+  }
+  return { type: 'string', description: 'Raw request body' };
+}
+
+function inferJsonType(value: unknown): string {
+  if (Array.isArray(value)) return 'array';
+  if (value === null) return 'string';
+  switch (typeof value) {
+    case 'number':
+      return Number.isInteger(value) ? 'integer' : 'number';
+    case 'boolean':
+      return 'boolean';
+    case 'object':
+      return 'object';
+    default:
+      return 'string';
+  }
+}
+
+export function convertPostmanToOpenApi(collection: Record<string, unknown>): Record<string, unknown> {
+  const info = (collection.info as Record<string, unknown>) || {};
+  const title = (info.name as string) || 'Imported Postman Collection';
+  const description = (info.description as string) || undefined;
+
+  // Collection-level variables for {{var}} resolution.
+  const vars: Record<string, string> = {};
+  for (const v of (collection.variable as Array<{ key?: string; value?: string }>) ?? []) {
+    if (v.key) vars[v.key] = v.value ?? '';
+  }
+
+  const paths: Record<string, Record<string, OpenApiOperation>> = {};
+  const baseUrlCounts = new Map<string, number>();
+  const usedOperationIds = new Set<string>();
+
+  const walk = (items: PostmanItem[] | undefined, folderPrefix: string) => {
+    for (const item of items ?? []) {
+      if (item.item) {
+        walk(item.item, folderPrefix ? `${folderPrefix} / ${item.name ?? ''}` : item.name ?? '');
+        continue;
+      }
+      const request: PostmanRequest | undefined =
+        typeof item.request === 'string' ? { url: item.request, method: 'GET' } : item.request;
+      if (!request) continue;
+
+      const method = (request.method || 'GET').toLowerCase();
+      const { baseUrl, path, query, pathVars } = normalizeUrl(request.url, vars);
+      if (baseUrl) baseUrlCounts.set(baseUrl, (baseUrlCounts.get(baseUrl) ?? 0) + 1);
+
+      const parameters: Array<Record<string, unknown>> = [];
+      for (const [name, desc] of Object.entries(pathVars)) {
+        parameters.push({
+          name,
+          in: 'path',
+          required: true,
+          description: desc || `Path parameter: ${name}`,
+          schema: { type: 'string' },
+        });
+      }
+      for (const q of query) {
+        parameters.push({
+          name: q.key,
+          in: 'query',
+          required: false,
+          description: q.description || `Query parameter: ${q.key}`,
+          schema: { type: 'string' },
+          ...(q.value ? { example: q.value } : {}),
+        });
+      }
+
+      const operation: OpenApiOperation = {
+        summary: item.name || `${method.toUpperCase()} ${path}`,
+        description: item.description || request.description || undefined,
+        operationId: uniqueOperationId(method, item.name || path, usedOperationIds),
+        ...(parameters.length ? { parameters } : {}),
+      };
+
+      if (['post', 'put', 'patch', 'delete'].includes(method)) {
+        const schema = buildRequestBodySchema(request.body);
+        if (schema) {
+          operation.requestBody = {
+            required: false,
+            content: { 'application/json': { schema } },
+          };
+        }
+      }
+
+      if (!paths[path]) paths[path] = {};
+      // Avoid clobbering when two requests share a method+path.
+      if (paths[path][method]) {
+        const altPath = `${path}#${Object.keys(paths).length}`;
+        paths[altPath] = { [method]: operation };
+      } else {
+        paths[path][method] = operation;
+      }
+    }
+  };
+
+  walk(collection.item as PostmanItem[], '');
+
+  // Pick the most common base URL as the server.
+  let serverUrl = '';
+  let best = 0;
+  for (const [url, count] of baseUrlCounts) {
+    if (count > best) {
+      best = count;
+      serverUrl = url;
+    }
+  }
+
+  const spec: Record<string, unknown> = {
+    openapi: '3.0.0',
+    info: {
+      title,
+      version: '1.0.0',
+      ...(description ? { description } : {}),
+    },
+    paths,
+  };
+  if (serverUrl) spec.servers = [{ url: serverUrl }];
+
+  return spec;
+}
+
+function uniqueOperationId(method: string, name: string, used: Set<string>): string {
+  const base = slugify(`${method}_${name}`, SLUG_OPTIONS) || `${method}_op`;
+  let candidate = base;
+  let i = 1;
+  while (used.has(candidate)) {
+    candidate = `${base}-${i}`;
+    i += 1;
+  }
+  used.add(candidate);
+  return candidate;
+}

--- a/src/lib/services/tools/toolService.ts
+++ b/src/lib/services/tools/toolService.ts
@@ -7,6 +7,7 @@
 
 import slugify from 'slugify';
 import { safeFetch } from '@/lib/security/outboundFetch';
+import { normalizeApiSpec, type SpecFormatHint } from '@/lib/services/specImport';
 import { createLogger } from '@/lib/core/logger';
 import { getDatabase } from '@/lib/database';
 import type { ITool, IToolAction, IToolAuthConfig } from '@/lib/database';
@@ -78,13 +79,18 @@ interface OpenApiOperation {
   responses?: Record<string, unknown>;
 }
 
-export function parseOpenApiToActions(specString: string): {
+export function parseOpenApiToActions(specString: string, format: SpecFormatHint = 'auto'): {
   actions: IToolAction[];
   baseUrl: string;
+  /** Canonical OpenAPI JSON string (YAML/Postman inputs are converted). */
+  normalizedSpec: string;
 } {
+  // Accept OpenAPI JSON/YAML or a Postman collection; normalize to OpenAPI JSON.
+  const { openApiJson } = normalizeApiSpec(specString, format);
+
   let spec: OpenApiSpec;
   try {
-    spec = JSON.parse(specString);
+    spec = JSON.parse(openApiJson);
   } catch {
     throw new Error('Invalid JSON: could not parse OpenAPI specification');
   }
@@ -156,7 +162,7 @@ export function parseOpenApiToActions(specString: string): {
     throw new Error('No operations found in the OpenAPI specification');
   }
 
-  return { actions, baseUrl };
+  return { actions, baseUrl, normalizedSpec: openApiJson };
 }
 
 // ── MCP Tool Discovery ───────────────────────────────────────────────────
@@ -238,13 +244,15 @@ export async function createTool(
 
   let actions: IToolAction[] = [];
   let upstreamBaseUrl = input.upstreamBaseUrl;
+  let normalizedSpec = input.openApiSpec;
 
   if (input.type === 'openapi') {
     if (!input.openApiSpec) {
       throw new Error('OpenAPI specification is required for "openapi" tool type');
     }
-    const parsed = parseOpenApiToActions(input.openApiSpec);
+    const parsed = parseOpenApiToActions(input.openApiSpec, input.specFormat);
     actions = parsed.actions;
+    normalizedSpec = parsed.normalizedSpec;
     if (!upstreamBaseUrl && parsed.baseUrl) upstreamBaseUrl = parsed.baseUrl;
     if (!upstreamBaseUrl) {
       throw new Error('Upstream base URL is required. Provide it explicitly or include a servers array in the spec.');
@@ -272,7 +280,7 @@ export async function createTool(
     type: input.type,
     status: 'active',
     actions,
-    openApiSpec: input.openApiSpec,
+    openApiSpec: normalizedSpec,
     upstreamBaseUrl,
     upstreamAuth: input.upstreamAuth as IToolAuthConfig,
     mcpEndpoint: input.mcpEndpoint,
@@ -305,8 +313,11 @@ export async function updateTool(
 
   // Re-parse spec or re-discover MCP tools if source config changed
   if (input.openApiSpec !== undefined) {
-    const { actions, baseUrl: specBaseUrl } = parseOpenApiToActions(input.openApiSpec);
-    updateData.openApiSpec = input.openApiSpec;
+    const { actions, baseUrl: specBaseUrl, normalizedSpec } = parseOpenApiToActions(
+      input.openApiSpec,
+      input.specFormat,
+    );
+    updateData.openApiSpec = normalizedSpec;
     updateData.actions = actions;
     if (!input.upstreamBaseUrl && specBaseUrl) {
       updateData.upstreamBaseUrl = specBaseUrl;

--- a/src/lib/services/tools/types.ts
+++ b/src/lib/services/tools/types.ts
@@ -3,6 +3,7 @@
  */
 
 import type { IToolAction, IToolAuthConfig, ToolSourceType } from '@/lib/database';
+import type { SpecFormatHint } from '@/lib/services/specImport';
 
 // ── View types ──────────────────────────────────────────────────────────
 
@@ -62,8 +63,10 @@ export interface CreateToolInput {
   name: string;
   description?: string;
   type: ToolSourceType;
-  /** For OpenAPI: spec JSON or YAML string */
+  /** For OpenAPI: spec JSON/YAML, or a Postman collection */
   openApiSpec?: string;
+  /** How to interpret `openApiSpec` (default: auto-detect). */
+  specFormat?: SpecFormatHint;
   upstreamBaseUrl?: string;
   upstreamAuth?: {
     type: 'none' | 'token' | 'header' | 'basic';
@@ -82,6 +85,7 @@ export interface UpdateToolInput {
   name?: string;
   description?: string;
   openApiSpec?: string;
+  specFormat?: SpecFormatHint;
   upstreamBaseUrl?: string;
   upstreamAuth?: IToolAuthConfig;
   mcpEndpoint?: string;

--- a/src/server/api/plugin.ts
+++ b/src/server/api/plugin.ts
@@ -68,6 +68,7 @@ import { projectsApiPlugin } from './plugins/projects';
 import { quotaApiPlugin } from './plugins/quota';
 import { ragApiPlugin } from './plugins/rag';
 import { rerankerApiPlugin } from './plugins/reranker';
+import { specsApiPlugin } from './plugins/specs';
 import { tokensApiPlugin } from './plugins/tokens';
 import { toolsApiPlugin } from './plugins/tools';
 import { tracingApiPlugin } from './plugins/tracing';
@@ -400,6 +401,7 @@ export const fastifyApiPlugin: FastifyPluginAsync = async (app) => {
   await app.register(quotaApiPlugin);
   await app.register(ragApiPlugin);
   await app.register(rerankerApiPlugin);
+  await app.register(specsApiPlugin);
   await app.register(tokensApiPlugin);
   await app.register(toolsApiPlugin);
   await app.register(tracingApiPlugin);

--- a/src/server/api/plugins/mcp.ts
+++ b/src/server/api/plugins/mcp.ts
@@ -1,14 +1,17 @@
 import type { IMcpAuthConfig, McpAuthType } from '@/lib/database';
 import type { FastifyPluginAsync } from 'fastify';
+import type { SpecFormatHint } from '@/lib/services/specImport';
 import { createLogger } from '@/lib/core/logger';
 import {
   aggregateMcpRequestLogs,
   countMcpRequestLogs,
   createMcpServer,
   deleteMcpServer,
+  executeMcpTool,
   getMcpServer,
   listMcpRequestLogs,
   listMcpServers,
+  logMcpRequest,
   serializeMcpServer,
   serializeMcpServerFull,
   updateMcpServer,
@@ -87,6 +90,7 @@ export const mcpApiPlugin: FastifyPluginAsync = async (app) => {
           description: typeof body.description === 'string' ? body.description.trim() : undefined,
           name: body.name.trim(),
           openApiSpec: body.openApiSpec,
+          specFormat: typeof body.specFormat === 'string' ? body.specFormat as SpecFormatHint : undefined,
           upstreamAuth: body.upstreamAuth as IMcpAuthConfig,
           upstreamBaseUrl: typeof body.upstreamBaseUrl === 'string'
             ? body.upstreamBaseUrl.trim()
@@ -167,6 +171,7 @@ export const mcpApiPlugin: FastifyPluginAsync = async (app) => {
         description: body.description as string | undefined,
         name: body.name as string | undefined,
         openApiSpec: body.openApiSpec as string | undefined,
+        specFormat: typeof body.specFormat === 'string' ? body.specFormat as SpecFormatHint : undefined,
         status: body.status as 'active' | 'disabled' | undefined,
         upstreamAuth: body.upstreamAuth as IMcpAuthConfig | undefined,
         upstreamBaseUrl: body.upstreamBaseUrl as string | undefined,
@@ -264,6 +269,62 @@ export const mcpApiPlugin: FastifyPluginAsync = async (app) => {
       });
     } catch (error) {
       logger.error('List MCP server logs error', { error });
+      return sendProjectContextError(reply, error)
+        ?? reply.code(500).send({
+          error: error instanceof Error ? error.message : 'Internal error',
+        });
+    }
+  }));
+
+  // Playground: test-execute one of the server's tools from the dashboard.
+  app.post('/mcp/:id/execute', withApiRequestContext(async (request, reply) => {
+    try {
+      const { session } = await requireProjectContextForRequest(request);
+      const { id } = request.params as { id: string };
+      const body = readJsonBody<Record<string, unknown>>(request);
+
+      const toolName = typeof body.tool === 'string'
+        ? body.tool
+        : typeof body.toolName === 'string'
+          ? body.toolName
+          : '';
+      if (!toolName.trim()) {
+        return reply.code(400).send({ error: '"tool" is required' });
+      }
+
+      const args = (body.arguments ?? body.args ?? {}) as Record<string, unknown>;
+
+      const server = await getMcpServer(session.tenantDbName, id);
+      if (!server) {
+        return reply.code(404).send({ error: 'MCP server not found' });
+      }
+      if (server.status !== 'active') {
+        return reply.code(400).send({ error: 'MCP server is disabled' });
+      }
+
+      try {
+        const { result, latencyMs } = await executeMcpTool(server, toolName, args);
+
+        void logMcpRequest(
+          session.tenantDbName, session.tenantId, server.projectId,
+          server.key, toolName, 'success', latencyMs,
+          { tool: toolName, arguments: args },
+          typeof result === 'object' ? result as Record<string, unknown> : { value: result },
+        );
+
+        return reply.code(200).send({ result, latencyMs });
+      } catch (execError) {
+        const message = execError instanceof Error ? execError.message : 'Execution failed';
+        void logMcpRequest(
+          session.tenantDbName, session.tenantId, server.projectId,
+          server.key, toolName, 'error', 0,
+          { tool: toolName, arguments: args },
+          undefined, message,
+        );
+        return reply.code(500).send({ error: message });
+      }
+    } catch (error) {
+      logger.error('Execute MCP tool error', { error });
       return sendProjectContextError(reply, error)
         ?? reply.code(500).send({
           error: error instanceof Error ? error.message : 'Internal error',

--- a/src/server/api/plugins/specs.ts
+++ b/src/server/api/plugins/specs.ts
@@ -1,0 +1,84 @@
+import type { FastifyPluginAsync } from 'fastify';
+import { createLogger } from '@/lib/core/logger';
+import { safeFetch } from '@/lib/security/outboundFetch';
+import { normalizeApiSpec, type SpecFormatHint } from '@/lib/services/specImport';
+import {
+  readJsonBody,
+  requireProjectContextForRequest,
+  sendProjectContextError,
+  withApiRequestContext,
+} from '../fastify-utils';
+
+const logger = createLogger('api:specs');
+
+// Cap fetched specs to a sane size to avoid pulling huge payloads server-side.
+const MAX_SPEC_BYTES = 5 * 1024 * 1024; // 5 MB
+
+export const specsApiPlugin: FastifyPluginAsync = async (app) => {
+  /**
+   * POST /specs/fetch
+   *
+   * Fetch an API specification (OpenAPI JSON/YAML or a Postman collection) from
+   * a remote URL, server-side, behind the SSRF guard. Used by the "From URL"
+   * import option in the MCP / Tool create dialogs so the browser does not hit
+   * cross-origin CORS restrictions.
+   *
+   * Body: { url: string, format?: 'auto' | 'openapi' | 'postman' }
+   * Returns: { content, contentType, detectedFormat }
+   */
+  app.post('/specs/fetch', withApiRequestContext(async (request, reply) => {
+    try {
+      // Auth + tenant/project binding (import is a project-scoped action).
+      await requireProjectContextForRequest(request);
+
+      const body = readJsonBody<Record<string, unknown>>(request);
+      const url = typeof body.url === 'string' ? body.url.trim() : '';
+      const format = typeof body.format === 'string' ? (body.format as SpecFormatHint) : 'auto';
+
+      if (!url) {
+        return reply.code(400).send({ error: '"url" is required' });
+      }
+
+      let response: Response;
+      try {
+        response = await safeFetch(url, {
+          method: 'GET',
+          headers: { Accept: 'application/json, application/yaml, text/yaml, text/plain, */*' },
+        });
+      } catch (err) {
+        return reply.code(400).send({
+          error: `Could not fetch spec: ${err instanceof Error ? err.message : String(err)}`,
+        });
+      }
+
+      if (!response.ok) {
+        return reply.code(400).send({
+          error: `Remote server responded with ${response.status}`,
+        });
+      }
+
+      const contentType = response.headers.get('content-type') ?? '';
+      const content = await response.text();
+
+      if (content.length > MAX_SPEC_BYTES) {
+        return reply.code(413).send({ error: 'Specification exceeds the 5 MB limit' });
+      }
+
+      // Best-effort validation/detection so the client can surface the format.
+      let detectedFormat: string | undefined;
+      try {
+        detectedFormat = normalizeApiSpec(content, format).detectedFormat;
+      } catch {
+        // Leave detectedFormat undefined; the client still receives the raw text.
+      }
+
+      return reply.code(200).send({ content, contentType, detectedFormat });
+    } catch (error) {
+      logger.error('Fetch spec error', { error });
+      return sendProjectContextError(reply, error)
+        ?? reply.code(500).send({
+          error: error instanceof Error ? error.message : 'Internal error',
+        });
+    }
+  }));
+};

--- a/src/server/api/plugins/tools.ts
+++ b/src/server/api/plugins/tools.ts
@@ -1,5 +1,6 @@
 import type { IToolAuthConfig } from '@/lib/database';
 import type { FastifyPluginAsync } from 'fastify';
+import type { SpecFormatHint } from '@/lib/services/specImport';
 import { createLogger } from '@/lib/core/logger';
 import {
   aggregateToolRequestLogs,
@@ -70,6 +71,7 @@ export const toolsApiPlugin: FastifyPluginAsync = async (app) => {
         mcpTransport: body.mcpTransport as 'sse' | 'streamable-http' | undefined,
         name: body.name,
         openApiSpec: body.openApiSpec as string | undefined,
+        specFormat: typeof body.specFormat === 'string' ? body.specFormat as SpecFormatHint : undefined,
         type: body.type,
         upstreamAuth: body.upstreamAuth as IToolAuthConfig | undefined,
         upstreamBaseUrl: body.upstreamBaseUrl as string | undefined,


### PR DESCRIPTION
## Summary

Broadens how **MCP servers** and **Tools** ingest an API definition, and adds a **playground** to try tools before binding them to an agent.

- **Shared normalizer** `src/lib/services/specImport` — accepts OpenAPI **JSON**, OpenAPI **YAML** (via `yaml`), and **Postman collection v2.x**, normalizing everything to a canonical OpenAPI 3.0 JSON string. The existing MCP/Tool OpenAPI parsers now take a format hint and **store the normalized spec**. Postman `{{baseUrl}}` / base-URL resolution avoids the double-scheme bug (`https://https://…`).
- **`SpecImportField`** — paste / upload-file / from-URL import with a format selector, used by the *New MCP server* and *New tool* dialogs. URL fetch goes through the SSRF-guarded proxy `POST /api/specs/fetch` (5 MB cap).
- **MCP Playground** — new tab on the MCP detail page (select tool → JSON args → run), backed by `POST /api/mcp/:id/execute` (reuses `executeMcpTool` + request logging). The Tools *Test* tab is relabeled **Playground**.
- **RBAC** — map `/api/specs` → `tools` service (write required, matching create flows).
- Adds `yaml` as a direct dependency (already present transitively; surgical lock edit) and **unit tests** for the normalizer.

## Test plan

- [x] `npm run lint` — clean
- [x] `tsc --noEmit` — clean
- [x] `npm run test` — 2534 passed / 4 skipped; new `spec-import.test.ts` (5) green; tenant-security guard tests green
- [x] `npm run build` — production build succeeds (incl. `/dashboard/mcp/[id]`, `/dashboard/tools/[id]`)

## Notes

- Live routes are the Fastify plugins under `src/server/api/plugins/*` (mounted at `/api`); the `src/server/api/routes/**` tree is legacy/test-only and was left untouched.
- No seam/registry changes; this is a community-side feature. A follow-up console-ee `COMPAT.json` bump will pin SaaS to the merge commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)