### PR TITLE
feat(alerts,rbac,license): community-side support for the Aegis enterprise module

### DIFF
--- a/src/app/dashboard/alerts/page.tsx
+++ b/src/app/dashboard/alerts/page.tsx
@@ -78,6 +78,10 @@ const METRIC_LABELS: Record<string, string> = {
   analysis_avg_accuracy: 'Avg Accuracy',
   redteam_attack_success_rate: 'Attack Success Rate',
   redteam_resilience_score: 'Resilience Score',
+  aegis_block_rate: 'Block Rate',
+  aegis_approval_rate: 'Approval Rate',
+  aegis_avg_risk_score: 'Avg Risk Score',
+  aegis_total_decisions: 'Total Decisions',
 };
 
 const METRIC_UNITS: Record<string, string> = {
@@ -104,6 +108,10 @@ const METRIC_UNITS: Record<string, string> = {
   analysis_avg_accuracy: '%',
   redteam_attack_success_rate: '%',
   redteam_resilience_score: '%',
+  aegis_block_rate: '%',
+  aegis_approval_rate: '%',
+  aegis_avg_risk_score: '',
+  aegis_total_decisions: '',
 };
 
 const METRIC_COLORS: Record<string, string> = {
@@ -130,6 +138,10 @@ const METRIC_COLORS: Record<string, string> = {
   analysis_avg_accuracy: 'teal',
   redteam_attack_success_rate: 'red',
   redteam_resilience_score: 'green',
+  aegis_block_rate: 'red',
+  aegis_approval_rate: 'orange',
+  aegis_avg_risk_score: 'grape',
+  aegis_total_decisions: 'blue',
 };
 
 const MODULE_LABELS: Record<string, string> = {
@@ -141,6 +153,7 @@ const MODULE_LABELS: Record<string, string> = {
   evaluation: 'Evaluation',
   analysis: 'Analysis',
   redteam: 'Red Team',
+  aegis: 'Aegis',
 };
 
 const MODULE_COLORS: Record<string, string> = {
@@ -152,6 +165,7 @@ const MODULE_COLORS: Record<string, string> = {
   evaluation: 'green',
   analysis: 'lime',
   redteam: 'red',
+  aegis: 'grape',
 };
 
 const OPERATOR_SYMBOLS: Record<string, string> = {
@@ -281,6 +295,7 @@ export default function AlertsPage() {
     if (rule.metric.startsWith('evaluation_')) return 'evaluation';
     if (rule.metric.startsWith('analysis_')) return 'analysis';
     if (rule.metric.startsWith('redteam_')) return 'redteam';
+    if (rule.metric.startsWith('aegis_')) return 'aegis';
     return 'models';
   };
 
@@ -367,6 +382,7 @@ export default function AlertsPage() {
           { label: 'Evaluation', value: 'evaluation' },
           { label: 'Analysis', value: 'analysis' },
           { label: 'Red Team', value: 'redteam' },
+          { label: 'Aegis', value: 'aegis' },
         ]}
         size="xs"
       />

--- a/src/config/platform-services.json
+++ b/src/config/platform-services.json
@@ -657,6 +657,19 @@
       "enterpriseModule": "sandbox"
     },
     {
+      "id": "aegis",
+      "href": "/dashboard/aegis",
+      "icon": "IconShield",
+      "category": "operate",
+      "navLabelKey": "aegis",
+      "navDescriptionKey": "aegisDescription",
+      "tags": ["policy", "enforcement", "dlp", "approvals"],
+      "searchKeywords": ["aegis", "policy", "enforcement", "dlp", "redaction", "approval", "tool call"],
+      "badge": "new",
+      "requiresEnterprise": true,
+      "enterpriseModule": "aegis"
+    },
+    {
       "id": "prompt-optimizer",
       "href": "/dashboard/prompt-optimizer",
       "icon": "IconSparkles",

--- a/src/lib/database/provider/types.domain.ts
+++ b/src/lib/database/provider/types.domain.ts
@@ -760,7 +760,7 @@ export interface IWebSearchRunLog {
 
 // ── Alert types ─────────────────────────────────────────────────────────
 
-export type AlertModule = 'models' | 'inference' | 'guardrails' | 'rag' | 'mcp' | 'analysis' | 'evaluation' | 'redteam';
+export type AlertModule = 'models' | 'inference' | 'guardrails' | 'rag' | 'mcp' | 'analysis' | 'evaluation' | 'redteam' | 'aegis';
 
 export type AlertMetric =
   // models
@@ -793,7 +793,12 @@ export type AlertMetric =
   | 'evaluation_avg_score'
   // red-team (percentages, 0–100, averaged over completed scans in the window)
   | 'redteam_attack_success_rate'
-  | 'redteam_resilience_score';
+  | 'redteam_resilience_score'
+  // aegis enforcement plane (over decisions in the window)
+  | 'aegis_block_rate'
+  | 'aegis_approval_rate'
+  | 'aegis_avg_risk_score'
+  | 'aegis_total_decisions';
 
 export type AlertConditionOperator = 'gt' | 'lt' | 'gte' | 'lte' | 'eq';
 

--- a/src/lib/i18n/messages/en.ts
+++ b/src/lib/i18n/messages/en.ts
@@ -64,6 +64,8 @@ export const en = {
     gpuFleetDescription: 'Onboard GPU hosts, deploy models from the curated library, manage pools',
     sandbox: 'Agent Sandbox',
     sandboxDescription: 'Remote, API-driven runtime sandboxes for code, files, terminals and previews',
+    aegis: 'Aegis',
+    aegisDescription: 'Enforcement-plane policy engine: tool-call evaluation, DLP redaction, approvals and audit',
     promptOptimizer: 'Prompt Optimizer',
     promptOptimizerDescription: 'Iteratively improve a prompt toward a goal: generate variants, test and score them, promote the best',
     memory: 'Agent Memory',

--- a/src/lib/license/enterprise-access.ts
+++ b/src/lib/license/enterprise-access.ts
@@ -76,6 +76,12 @@ export const ENTERPRISE_API_RULES: EnterpriseApiRule[] = [
     module: 'reports',
     prefixes: ['/api/reports/'],
   },
+  {
+    // Aegis enforcement plane: policy evaluation, approvals and decision audit.
+    // Gates both the admin surface and the SDK's API-token surface.
+    module: 'aegis',
+    prefixes: ['/api/aegis/', '/api/client/v1/aegis/'],
+  },
 ];
 
 export interface EnterpriseDenial {

--- a/src/lib/security/rbac.ts
+++ b/src/lib/security/rbac.ts
@@ -22,6 +22,7 @@ export type PermissionService =
   | 'mcp'
   | 'tools'
   | 'sandbox'
+  | 'aegis'
   | 'browser'
   | 'crawler'
   | 'websearch'
@@ -102,6 +103,7 @@ export const RBAC_SERVICE_DEFINITIONS: RbacServiceDefinition[] = [
   { id: 'audit', label: 'Audit Log', description: 'Security and administrative audit events.', category: 'admin', adminService: true },
   { id: 'gpu-fleet', label: 'GPU Fleet', description: 'GPU hosts, MIG slices, model deployments, and terminal access.', category: 'operate', adminService: true },
   { id: 'sandbox', label: 'Agent Sandbox', description: 'Agent runtime sandboxes: runners, templates, instances, volumes, and terminal access.', category: 'operate', adminService: true },
+  { id: 'aegis', label: 'Aegis', description: 'Enforcement-plane policy engine: tool-call evaluation, DLP redaction, approvals and decision audit.', category: 'operate' },
   { id: 'cluster', label: 'Cluster', description: 'Multi-node cluster: node registry and per-instance assignment/orchestration.', category: 'admin', adminService: true },
 ];
 
@@ -129,6 +131,7 @@ const ROUTE_PREFIXES: Array<{ prefix: string; service: PermissionService }> = [
   { prefix: '/api/client/v1/pii', service: 'pii' },
   { prefix: '/api/client/v1/mcp', service: 'mcp' },
   { prefix: '/api/client/v1/sandbox', service: 'sandbox' },
+  { prefix: '/api/client/v1/aegis', service: 'aegis' },
   { prefix: '/api/client/v1/memory', service: 'memory' },
   { prefix: '/api/client/v1/prompts', service: 'prompts' },
   { prefix: '/api/client/v1/rag', service: 'rag' },
@@ -183,6 +186,7 @@ const ROUTE_PREFIXES: Array<{ prefix: string; service: PermissionService }> = [
   { prefix: '/api/alerts', service: 'alerts' },
   { prefix: '/api/gpu-fleet', service: 'gpu-fleet' },
   { prefix: '/api/sandbox', service: 'sandbox' },
+  { prefix: '/api/aegis', service: 'aegis' },
   { prefix: '/api/cluster', service: 'cluster' },
 ];
 

--- a/src/lib/services/alerts/alertService.ts
+++ b/src/lib/services/alerts/alertService.ts
@@ -25,6 +25,7 @@ const MODULE_METRICS: Record<AlertModule, AlertMetric[]> = {
   analysis: ['analysis_pass_rate', 'analysis_avg_judge_score', 'analysis_avg_accuracy'],
   evaluation: ['evaluation_pass_rate', 'evaluation_avg_score'],
   redteam: ['redteam_attack_success_rate', 'redteam_resilience_score'],
+  aegis: ['aegis_block_rate', 'aegis_approval_rate', 'aegis_avg_risk_score', 'aegis_total_decisions'],
 };
 
 /** Supported metric names for validation */


### PR DESCRIPTION
Community half of the **Aegis enforcement plane** enterprise module (implementation lives in the console-ee overlay — companion PR there). Follows the same pattern as the other EE modules (gpu-fleet, sandbox, reports):

- **RBAC**: new `aegis` permission service + `/api/aegis` and `/api/client/v1/aegis` route prefixes
- **License gate**: `aegis` enterprise module rule covering both the dashboard API and the SDK client surface
- **Alerts**: new `aegis` alert module with 4 metrics — `aegis_block_rate`, `aegis_approval_rate`, `aegis_avg_risk_score`, `aegis_total_decisions` — wired into the alerts dashboard filters/labels
- **Nav**: `aegis` platform-services entry (`requiresEnterprise`, `enterpriseModule: aegis`) + i18n strings

No behavior change for community-only deployments: the nav entry is enterprise-gated and the routes 402 without a license.

Verified via the EE overlay build: `tsc --noEmit` clean, aegis unit tests 12/12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)