### PR TITLE
fix(crawler): job status persistence, webhook SSRF hardening, content extraction reliability

### DIFF
--- a/docs/api/crawler.md
+++ b/docs/api/crawler.md
@@ -27,7 +27,7 @@ These appear on create/update and inside a job's frozen `planSnapshot`:
 | `maxPages` | int 0–5000 | `50` | Page cap. `0` = unlimited. |
 | `autoCrawl` | boolean | `false` | Follow discovered links within scope. |
 | `scope` | object | — | `sameDomainOnly` (default `true`), `includeSubdomains` (default `false`), `allowList[]`, `blockList[]` host globs. |
-| `http` | object | — | `userAgent`, `acceptLanguage`, `timeoutMs` (1000–120000), `maxConcurrency` (1–16), `retries` (1–5), `headers`, `cookies[]`, `basicAuth`, `bearerToken`, `allowPrivateNetwork`. |
+| `http` | object | — | `userAgent`, `acceptLanguage`, `timeoutMs` (1000–120000), `maxConcurrency` (1–16), `retries` (1–5), `headers`, `cookies[]`, `basicAuth`, `bearerToken`, `allowPrivateNetwork`, `allowInsecureTls` (skips TLS certificate verification — opt-in escape hatch for sites with a misconfigured cert chain). |
 | `downloadableMimes` | string[] | — | MIME types treated as downloadable files. |
 | `markdownOptions` | object | — | `{ ocr: { enabled, languages? } }` forwarded to the Markdown extractor. |
 | `rag` | object | — | `{ ragModuleKey, enabled }` — ingest crawled pages into a RAG module. |

--- a/src/app/dashboard/crawler/[crawlerId]/page.tsx
+++ b/src/app/dashboard/crawler/[crawlerId]/page.tsx
@@ -63,6 +63,7 @@ interface HttpForm {
   headers: string;
   cookies: string;
   allowPrivateNetwork: boolean;
+  allowInsecureTls: boolean;
 }
 
 interface IntegrationForm {
@@ -135,6 +136,7 @@ export default function CrawlerDetailPage() {
       headers: '',
       cookies: '',
       allowPrivateNetwork: false,
+      allowInsecureTls: false,
     },
   });
 
@@ -197,6 +199,7 @@ export default function CrawlerDetailPage() {
         headers: c.http.headers ? JSON.stringify(c.http.headers, null, 2) : '',
         cookies: c.http.cookies ? JSON.stringify(c.http.cookies, null, 2) : '',
         allowPrivateNetwork: c.http.allowPrivateNetwork ?? false,
+        allowInsecureTls: c.http.allowInsecureTls ?? false,
       });
 
       intForm.setValues({
@@ -384,6 +387,7 @@ export default function CrawlerDetailPage() {
         maxConcurrency: values.maxConcurrency,
         bearerToken: values.bearerToken || undefined,
         allowPrivateNetwork: values.allowPrivateNetwork,
+        allowInsecureTls: values.allowInsecureTls,
         headers,
         cookies,
       };
@@ -682,7 +686,7 @@ export default function CrawlerDetailPage() {
     {
       key: 'status',
       label: 'Status',
-      render: (j) => <StatusBadge status={statusToBadge(j.status)} />,
+      render: (j) => <StatusBadge status={j.status} />,
     },
     {
       key: 'startedAt',
@@ -826,7 +830,7 @@ export default function CrawlerDetailPage() {
             {summary.last ? (
               <Stack gap={4}>
                 <Group gap="xs">
-                  <StatusBadge status={statusToBadge(summary.last.status)} />
+                  <StatusBadge status={summary.last.status} />
                   <span className="ds-mono ds-muted" style={{ fontSize: 12 }}>
                     {new Date(summary.last.createdAt ?? Date.now()).toLocaleString()}
                   </span>
@@ -1062,6 +1066,11 @@ Content-Type: application/json
                 label="Allow private network (DANGER: disables SSRF guard)"
                 {...httpForm.getInputProps('allowPrivateNetwork', { type: 'checkbox' })}
               />
+              <Switch
+                label="Allow insecure TLS (DANGER: skips certificate verification)"
+                description="Use only when a site's TLS chain is misconfigured (e.g. missing intermediate certificate) and you trust the destination."
+                {...httpForm.getInputProps('allowInsecureTls', { type: 'checkbox' })}
+              />
               <Group justify="flex-end">
                 <Button type="submit" loading={savingHttp}>Save HTTP settings</Button>
               </Group>
@@ -1193,7 +1202,7 @@ Content-Type: application/json
           <Stack>
             <Group justify="space-between">
               <Group>
-                <StatusBadge status={statusToBadge(openJob.status)} />
+                <StatusBadge status={openJob.status} />
                 <span className="ds-faint">
                   {openJob.pagesProcessed} pages · {openJob.filesProcessed} files · {openJob.errorsCount} errors
                   {openJob.durationMs ? ` · ${(openJob.durationMs / 1000).toFixed(1)}s` : ''}
@@ -1255,20 +1264,4 @@ Content-Type: application/json
       </Modal>
     </PageContainer>
   );
-}
-
-function statusToBadge(status: CrawlJobView['status']): string {
-  switch (status) {
-    case 'succeeded':
-      return 'active';
-    case 'failed':
-      return 'failed';
-    case 'partial':
-    case 'canceled':
-      return 'warn';
-    case 'running':
-      return 'info';
-    default:
-      return 'pending';
-  }
 }

--- a/src/components/common/ui/StatusBadge.tsx
+++ b/src/components/common/ui/StatusBadge.tsx
@@ -22,6 +22,14 @@ const STATUS_MAP: Record<string, { cls: string; label: string }> = {
   error: { cls: 'ds-badge-err', label: 'Error' },
   pending: { cls: 'ds-badge-info', label: 'Pending' },
   info: { cls: 'ds-badge-info', label: 'Info' },
+  // Job/run lifecycle statuses (crawler, batch, evaluation, etc.)
+  queued: { cls: 'ds-badge-info', label: 'Queued' },
+  running: { cls: 'ds-badge-teal', label: 'Running' },
+  succeeded: { cls: 'ds-badge-ok', label: 'Succeeded' },
+  completed: { cls: 'ds-badge-ok', label: 'Completed' },
+  partial: { cls: 'ds-badge-warn', label: 'Partial' },
+  canceled: { cls: '', label: 'Canceled' },
+  cancelled: { cls: '', label: 'Cancelled' },
 };
 
 export default function StatusBadge({ status, label, withDot = true }: StatusBadgeProps) {

--- a/src/lib/database/mongodb/crawler.mixin.ts
+++ b/src/lib/database/mongodb/crawler.mixin.ts
@@ -148,6 +148,67 @@ export function CrawlerMixin<TBase extends Constructor<MongoDBProviderBase>>(Bas
       return { ...result, _id: toId(result._id) } as ICrawlJob;
     }
 
+    async claimCrawlJob(id: string, tenantId: string, startedAt: Date): Promise<ICrawlJob | null> {
+      const db = this.getTenantDb();
+      const result = await db
+        .collection<ICrawlJob>(COLLECTIONS.crawlJobs)
+        .findOneAndUpdate(
+          { _id: objectId(id), tenantId, status: 'queued' },
+          { $set: { status: 'running', startedAt, updatedAt: new Date() } },
+          { returnDocument: 'after' },
+        );
+      if (!result) return null;
+      return { ...result, _id: toId(result._id) } as ICrawlJob;
+    }
+
+    async requestCrawlJobCancel(id: string, tenantId: string): Promise<ICrawlJob | null> {
+      const db = this.getTenantDb();
+      const now = new Date();
+      // Fast path: job hasn't started yet, cancel it outright.
+      const queuedResult = await db
+        .collection<ICrawlJob>(COLLECTIONS.crawlJobs)
+        .findOneAndUpdate(
+          { _id: objectId(id), tenantId, status: 'queued' },
+          { $set: { status: 'canceled', endedAt: now, updatedAt: now } },
+          { returnDocument: 'after' },
+        );
+      if (queuedResult) {
+        return { ...queuedResult, _id: toId(queuedResult._id) } as ICrawlJob;
+      }
+      // Already running (possibly on another node) — stamp the request so
+      // the owning runner observes it on its next DB round trip.
+      const runningResult = await db
+        .collection<ICrawlJob>(COLLECTIONS.crawlJobs)
+        .findOneAndUpdate(
+          { _id: objectId(id), tenantId, status: 'running' },
+          { $set: { cancelRequestedAt: now, updatedAt: now } },
+          { returnDocument: 'after' },
+        );
+      if (!runningResult) return null;
+      return { ...runningResult, _id: toId(runningResult._id) } as ICrawlJob;
+    }
+
+    async finalizeCrawlJob(
+      id: string,
+      tenantId: string,
+      data: Partial<Omit<ICrawlJob, '_id' | 'tenantId' | 'createdAt'>>,
+    ): Promise<ICrawlJob | null> {
+      const db = this.getTenantDb();
+      const payload: Partial<ICrawlJob> = { ...data, updatedAt: new Date() };
+      delete payload._id;
+      delete payload.tenantId;
+      delete payload.createdAt;
+      const result = await db
+        .collection<ICrawlJob>(COLLECTIONS.crawlJobs)
+        .findOneAndUpdate(
+          { _id: objectId(id), tenantId, status: 'running' },
+          { $set: payload },
+          { returnDocument: 'after' },
+        );
+      if (!result) return null;
+      return { ...result, _id: toId(result._id) } as ICrawlJob;
+    }
+
     async findCrawlJobById(id: string): Promise<ICrawlJob | null> {
       const db = this.getTenantDb();
       try {

--- a/src/lib/database/provider/contract.ts
+++ b/src/lib/database/provider/contract.ts
@@ -1247,6 +1247,34 @@ export interface DatabaseProvider extends EnterpriseDbMethods {
     id: string,
     data: Partial<Omit<ICrawlJob, '_id' | 'tenantId' | 'createdAt'>>,
   ): Promise<ICrawlJob | null>;
+  /**
+   * Atomically transition a `queued` job to `running`. Returns the claimed
+   * job (now `running`) only if this call performed the transition; returns
+   * `null` if the job was not `queued` (e.g. a duplicate/redelivered queue
+   * message tried to claim a job another consumer already started).
+   * Callers MUST treat `null` as "do not run this job".
+   */
+  claimCrawlJob(id: string, tenantId: string, startedAt: Date): Promise<ICrawlJob | null>;
+  /**
+   * Record a cancellation request. A `queued` job is transitioned straight
+   * to `canceled` (nothing is executing it yet); a `running` job only has
+   * `cancelRequestedAt` stamped so the *owning* runner — which may be on a
+   * different node than the one handling this request — observes it on its
+   * next DB round trip and performs its own terminal transition. Returns
+   * `null` if the job does not exist or is already in a terminal state.
+   */
+  requestCrawlJobCancel(id: string, tenantId: string): Promise<ICrawlJob | null>;
+  /**
+   * Persist a running job's terminal status/counters, guarded so it only
+   * applies while the job is still `running`. This prevents a late/duplicate
+   * writer from clobbering a status another writer already finalized (e.g.
+   * a cross-node cancel that raced the owning runner's own completion).
+   */
+  finalizeCrawlJob(
+    id: string,
+    tenantId: string,
+    data: Partial<Omit<ICrawlJob, '_id' | 'tenantId' | 'createdAt'>>,
+  ): Promise<ICrawlJob | null>;
   findCrawlJobById(id: string): Promise<ICrawlJob | null>;
   listCrawlJobs(
     tenantId: string,

--- a/src/lib/database/provider/types.domain.ts
+++ b/src/lib/database/provider/types.domain.ts
@@ -1313,6 +1313,11 @@ export interface ICrawlerHttpConfig {
   bearerToken?: string;
   /** Allow private / link-local destinations. Default false (SSRF guard). */
   allowPrivateNetwork?: boolean;
+  /**
+   * Skip TLS certificate verification (DANGER: disables MITM protection).
+   * Use only for sites with a known-broken TLS chain. Default false.
+   */
+  allowInsecureTls?: boolean;
 }
 
 export interface ICrawlerWebhookConfig {

--- a/src/lib/database/provider/types.domain.ts
+++ b/src/lib/database/provider/types.domain.ts
@@ -1433,6 +1433,14 @@ export interface ICrawlJob {
   filesProcessed: number;
   errorsCount: number;
   limitReached?: boolean;
+  /**
+   * Persisted cancellation intent. Set when a cancel request arrives while
+   * the job is `running` (possibly from a different node than the one
+   * actually executing it) — the owning runner observes this on its next
+   * DB round trip and performs its own guarded transition to `canceled`.
+   * A `queued` job is canceled outright instead (see `requestCrawlJobCancel`).
+   */
+  cancelRequestedAt?: Date;
   /** Per-run callback override (ad-hoc tek-shot run desteği). */
   callbackUrl?: string;
   errorMessage?: string;

--- a/src/lib/database/sqlite/base.ts
+++ b/src/lib/database/sqlite/base.ts
@@ -450,6 +450,9 @@ export class SQLiteProviderBase {
     // ensure on boot for tenants created before the feature.
     this.ensureTableColumn(db, TABLES.guardrails, 'target', "target TEXT NOT NULL DEFAULT 'input'");
     this.ensureTableColumn(db, TABLES.guardrails, 'failMode', "failMode TEXT NOT NULL DEFAULT 'open'");
+    // Cross-node crawl-job cancellation signal (added with atomic job claim
+    // hardening). Safe to ensure on boot for tenants created before the feature.
+    this.ensureTableColumn(db, TABLES.crawlJobs, 'cancelRequestedAt', 'cancelRequestedAt TEXT');
   }
 
   private migrateOcrJobsSchema(db: Database.Database): void {

--- a/src/lib/database/sqlite/crawler.mixin.ts
+++ b/src/lib/database/sqlite/crawler.mixin.ts
@@ -228,6 +228,63 @@ export function CrawlerMixin<TBase extends Constructor<SQLiteProviderBase>>(Base
     ): Promise<ICrawlJob | null> {
       const db = this.getTenantDb();
       const now = this.now();
+      const { sets, params } = this.buildCrawlJobSetClause(data, id, now);
+      db.prepare(`UPDATE ${TABLES.crawlJobs} SET ${sets.join(', ')} WHERE id = @id`).run(params);
+      return this.findCrawlJobById(id);
+    }
+
+    async claimCrawlJob(id: string, tenantId: string, startedAt: Date): Promise<ICrawlJob | null> {
+      const db = this.getTenantDb();
+      const now = this.now();
+      const result = db.prepare(`
+        UPDATE ${TABLES.crawlJobs} SET status = 'running', startedAt = @startedAt, updatedAt = @updatedAt
+        WHERE id = @id AND tenantId = @tenantId AND status = 'queued'
+      `).run({ id, tenantId, startedAt: startedAt.toISOString(), updatedAt: now });
+      if (result.changes !== 1) return null;
+      return this.findCrawlJobById(id);
+    }
+
+    async requestCrawlJobCancel(id: string, tenantId: string): Promise<ICrawlJob | null> {
+      const db = this.getTenantDb();
+      const now = this.now();
+      // Fast path: job hasn't started yet, cancel it outright.
+      const queuedResult = db.prepare(`
+        UPDATE ${TABLES.crawlJobs} SET status = 'canceled', endedAt = @now, updatedAt = @now
+        WHERE id = @id AND tenantId = @tenantId AND status = 'queued'
+      `).run({ id, tenantId, now });
+      if (queuedResult.changes === 1) return this.findCrawlJobById(id);
+
+      // Already running (possibly on another node) — stamp the request so
+      // the owning runner observes it on its next DB round trip.
+      const runningResult = db.prepare(`
+        UPDATE ${TABLES.crawlJobs} SET cancelRequestedAt = @now, updatedAt = @now
+        WHERE id = @id AND tenantId = @tenantId AND status = 'running'
+      `).run({ id, tenantId, now });
+      if (runningResult.changes !== 1) return null;
+      return this.findCrawlJobById(id);
+    }
+
+    async finalizeCrawlJob(
+      id: string,
+      tenantId: string,
+      data: Partial<Omit<ICrawlJob, '_id' | 'tenantId' | 'createdAt'>>,
+    ): Promise<ICrawlJob | null> {
+      const db = this.getTenantDb();
+      const now = this.now();
+      const { sets, params } = this.buildCrawlJobSetClause(data, id, now);
+      params.tenantId = tenantId;
+      const result = db.prepare(
+        `UPDATE ${TABLES.crawlJobs} SET ${sets.join(', ')} WHERE id = @id AND tenantId = @tenantId AND status = 'running'`,
+      ).run(params);
+      if (result.changes !== 1) return null;
+      return this.findCrawlJobById(id);
+    }
+
+    private buildCrawlJobSetClause(
+      data: Partial<Omit<ICrawlJob, '_id' | 'tenantId' | 'createdAt'>>,
+      id: string,
+      now: string,
+    ): { sets: string[]; params: Record<string, unknown> } {
       const sets: string[] = ['updatedAt = @updatedAt'];
       const params: Record<string, unknown> = { id, updatedAt: now };
       const scalarFields = ['status', 'crawlerKey', 'callbackUrl', 'errorMessage', 'projectId'];
@@ -248,7 +305,9 @@ export function CrawlerMixin<TBase extends Constructor<SQLiteProviderBase>>(Base
         sets.push('limitReached = @limitReached');
         params.limitReached = data.limitReached ? 1 : 0;
       }
-      const dateFields: Array<'startedAt' | 'endedAt'> = ['startedAt', 'endedAt'];
+      const dateFields: Array<'startedAt' | 'endedAt' | 'cancelRequestedAt'> = [
+        'startedAt', 'endedAt', 'cancelRequestedAt',
+      ];
       for (const f of dateFields) {
         if ((data as Record<string, unknown>)[f] !== undefined) {
           sets.push(`${f} = @${f}`);
@@ -264,8 +323,7 @@ export function CrawlerMixin<TBase extends Constructor<SQLiteProviderBase>>(Base
         sets.push('metadata = @metadata');
         params.metadata = this.toJson(data.metadata);
       }
-      db.prepare(`UPDATE ${TABLES.crawlJobs} SET ${sets.join(', ')} WHERE id = @id`).run(params);
-      return this.findCrawlJobById(id);
+      return { sets, params };
     }
 
     async findCrawlJobById(id: string): Promise<ICrawlJob | null> {
@@ -308,6 +366,7 @@ export function CrawlerMixin<TBase extends Constructor<SQLiteProviderBase>>(Base
         filesProcessed: Number(row.filesProcessed) || 0,
         errorsCount: Number(row.errorsCount) || 0,
         limitReached: Number(row.limitReached) === 1,
+        cancelRequestedAt: row.cancelRequestedAt ? this.toDate(row.cancelRequestedAt) : undefined,
         callbackUrl: (row.callbackUrl as string) ?? undefined,
         errorMessage: (row.errorMessage as string) ?? undefined,
         metadata: this.parseJson(row.metadata, {}),

--- a/src/lib/database/sqlite/schema.ts
+++ b/src/lib/database/sqlite/schema.ts
@@ -1603,6 +1603,7 @@ export const TENANT_SCHEMA_SQL = `
     filesProcessed INTEGER NOT NULL DEFAULT 0,
     errorsCount INTEGER NOT NULL DEFAULT 0,
     limitReached INTEGER NOT NULL DEFAULT 0,
+    cancelRequestedAt TEXT,
     callbackUrl TEXT,
     errorMessage TEXT,
     metadata TEXT DEFAULT '{}',

--- a/src/lib/services/crawler/crawlerJobService.ts
+++ b/src/lib/services/crawler/crawlerJobService.ts
@@ -67,25 +67,16 @@ export async function runCrawlJobLocal(
   jobId: string,
 ): Promise<void> {
   const db = await withTenantDb(ctx.tenantDbName);
-  const job = await db.findCrawlJobById(jobId);
-  if (!job) {
-    logger.warn('Crawl job not found, skipping run', { jobId });
-    return;
-  }
-  if (job.tenantId !== ctx.tenantId) {
-    logger.warn('Crawl job tenant mismatch; refusing to run', { jobId });
-    return;
-  }
-  if (job.status !== 'queued') {
-    logger.info('Crawl job not in queued state; skipping', {
-      jobId,
-      status: job.status,
-    });
-    return;
-  }
-
   const startedAt = new Date();
-  await db.updateCrawlJob(jobId, { status: 'running', startedAt });
+  // Atomic queued -> running transition (CAS on `status`). If this returns
+  // `null`, another consumer already claimed the job — a duplicate/
+  // redelivered queue message MUST NOT re-run it (duplicate crawl results,
+  // duplicate RAG ingestion, duplicate signed webhooks otherwise).
+  const job = await db.claimCrawlJob(jobId, ctx.tenantId, startedAt);
+  if (!job) {
+    logger.info('Crawl job already claimed or not queued; skipping duplicate run', { jobId });
+    return;
+  }
   logger.info('Crawl job started', { jobId, crawlerKey: job.crawlerKey });
 
   const plan = snapshotToPlan(job.planSnapshot);
@@ -120,12 +111,21 @@ export async function runCrawlJobLocal(
         limitReached = true;
       }
 
-      await db.updateCrawlJob(jobId, {
+      const updated = await db.updateCrawlJob(jobId, {
         pagesProcessed,
         filesProcessed,
         errorsCount,
         limitReached,
       });
+      // Cross-node cancellation: a cancel request may have been recorded by
+      // a different node than the one running this job. `cancelRequestedAt`
+      // rides along on the per-page update above (no extra DB round trip),
+      // so it's observed here even without any pub/sub between nodes.
+      if (updated?.cancelRequestedAt && !cancelRequested.has(jobId)) {
+        logger.info('Cross-node cancel request observed; aborting crawl', { jobId });
+        cancelRequested.add(jobId);
+        abort.abort();
+      }
 
       if (page.type === 'html' || page.type === 'file') {
         await fireWebhook(job, page, written.ragDocumentId, 'page').catch(() => undefined);
@@ -156,7 +156,10 @@ export async function runCrawlJobLocal(
           ? 'partial'
           : 'failed';
 
-    await db.updateCrawlJob(jobId, {
+    // Guarded by `WHERE status = 'running'` — this runner is the exclusive
+    // owner of the job (claimed atomically above), so this only fails to
+    // apply if something unexpected already moved the job out of `running`.
+    const finalized = await db.finalizeCrawlJob(jobId, ctx.tenantId, {
       status,
       endedAt,
       durationMs,
@@ -166,6 +169,9 @@ export async function runCrawlJobLocal(
       limitReached,
       errorMessage: failureMessage,
     });
+    if (!finalized) {
+      logger.warn('Crawl job finalize skipped: job was no longer running', { jobId, status });
+    }
 
     const event = status === 'failed' ? 'failed' : 'completed';
     await fireSummaryWebhook(job, status, {
@@ -185,6 +191,7 @@ export async function runCrawlJobLocal(
     });
   }
 }
+
 
 async function persistPage(
   db: DatabaseProvider,

--- a/src/lib/services/crawler/crawlerJobService.ts
+++ b/src/lib/services/crawler/crawlerJobService.ts
@@ -55,6 +55,7 @@ function snapshotToPlan(snapshot: ICrawlPlanSnapshot): CrawlPlan {
       basicAuth: snapshot.http?.basicAuth,
       bearerToken: snapshot.http?.bearerToken,
       allowPrivateNetwork: snapshot.http?.allowPrivateNetwork,
+      allowInsecureTls: snapshot.http?.allowInsecureTls,
     },
     downloadableMimes: snapshot.downloadableMimes,
     markdownOptions: snapshot.markdownOptions,
@@ -139,13 +140,21 @@ export async function runCrawlJobLocal(
     const durationMs = endedAt.getTime() - startedAt.getTime();
     const canceled = cancelRequested.has(jobId);
     cancelRequested.delete(jobId);
+    // Persisted job status must reflect ALL failures, not just a thrown
+    // exception from the crawl generator itself. Per-page failures (TLS
+    // errors, 404s, timeouts, etc.) are streamed as `page.type === 'error'`
+    // and rolled into `errorsCount` above — without checking it here, a run
+    // with 50 good pages and 20 broken ones was persisted to the DB as
+    // `succeeded`, and the UI had no correct status to ever display.
+    const hadFailure = Boolean(failureMessage) || errorsCount > 0;
+    const processedAny = pagesProcessed + filesProcessed > 0;
     const status: ICrawlJob['status'] = canceled
       ? 'canceled'
-      : failureMessage
-        ? errorsCount === pagesProcessed + filesProcessed + errorsCount && pagesProcessed === 0
-          ? 'failed'
-          : 'partial'
-        : 'succeeded';
+      : !hadFailure
+        ? 'succeeded'
+        : processedAny
+          ? 'partial'
+          : 'failed';
 
     await db.updateCrawlJob(jobId, {
       status,
@@ -186,7 +195,11 @@ async function persistPage(
   let ragStatus: 'pending' | 'indexed' | 'skipped' | 'failed' | undefined;
   let ragError: string | undefined;
 
-  if (page.type === 'html' && job.planSnapshot.rag?.enabled && page.body) {
+  if (
+    (page.type === 'html' || page.type === 'file') &&
+    job.planSnapshot.rag?.enabled &&
+    page.body
+  ) {
     const ingest = await ingestCrawlPage({
       tenantDbName: job.tenantId, // ignored by ingestDocument; we use the loaded db below
       tenantId: job.tenantId,

--- a/src/lib/services/crawler/crawlerJobService.ts
+++ b/src/lib/services/crawler/crawlerJobService.ts
@@ -252,6 +252,7 @@ async function fireWebhook(
   await sendCrawlerWebhook({
     webhook: job.planSnapshot.webhook,
     overrideUrl: job.callbackUrl,
+    allowPrivateNetwork: job.planSnapshot.http?.allowPrivateNetwork,
     event,
     payload: {
       tenantId: job.tenantId,
@@ -288,6 +289,7 @@ async function fireSummaryWebhook(
   await sendCrawlerWebhook({
     webhook: job.planSnapshot.webhook,
     overrideUrl: job.callbackUrl,
+    allowPrivateNetwork: job.planSnapshot.http?.allowPrivateNetwork,
     event,
     payload: {
       tenantId: job.tenantId,

--- a/src/lib/services/crawler/crawlerService.ts
+++ b/src/lib/services/crawler/crawlerService.ts
@@ -528,10 +528,17 @@ export async function cancelCrawlJob(
   if (!job) return false;
   if (job.status !== 'queued' && job.status !== 'running') return false;
   const db = await withTenantDb(ctx.tenantDbName);
-  await db.updateCrawlJob(jobId, { status: 'canceled', endedAt: new Date() });
-  // Signal the in-process runner if it's here. Cross-node cancel arrives
-  // in Faz 2 — see crawlerJobService.markJobCancelRequested for the local
-  // hook used today.
+  // Atomic: a `queued` job is canceled outright; a `running` job only has
+  // `cancelRequestedAt` stamped. The runner that actually claimed the job
+  // (which may be on a different node than the one handling this request)
+  // observes the flag on its own DB round trips and performs the terminal
+  // `running -> canceled` transition itself — this request never overwrites
+  // a `running` job's status directly, so a late-finishing runner can never
+  // have its own legitimate `succeeded`/`partial`/`failed` write clobbered
+  // by, or clobber, this cancellation.
+  const result = await db.requestCrawlJobCancel(jobId, ctx.tenantId);
+  if (!result) return false;
+  // Same-node fast path: skip the DB round trip if the runner is local.
   const { markJobCancelRequested } = await import('./crawlerJobService');
   markJobCancelRequested(jobId);
   return true;

--- a/src/lib/services/crawler/crawlerWebhook.ts
+++ b/src/lib/services/crawler/crawlerWebhook.ts
@@ -34,6 +34,13 @@ export interface SendWebhookInput<T = unknown> {
   overrideUrl?: string;
   /** Secret used for signing when `webhook` is missing but overrideUrl is set. */
   overrideSecret?: string;
+  /**
+   * Mirrors the crawler's own `http.allowPrivateNetwork` opt-in: a tenant
+   * that has explicitly accepted the risk of crawling private/internal
+   * hosts is trusted to also receive webhooks there (e.g. an internal
+   * notification service on the same network).
+   */
+  allowPrivateNetwork?: boolean;
   event: CrawlerWebhookEvent;
   payload: Omit<WebhookPayload<T>, 'id' | 'event' | 'createdAt'>;
 }
@@ -44,11 +51,12 @@ export async function sendCrawlerWebhook<T>(input: SendWebhookInput<T>): Promise
   const events = input.webhook?.events ?? ['page', 'completed', 'failed'];
   if (!events.includes(input.event)) return;
 
-  // Webhooks always target external systems the tenant owns — never allow
-  // delivery to private/loopback/link-local/metadata hosts (SSRF hardening).
-  // Unlike crawl targets, there is no legitimate opt-in here.
+  // Webhooks should target external systems the tenant owns — block
+  // delivery to private/loopback/link-local/metadata hosts (SSRF hardening)
+  // unless the tenant has explicitly opted in via `allowPrivateNetwork`
+  // (same flag that gates crawling private hosts).
   try {
-    assertSafeUrl(url);
+    assertSafeUrl(url, input.allowPrivateNetwork);
   } catch (err) {
     log.warn('Refusing to deliver webhook to private/loopback host', {
       url,

--- a/src/lib/services/crawler/crawlerWebhook.ts
+++ b/src/lib/services/crawler/crawlerWebhook.ts
@@ -10,6 +10,7 @@ import crypto from 'node:crypto';
 import axios from 'axios';
 import { createLogger } from '@/lib/core/logger';
 import type { ICrawlerWebhookConfig, CrawlerWebhookEvent } from '@/lib/database';
+import { assertSafeUrl } from './engine/ssrf';
 
 const log = createLogger('crawler:webhook');
 
@@ -42,6 +43,22 @@ export async function sendCrawlerWebhook<T>(input: SendWebhookInput<T>): Promise
   if (!url) return;
   const events = input.webhook?.events ?? ['page', 'completed', 'failed'];
   if (!events.includes(input.event)) return;
+
+  // Webhooks always target external systems the tenant owns — never allow
+  // delivery to private/loopback/link-local/metadata hosts (SSRF hardening).
+  // Unlike crawl targets, there is no legitimate opt-in here.
+  try {
+    assertSafeUrl(url);
+  } catch (err) {
+    log.warn('Refusing to deliver webhook to private/loopback host', {
+      url,
+      event: input.event,
+      jobId: input.payload.jobId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return;
+  }
+
   const secret = input.overrideSecret ?? input.webhook?.secret;
 
   const body: WebhookPayload<T> = {
@@ -72,6 +89,10 @@ export async function sendCrawlerWebhook<T>(input: SendWebhookInput<T>): Promise
         headers,
         timeout: DEFAULT_TIMEOUT_MS,
         validateStatus: (s) => s >= 200 && s < 300,
+        // Do not follow redirects: a public URL could 3xx to a private/
+        // metadata host, bypassing the assertSafeUrl check above (SSRF via
+        // redirect). Webhook receivers should respond directly.
+        maxRedirects: 0,
       });
       return;
     } catch (err) {

--- a/src/lib/services/crawler/engine/axiosFetcher.ts
+++ b/src/lib/services/crawler/engine/axiosFetcher.ts
@@ -8,12 +8,21 @@ import https from 'node:https';
 import iconv from 'iconv-lite';
 import mime from 'mime-types';
 import { parseContentTypeBase } from './normalize';
+import { assertSafeUrl } from './ssrf';
 import type { CrawlHttpConfig, CrawlerEngineMode } from './types';
 import { DEFAULT_ACCEPT_LANGUAGE, DEFAULT_USER_AGENT } from './types';
 
 // Reused across requests when allowInsecureTls is set, to avoid creating a
 // fresh TLS agent (and losing keep-alive) per fetch.
 const insecureAgent = new https.Agent({ rejectUnauthorized: false });
+
+// The initial frontier URL is SSRF-checked by the caller (engine/index.ts),
+// but axios happily follows a 3xx `Location` chain on its own — a public
+// seed can redirect straight to `http://169.254.169.254/` (or any other
+// private target) and axios would fetch it transparently, bypassing the
+// guard entirely. To prevent that, redirects are followed manually here:
+// each hop is re-validated with `assertSafeUrl()` before being requested.
+const MAX_MANUAL_REDIRECTS = 5;
 
 export interface FetchResult {
   type: 'html' | 'file';
@@ -32,81 +41,103 @@ export async function fetchWithAxios(
   downloadableMimes: string[],
 ): Promise<FetchResult> {
   const timeout = http.timeoutMs ?? 30_000;
-  const controller = new AbortController();
-  const tid = setTimeout(() => controller.abort(), timeout + 2000);
+  const headers: Record<string, string> = {
+    'User-Agent': http.userAgent ?? DEFAULT_USER_AGENT,
+    Accept:
+      'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8',
+    'Accept-Language': http.acceptLanguage ?? DEFAULT_ACCEPT_LANGUAGE,
+    'Cache-Control': 'no-cache',
+    Pragma: 'no-cache',
+    ...(http.headers ?? {}),
+  };
+  if (http.cookies?.length) {
+    headers.Cookie = http.cookies
+      .map((c) => `${c.name}=${c.value}`)
+      .join('; ');
+  }
+  if (http.bearerToken) {
+    headers.Authorization = `Bearer ${http.bearerToken}`;
+  }
 
-  try {
-    const headers: Record<string, string> = {
-      'User-Agent': http.userAgent ?? DEFAULT_USER_AGENT,
-      Accept:
-        'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8',
-      'Accept-Language': http.acceptLanguage ?? DEFAULT_ACCEPT_LANGUAGE,
-      'Cache-Control': 'no-cache',
-      Pragma: 'no-cache',
-      ...(http.headers ?? {}),
-    };
-    if (http.cookies?.length) {
-      headers.Cookie = http.cookies
-        .map((c) => `${c.name}=${c.value}`)
-        .join('; ');
-    }
-    if (http.bearerToken) {
-      headers.Authorization = `Bearer ${http.bearerToken}`;
-    }
+  let currentUrl = url;
 
-    const response = await axios.get(url, {
-      responseType: 'arraybuffer',
-      headers,
-      timeout,
-      maxContentLength: 15 * 1024 * 1024,
-      maxRedirects: 10,
-      signal: controller.signal,
-      auth: http.basicAuth,
-      validateStatus: (status) => status < 400,
-      httpsAgent: http.allowInsecureTls ? insecureAgent : undefined,
-    });
-    clearTimeout(tid);
+  for (let hop = 0; ; hop += 1) {
+    const controller = new AbortController();
+    const tid = setTimeout(() => controller.abort(), timeout + 2000);
 
-    const contentTypeRaw = String(response.headers['content-type'] ?? '');
-    const contentType = parseContentTypeBase(contentTypeRaw);
-    const disposition = String(response.headers['content-disposition'] ?? '').toLowerCase();
-    const buffer = Buffer.from(response.data as ArrayBuffer);
+    try {
+      const response = await axios.get(currentUrl, {
+        responseType: 'arraybuffer',
+        headers,
+        timeout,
+        maxContentLength: 15 * 1024 * 1024,
+        // Redirects are followed manually below so every hop can be
+        // SSRF-checked before it's requested (see MAX_MANUAL_REDIRECTS doc).
+        maxRedirects: 0,
+        signal: controller.signal,
+        auth: http.basicAuth,
+        validateStatus: (status) => status < 400,
+        httpsAgent: http.allowInsecureTls ? insecureAgent : undefined,
+      });
+      clearTimeout(tid);
 
-    const isFile =
-      disposition.includes('attachment') ||
-      disposition.includes('filename') ||
-      (contentType && !contentType.includes('text/html')) ||
-      (contentType && downloadableMimes.includes(contentType));
+      if (response.status >= 300 && response.status < 400) {
+        const location = response.headers['location'];
+        if (!location) {
+          throw new Error(`Redirect (${response.status}) from ${currentUrl} has no Location header`);
+        }
+        if (hop >= MAX_MANUAL_REDIRECTS) {
+          throw new Error(`Too many redirects (>${MAX_MANUAL_REDIRECTS}) starting from ${url}`);
+        }
+        const nextUrl = new URL(location, currentUrl).toString();
+        // Re-validate every redirect hop — a public seed can 302 to a
+        // private/metadata host and must not be followed silently.
+        assertSafeUrl(nextUrl, http.allowPrivateNetwork);
+        currentUrl = nextUrl;
+        continue;
+      }
 
-    if (isFile) {
+      const contentTypeRaw = String(response.headers['content-type'] ?? '');
+      const contentType = parseContentTypeBase(contentTypeRaw);
+      const disposition = String(response.headers['content-disposition'] ?? '').toLowerCase();
+      const buffer = Buffer.from(response.data as ArrayBuffer);
+
+      const isFile =
+        disposition.includes('attachment') ||
+        disposition.includes('filename') ||
+        (contentType && !contentType.includes('text/html')) ||
+        (contentType && downloadableMimes.includes(contentType));
+
+      if (isFile) {
+        return {
+          type: 'file',
+          httpStatus: response.status,
+          contentType: contentType || mime.lookup(currentUrl) || 'application/octet-stream',
+          fileBytes: buffer.length,
+          fileBuffer: buffer,
+        };
+      }
+
+      const html = decodeBuffer(buffer, contentTypeRaw);
       return {
-        type: 'file',
+        type: 'html',
         httpStatus: response.status,
-        contentType: contentType || mime.lookup(url) || 'application/octet-stream',
-        fileBytes: buffer.length,
-        fileBuffer: buffer,
+        contentType: contentType || 'text/html',
+        html,
+        htmlBytes: buffer.length,
       };
-    }
-
-    const html = decodeBuffer(buffer, contentTypeRaw);
-    return {
-      type: 'html',
-      httpStatus: response.status,
-      contentType: contentType || 'text/html',
-      html,
-      htmlBytes: buffer.length,
-    };
-  } catch (error) {
-    clearTimeout(tid);
-    if (axios.isAxiosError(error)) {
-      if (error.code === 'ECONNABORTED' || error.code === 'ERR_CANCELED') {
-        throw new Error(`Timeout fetching ${url} (${timeout}ms)`);
+    } catch (error) {
+      clearTimeout(tid);
+      if (axios.isAxiosError(error)) {
+        if (error.code === 'ECONNABORTED' || error.code === 'ERR_CANCELED') {
+          throw new Error(`Timeout fetching ${currentUrl} (${timeout}ms)`);
+        }
+        if (error.response) {
+          throw new Error(`HTTP ${error.response.status} for ${currentUrl}`);
+        }
       }
-      if (error.response) {
-        throw new Error(`HTTP ${error.response.status} for ${url}`);
-      }
+      throw new Error(`Axios error for ${currentUrl}: ${(error as Error).message}`);
     }
-    throw new Error(`Axios error for ${url}: ${(error as Error).message}`);
   }
 }
 

--- a/src/lib/services/crawler/engine/axiosFetcher.ts
+++ b/src/lib/services/crawler/engine/axiosFetcher.ts
@@ -4,11 +4,16 @@
  */
 
 import axios from 'axios';
+import https from 'node:https';
 import iconv from 'iconv-lite';
 import mime from 'mime-types';
 import { parseContentTypeBase } from './normalize';
 import type { CrawlHttpConfig, CrawlerEngineMode } from './types';
 import { DEFAULT_ACCEPT_LANGUAGE, DEFAULT_USER_AGENT } from './types';
+
+// Reused across requests when allowInsecureTls is set, to avoid creating a
+// fresh TLS agent (and losing keep-alive) per fetch.
+const insecureAgent = new https.Agent({ rejectUnauthorized: false });
 
 export interface FetchResult {
   type: 'html' | 'file';
@@ -17,6 +22,8 @@ export interface FetchResult {
   html?: string;
   htmlBytes?: number;
   fileBytes?: number;
+  /** Raw bytes of a downloaded attachment. Present when `type === 'file'`. */
+  fileBuffer?: Buffer;
 }
 
 export async function fetchWithAxios(
@@ -56,6 +63,7 @@ export async function fetchWithAxios(
       signal: controller.signal,
       auth: http.basicAuth,
       validateStatus: (status) => status < 400,
+      httpsAgent: http.allowInsecureTls ? insecureAgent : undefined,
     });
     clearTimeout(tid);
 
@@ -76,6 +84,7 @@ export async function fetchWithAxios(
         httpStatus: response.status,
         contentType: contentType || mime.lookup(url) || 'application/octet-stream',
         fileBytes: buffer.length,
+        fileBuffer: buffer,
       };
     }
 
@@ -127,6 +136,23 @@ function decodeBuffer(buffer: Buffer, contentType: string): string {
 export function isFileByExtension(url: string, downloadableMimes: string[]): boolean {
   const ext = String(mime.lookup(url) || '').toLowerCase();
   return Boolean(ext && downloadableMimes.includes(ext));
+}
+
+/**
+ * Derives a sensible file name for an attachment so the markdown converter
+ * can pick the right parser (extension-driven). Falls back to the mime type
+ * when the URL path has no usable file name (e.g. `/getFile?id=123`).
+ */
+export function deriveAttachmentFileName(url: string, contentType?: string): string {
+  try {
+    const { pathname } = new URL(url);
+    const last = pathname.split('/').filter(Boolean).pop();
+    if (last && last.includes('.')) return decodeURIComponent(last);
+    const ext = contentType ? mime.extension(contentType) : '';
+    return last ? `${decodeURIComponent(last)}.${ext || 'bin'}` : `attachment.${ext || 'bin'}`;
+  } catch {
+    return 'attachment';
+  }
 }
 
 export const AXIOS_ENGINE_NAME: CrawlerEngineMode = 'axios';

--- a/src/lib/services/crawler/engine/index.ts
+++ b/src/lib/services/crawler/engine/index.ts
@@ -10,10 +10,10 @@
  */
 
 import { Semaphore, retry } from './concurrency';
-import { fetchWithAxios, isFileByExtension } from './axiosFetcher';
+import { deriveAttachmentFileName, fetchWithAxios, isFileByExtension } from './axiosFetcher';
 import { PlaywrightSession } from './playwrightFetcher';
 import { extractLinks, extractMeta, looksLikeJsShell } from './links';
-import { htmlToMarkdown } from './markdown';
+import { fileToMarkdown, htmlToMarkdown } from './markdown';
 import {
   getHostname,
   isSkippableExtension,
@@ -78,6 +78,7 @@ export async function* crawl(
     html?: string;
     htmlBytes?: number;
     fileBytes?: number;
+    fileBuffer?: Buffer;
   }> {
     if (isFileByExtension(url, downloadableMimes)) {
       return retry(() => fetchWithAxios(url, plan.http, downloadableMimes), retries);
@@ -164,6 +165,20 @@ export async function* crawl(
         try {
           const fetched = await fetchOne(item.url);
           if (fetched.type === 'file') {
+            let attachmentBody: string | undefined;
+            if (fetched.fileBuffer) {
+              attachmentBody = await fileToMarkdown({
+                buffer: fetched.fileBuffer,
+                fileName: deriveAttachmentFileName(item.url, fetched.contentType),
+                options: plan.markdownOptions,
+              }).catch((err: unknown) => {
+                logger.warn('Attachment markdown conversion failed', {
+                  url: item.url,
+                  error: (err as Error).message,
+                });
+                return undefined;
+              });
+            }
             return {
               url: item.url,
               parentUrl: item.parent,
@@ -171,6 +186,7 @@ export async function* crawl(
               type: 'file' as const,
               httpStatus: fetched.httpStatus,
               contentType: fetched.contentType,
+              body: attachmentBody,
               bytes: fetched.fileBytes,
               fetchedAt: new Date(),
             };

--- a/src/lib/services/crawler/engine/links.ts
+++ b/src/lib/services/crawler/engine/links.ts
@@ -91,9 +91,25 @@ export function extractLinks({
 export function looksLikeJsShell(html: string): boolean {
   try {
     const $ = cheerio.load(html);
+
+    // Strong signal: known SPA root containers (Angular/React/Vue/Next)
+    // rendered empty because the framework bundle hasn't executed yet.
+    // Catches shells that otherwise have enough surrounding chrome text
+    // (nav/footer/cookie banner) to pass a text-length check alone.
+    const spaRootSelectors = ['app-root', '#root', '#app', '#__next', '[data-reactroot]'];
+    for (const selector of spaRootSelectors) {
+      const el = $(selector).first();
+      if (el.length > 0 && el.children().length === 0 && el.text().trim().length < 20) {
+        return true;
+      }
+    }
+
     $('script, style, noscript, iframe, svg').remove();
     const textLen = $('body').text().replace(/\s+/g, ' ').trim().length;
-    return textLen < 100;
+    // 200 rather than 100: many shells ship enough static nav/footer/cookie
+    // banner text to clear a lower bar while the real content is still
+    // client-rendered.
+    return textLen < 200;
   } catch {
     return false;
   }

--- a/src/lib/services/crawler/engine/markdown.ts
+++ b/src/lib/services/crawler/engine/markdown.ts
@@ -42,3 +42,33 @@ function cheerioFallback(html: string): string {
     return '';
   }
 }
+
+export interface FileMarkdownInput {
+  buffer: Buffer;
+  fileName: string;
+  options?: CrawlMarkdownOptions;
+}
+
+/**
+ * Converts a downloaded attachment (PDF/DOCX/XLSX/…) to markdown text so it
+ * can be persisted alongside HTML pages and ingested into RAG. Returns
+ * `undefined` (rather than throwing) when the converter cannot extract any
+ * content — the caller still keeps the file metadata (bytes/contentType).
+ */
+export async function fileToMarkdown(input: FileMarkdownInput): Promise<string | undefined> {
+  const { buffer, fileName, options } = input;
+  try {
+    const result = await convertToMarkdown(buffer, {
+      fileName,
+      ...(options?.ocr ? { ocr: options.ocr } : {}),
+    });
+    if (typeof result === 'string') return result || undefined;
+    if (result && typeof result === 'object' && 'markdown' in result) {
+      const md = (result as { markdown?: unknown }).markdown;
+      if (typeof md === 'string') return md || undefined;
+    }
+    return undefined;
+  } catch {
+    return undefined;
+  }
+}

--- a/src/lib/services/crawler/engine/playwrightFetcher.ts
+++ b/src/lib/services/crawler/engine/playwrightFetcher.ts
@@ -7,6 +7,7 @@
 import { chromium, type Browser, type BrowserContext } from 'playwright';
 import mime from 'mime-types';
 import { parseContentTypeBase } from './normalize';
+import { assertSafeUrl } from './ssrf';
 import type { CrawlHttpConfig } from './types';
 import { DEFAULT_ACCEPT_LANGUAGE, DEFAULT_USER_AGENT } from './types';
 
@@ -72,9 +73,22 @@ export class PlaywrightSession {
           })) as Parameters<BrowserContext['addCookies']>[0],
         );
       }
-      // Block heavy resources to speed crawls up
+      // Block heavy resources to speed crawls up, and re-validate every
+      // navigation (including server redirects and client-side location
+      // changes) against the SSRF guard: Chromium follows redirect chains
+      // itself, so the original URL passing `assertSafeUrl()` in the caller
+      // is not enough — a public seed can 3xx straight to a private/
+      // metadata host and the browser would navigate there transparently.
       await this.context.route('**/*', (route) => {
-        const type = route.request().resourceType();
+        const request = route.request();
+        if (request.isNavigationRequest()) {
+          try {
+            assertSafeUrl(request.url(), this.http.allowPrivateNetwork);
+          } catch {
+            return route.abort('blockedbyclient').catch(() => undefined);
+          }
+        }
+        const type = request.resourceType();
         if (['image', 'media', 'font', 'stylesheet'].includes(type)) {
           return route.abort().catch(() => undefined);
         }

--- a/src/lib/services/crawler/engine/playwrightFetcher.ts
+++ b/src/lib/services/crawler/engine/playwrightFetcher.ts
@@ -17,6 +17,8 @@ export interface PlaywrightFetchResult {
   html?: string;
   htmlBytes?: number;
   fileBytes?: number;
+  /** Raw bytes of a downloaded attachment. Present when `type === 'file'`. */
+  fileBuffer?: Buffer;
 }
 
 export class PlaywrightSession {
@@ -52,6 +54,7 @@ export class PlaywrightSession {
             : {}),
         },
         httpCredentials: this.http.basicAuth,
+        ignoreHTTPSErrors: this.http.allowInsecureTls ?? false,
       });
       if (this.http.cookies?.length) {
         await this.context.addCookies(
@@ -107,19 +110,32 @@ export class PlaywrightSession {
 
       if (isFile) {
         let fileBytes = 0;
+        let fileBuffer: Buffer | undefined;
         try {
           const buf = await response.body();
           fileBytes = buf.length;
+          fileBuffer = buf;
         } catch { /* ignore */ }
         return {
           type: 'file',
           httpStatus: status,
           contentType: contentType || mime.lookup(url) || 'application/octet-stream',
           fileBytes,
+          fileBuffer,
         };
       }
 
-      // Allow a short window for late-arriving JS rendering
+      // SPA pages (Angular/React) often render their real content well after
+      // `domcontentloaded` — the initial HTML is just a shell/title. Give the
+      // page a chance to go network-idle (bounded, since some sites keep a
+      // long-lived connection open for polling/websockets) before falling
+      // back to a short settle window either way.
+      try {
+        await page.waitForLoadState('networkidle', { timeout: Math.min(timeout, 8000) });
+      } catch {
+        // Timed out waiting for network idle (long-poll/websocket/etc.) —
+        // capture whatever has rendered so far rather than failing the page.
+      }
       await page.waitForTimeout(500);
       const html = await page.content();
       return {

--- a/src/lib/services/crawler/engine/types.ts
+++ b/src/lib/services/crawler/engine/types.ts
@@ -37,6 +37,13 @@ export interface CrawlHttpConfig {
   basicAuth?: { username: string; password: string };
   bearerToken?: string;
   allowPrivateNetwork?: boolean;
+  /**
+   * Skip TLS certificate verification (DANGER: disables MITM protection).
+   * Opt-in escape hatch for sites whose server misconfigures the TLS chain
+   * (e.g. missing intermediate certificate) so Node can't build trust even
+   * though browsers/OS trust stores can. Default false.
+   */
+  allowInsecureTls?: boolean;
 }
 
 export interface CrawlMarkdownOptions {
@@ -66,7 +73,11 @@ export interface PageResult {
   contentType?: string;
   title?: string;
   description?: string;
-  /** Markdown text. Present for `type === 'html'`. */
+  /**
+   * Markdown text. Present for `type === 'html'` (rendered page content) and,
+   * when extraction succeeds, for `type === 'file'` (PDF/DOCX/XLSX/… attachment
+   * content converted via `@cognipeer/to-markdown`).
+   */
   body?: string;
   /** Raw bytes of fetched content (HTML before markdown, or file). */
   bytes?: number;

--- a/src/lib/services/crawler/validation.ts
+++ b/src/lib/services/crawler/validation.ts
@@ -33,6 +33,7 @@ const httpSchema = z.object({
   basicAuth: z.object({ username: z.string(), password: z.string() }).optional(),
   bearerToken: z.string().optional(),
   allowPrivateNetwork: z.boolean().optional(),
+  allowInsecureTls: z.boolean().optional(),
 });
 
 const webhookSchema = z.object({


### PR DESCRIPTION
## Summary

Crawler module audit + fixes covering 4 areas requested:

1. **Job status (DB-level fix, not just UI)** — `crawlerJobService.ts`'s final status computation only looked at whether the crawl generator threw (`failureMessage`), completely ignoring per-page failures accumulated in `errorsCount` (TLS errors, 404s, timeouts streamed as `page.type === 'error'`). A run with e.g. 50 good pages + 20 broken ones was persisted to MongoDB as `succeeded`, never `partial`. Fixed the computation to properly yield `succeeded | partial | failed | canceled`.
   - Dashboard now renders the raw job status (`queued/running/succeeded/partial/failed/canceled`) via `StatusBadge` instead of translating it into a generic `active/warn/info` label, consistent with other modules (e.g. `vector/migrations`).

2. **JS/CSS crawl scope** — Verified `isSkippableExtension()` is applied both at link-discovery time and at frontier-processing time (covers seeds too). No code change needed; confirmed correct via live crawl test.

3. **Content extraction reliability ("only titles, missing content")**:
   - `playwrightFetcher.ts`: replaced a fixed 500ms post-navigation wait with a bounded `networkidle` wait (capped, falls through for long-poll/websocket pages) — gives slow SPA pages (Angular/React) a real chance to finish rendering before capture.
   - `links.ts`'s `looksLikeJsShell()` heuristic (used for axios→Playwright escalation in `auto` engine mode): raised the text-length threshold and added detection of empty SPA root containers (`app-root`, `#root`, `#app`, `#__next`) so shells with enough nav/footer chrome text to pass the old check are still escalated.
   - Attachment/file responses (PDF, DOCX, etc.) are now converted to markdown via `fileToMarkdown()` and ingested into RAG — previously only metadata (bytes/contentType) was recorded and file content was dropped entirely.
   - Added opt-in `allowInsecureTls` (mirrors the existing `allowPrivateNetwork` pattern) for sites with incomplete TLS certificate chains (verified against a real site).

4. **API/webhook audit** — Dashboard (`src/server/api/plugins/crawler.ts`) and client (`.../client-crawler.ts`) APIs are properly tenant-scoped and Zod-validated; no gaps found there. Found and fixed a real SSRF gap in `crawlerWebhook.ts`: outbound webhook/callback POSTs had no protection against private/loopback/metadata-IP targets (unlike crawl targets, which go through `assertSafeUrl`). Added the same guard plus `maxRedirects: 0` to block redirect-based SSRF bypass.

## Verification

- `crawler-engine.test.ts` + `client-crawler-sync.test.ts` (16/16) pass.
- `npx tsc --noEmit` clean.
- Live end-to-end verification against real sites (temp script, removed after use):
  - `tbb.org.tr`: 8-page crawl, real multi-KB content extracted per page, no JS/CSS in results.
  - `bddk.org.tr`: TLS failure surfaces as a proper per-page error (not a crash) without `allowInsecureTls`; succeeds with real content when enabled.
- `crawler-e2e.test.ts` (SQLite-backed integration test) still can't run in this environment due to a pre-existing, unrelated `better-sqlite3` native binding incompatibility with Node 26 (not caused by this change).