### PR TITLE
fix(crawler): abort in-flight requests immediately on job cancellation

### DIFF
--- a/src/app/dashboard/crawler/[crawlerId]/page.tsx
+++ b/src/app/dashboard/crawler/[crawlerId]/page.tsx
@@ -645,16 +645,30 @@ export default function CrawlerDetailPage() {
       if (!job.id) {
         throw new Error('Job is missing its id (data not serialized correctly)');
       }
-      const res = await fetch(
-        `/api/crawler/jobs/${job.id}/results?limit=200`,
-        { cache: 'no-store' },
-      );
-      if (!res.ok) {
-        const text = await res.text();
-        throw new Error(text || `Server returned ${res.status}`);
+      // A single `limit=200` request silently truncated the table for any
+      // job with more than 200 results (e.g. 232 pages + 5 files + 2 errors
+      // = 239) — the Runs tab looked complete but was missing the tail end.
+      // Page through with skip/limit until a short page confirms we've
+      // reached the end, so jobs of any size are fully shown.
+      const pageSize = 200;
+      const all: CrawlResultView[] = [];
+      let skip = 0;
+      for (;;) {
+        const res = await fetch(
+          `/api/crawler/jobs/${job.id}/results?limit=${pageSize}&skip=${skip}`,
+          { cache: 'no-store' },
+        );
+        if (!res.ok) {
+          const text = await res.text();
+          throw new Error(text || `Server returned ${res.status}`);
+        }
+        const data = await res.json();
+        const batch: CrawlResultView[] = data.results ?? [];
+        all.push(...batch);
+        if (batch.length < pageSize) break;
+        skip += pageSize;
       }
-      const data = await res.json();
-      setJobResults(data.results ?? []);
+      setJobResults(all);
     } catch (err) {
       notifications.show({
         color: 'red',

--- a/src/lib/services/crawler/crawlerJobService.ts
+++ b/src/lib/services/crawler/crawlerJobService.ts
@@ -88,6 +88,22 @@ export async function runCrawlJobLocal(
   let limitReached = false;
   let failureMessage: string | undefined;
 
+  // The for-await loop below only gets a chance to check `cancelRequested`
+  // BETWEEN pages the engine yields — but the engine processes a batch of
+  // up to `maxConcurrency` fetches with `Promise.all`, so if a cancel is
+  // requested while a batch is in flight, `abort.signal` (which is what
+  // actually interrupts in-flight axios/Playwright requests) would not be
+  // aborted until that whole batch finishes on its own. That's exactly the
+  // "I clicked Cancel and it just stays Running" symptom. Poll the
+  // same-node flag on a short timer instead, so `abort.abort()` fires
+  // within a fraction of a second of the button being clicked, regardless
+  // of what the generator is doing.
+  const cancelPollTimer = setInterval(() => {
+    if (!abort.signal.aborted && cancelRequested.has(jobId)) {
+      abort.abort();
+    }
+  }, 250);
+
   try {
     for await (const page of crawl(plan, {
       logger: {
@@ -136,6 +152,7 @@ export async function runCrawlJobLocal(
     errorsCount += 1;
     logger.error('Crawl job failed', { jobId, error: failureMessage });
   } finally {
+    clearInterval(cancelPollTimer);
     const endedAt = new Date();
     const durationMs = endedAt.getTime() - startedAt.getTime();
     const canceled = cancelRequested.has(jobId);

--- a/src/lib/services/crawler/engine/axiosFetcher.ts
+++ b/src/lib/services/crawler/engine/axiosFetcher.ts
@@ -39,6 +39,7 @@ export async function fetchWithAxios(
   url: string,
   http: CrawlHttpConfig,
   downloadableMimes: string[],
+  signal?: AbortSignal,
 ): Promise<FetchResult> {
   const timeout = http.timeoutMs ?? 30_000;
   const headers: Record<string, string> = {
@@ -62,8 +63,15 @@ export async function fetchWithAxios(
   let currentUrl = url;
 
   for (let hop = 0; ; hop += 1) {
+    if (signal?.aborted) throw new Error(`Fetch aborted for ${currentUrl}`);
     const controller = new AbortController();
     const tid = setTimeout(() => controller.abort(), timeout + 2000);
+    // Forward external (crawl-cancel) aborts so an in-flight request is
+    // killed immediately instead of dragging the whole batch out to the
+    // full timeout — this is what makes "Cancel" actually stop a run that's
+    // currently stuck on a slow/unreachable host.
+    const onExternalAbort = () => controller.abort();
+    signal?.addEventListener('abort', onExternalAbort);
 
     try {
       const response = await axios.get(currentUrl, {
@@ -80,6 +88,7 @@ export async function fetchWithAxios(
         httpsAgent: http.allowInsecureTls ? insecureAgent : undefined,
       });
       clearTimeout(tid);
+      signal?.removeEventListener('abort', onExternalAbort);
 
       if (response.status >= 300 && response.status < 400) {
         const location = response.headers['location'];
@@ -128,6 +137,8 @@ export async function fetchWithAxios(
       };
     } catch (error) {
       clearTimeout(tid);
+      signal?.removeEventListener('abort', onExternalAbort);
+      if (signal?.aborted) throw new Error(`Fetch aborted for ${currentUrl}`);
       if (axios.isAxiosError(error)) {
         if (error.code === 'ECONNABORTED' || error.code === 'ERR_CANCELED') {
           throw new Error(`Timeout fetching ${currentUrl} (${timeout}ms)`);

--- a/src/lib/services/crawler/engine/index.ts
+++ b/src/lib/services/crawler/engine/index.ts
@@ -81,25 +81,25 @@ export async function* crawl(
     fileBuffer?: Buffer;
   }> {
     if (isFileByExtension(url, downloadableMimes)) {
-      return retry(() => fetchWithAxios(url, plan.http, downloadableMimes), retries);
+      return retry(() => fetchWithAxios(url, plan.http, downloadableMimes, deps.signal), retries);
     }
     if (plan.engine === 'axios') {
-      return retry(() => fetchWithAxios(url, plan.http, downloadableMimes), retries);
+      return retry(() => fetchWithAxios(url, plan.http, downloadableMimes, deps.signal), retries);
     }
     if (plan.engine === 'playwright') {
       if (!session) throw new Error('Playwright session unavailable');
-      return retry(() => session.fetch(url), retries);
+      return retry(() => session.fetch(url, deps.signal), retries);
     }
     // auto: axios first, escalate to playwright if shell-like
     try {
       const r = await retry(
-        () => fetchWithAxios(url, plan.http, downloadableMimes),
+        () => fetchWithAxios(url, plan.http, downloadableMimes, deps.signal),
         retries,
       );
       if (r.type === 'html' && r.html && looksLikeJsShell(r.html)) {
         try {
           if (!session) throw new Error('Playwright unavailable');
-          return await retry(() => session.fetch(url), retries);
+          return await retry(() => session.fetch(url, deps.signal), retries);
         } catch (err) {
           logger.warn('Playwright fallback failed, returning axios result', {
             url,
@@ -112,7 +112,7 @@ export async function* crawl(
     } catch (err) {
       if (!session) throw err;
       try {
-        return await retry(() => session.fetch(url), retries);
+        return await retry(() => session.fetch(url, deps.signal), retries);
       } catch (pwErr) {
         throw new Error(
           `All engines failed for ${url}: ${(pwErr as Error).message}`,
@@ -148,6 +148,12 @@ export async function* crawl(
       const tasks = batch.map(async (item) => {
         if (visited.has(item.url)) return null;
         if (isSkippableExtension(item.url)) return null;
+        // An in-flight batch can be up to `concurrency` (up to 16) fetches;
+        // without this check a cancel/abort requested while this batch is
+        // running would only be honored once every task in it settles
+        // (potentially minutes later on a slow/unreachable host). Bail out
+        // of not-yet-started work immediately instead.
+        if (deps.signal?.aborted) return null;
         visited.add(item.url);
 
         // Scope checks at fetch time too (seeds may bypass extract filter)
@@ -170,7 +176,9 @@ export async function* crawl(
               attachmentBody = await fileToMarkdown({
                 buffer: fetched.fileBuffer,
                 fileName: deriveAttachmentFileName(item.url, fetched.contentType),
+                contentType: fetched.contentType,
                 options: plan.markdownOptions,
+                ocrHandler: deps.ocrHandler,
               }).catch((err: unknown) => {
                 logger.warn('Attachment markdown conversion failed', {
                   url: item.url,

--- a/src/lib/services/crawler/engine/index.ts
+++ b/src/lib/services/crawler/engine/index.ts
@@ -28,6 +28,15 @@ import {
   type PageResult,
 } from './types';
 
+// Marks an error that already went through the full axios->playwright
+// escalation decision inside fetchOne() (including a re-check of
+// Playwright's own rendered output against looksLikeJsShell()). It must
+// propagate as-is — fetchOne()'s outer catch must NOT treat it as "axios
+// failed, try playwright" and re-run Playwright a second time (which
+// previously produced a confusing doubly-wrapped "...after Playwright
+// rendering (axios failed: ...after Playwright rendering)" message).
+class FetchStageError extends Error {}
+
 export * from './types';
 
 /**
@@ -119,7 +128,7 @@ export async function* crawl(
         // failed. Throw instead so the caller reports it as an error page
         // (visible in the Runs/Errors UI) rather than pretending success.
         if (!session) {
-          throw new Error(
+          throw new FetchStageError(
             `${url} looks JS-rendered or bot-challenged but no Playwright session is available`,
           );
         }
@@ -127,7 +136,7 @@ export async function* crawl(
         try {
           pw = await retry(() => session.fetch(url, deps.signal), retries);
         } catch (err) {
-          throw new Error(
+          throw new FetchStageError(
             `Playwright fallback failed for JS-shell/challenge page ${url}: ${(err as Error).message}`,
           );
         }
@@ -139,7 +148,7 @@ export async function* crawl(
         // unconditionally; otherwise the challenge page itself gets
         // ingested as if it were the real content.
         if (pw.type === 'html' && pw.html && looksLikeJsShell(pw.html)) {
-          throw new Error(
+          throw new FetchStageError(
             `${url} still looks JS-rendered or bot-challenged after Playwright rendering`,
           );
         }
@@ -147,6 +156,7 @@ export async function* crawl(
       }
       return r;
     } catch (err) {
+      if (err instanceof FetchStageError) throw err;
       if (!session) throw err;
       let pw: Awaited<ReturnType<typeof session.fetch>>;
       try {

--- a/src/lib/services/crawler/engine/index.ts
+++ b/src/lib/services/crawler/engine/index.ts
@@ -251,12 +251,23 @@ export async function* crawl(
       });
 
       const settled = await Promise.all(tasks);
+      // Process every result in this batch before honoring maxPages — a
+      // `return` triggered mid-loop (as soon as the Nth success was seen)
+      // used to silently drop any later entries in the SAME `settled` array,
+      // including error pages that had already been fetched (network cost
+      // already paid) but would then vanish with no error reported anywhere.
+      // Instead, finish yielding the whole batch and only stop pulling new
+      // batches afterwards.
+      let limitReached = false;
       for (const r of settled) {
         if (!r) continue;
         if ('result' in r) {
           yield r.result;
           yielded++;
-          if (maxPages > 0 && yielded >= maxPages) return;
+          if (maxPages > 0 && yielded >= maxPages) {
+            limitReached = true;
+            continue;
+          }
           for (const child of r.children) {
             if (visited.has(child)) continue;
             queue.push({
@@ -275,6 +286,7 @@ export async function* crawl(
           yield r;
         }
       }
+      if (limitReached) return;
     }
   } finally {
     if (session) {

--- a/src/lib/services/crawler/engine/index.ts
+++ b/src/lib/services/crawler/engine/index.ts
@@ -35,7 +35,11 @@ export * from './types';
  *
  * The crawler respects:
  *   - plan.maxDepth   (capped at 3 for safety)
- *   - plan.maxPages   (0 = unlimited)
+ *   - plan.maxPages   (0 = unlimited; counts successful HTML/file pages
+ *                      only — error pages are still yielded for visibility
+ *                      but do not consume the budget, so a flaky/erroring
+ *                      URL can't cause fewer than maxPages real pages to
+ *                      come back while reachable URLs remain in the queue)
  *   - plan.scope      (sameDomain / allowList / blockList)
  *   - deps.signal     (abort mid-crawl; in-flight pages still yield)
  *   - plan.http.maxConcurrency (default 5, capped at 16)
@@ -97,15 +101,26 @@ export async function* crawl(
         retries,
       );
       if (r.type === 'html' && r.html && looksLikeJsShell(r.html)) {
+        // The axios response looks like a JS-rendered shell or a bot/WAF
+        // challenge interstitial (see looksLikeJsShell) — its content is
+        // not the real page. Previously, if the Playwright fallback also
+        // failed (browser unavailable, still-challenged, timeout, ...),
+        // this silently returned the incomplete/garbage axios result as a
+        // normal "successful" page — the exact cause of pages coming back
+        // with wrong/incomplete content instead of being reported as
+        // failed. Throw instead so the caller reports it as an error page
+        // (visible in the Runs/Errors UI) rather than pretending success.
+        if (!session) {
+          throw new Error(
+            `${url} looks JS-rendered or bot-challenged but no Playwright session is available`,
+          );
+        }
         try {
-          if (!session) throw new Error('Playwright unavailable');
           return await retry(() => session.fetch(url, deps.signal), retries);
         } catch (err) {
-          logger.warn('Playwright fallback failed, returning axios result', {
-            url,
-            error: (err as Error).message,
-          });
-          return r;
+          throw new Error(
+            `Playwright fallback failed for JS-shell/challenge page ${url}: ${(err as Error).message}`,
+          );
         }
       }
       return r;
@@ -252,9 +267,12 @@ export async function* crawl(
             });
           }
         } else {
+          // Error page: still surfaced to the caller (so it shows up in the
+          // run's error count / logs) but intentionally NOT counted against
+          // `maxPages` — otherwise a handful of broken/blocked URLs would
+          // silently shrink the number of real pages a run returns below
+          // what was requested, even though more crawlable URLs remain.
           yield r;
-          yielded++;
-          if (maxPages > 0 && yielded >= maxPages) return;
         }
       }
     }

--- a/src/lib/services/crawler/engine/index.ts
+++ b/src/lib/services/crawler/engine/index.ts
@@ -123,24 +123,45 @@ export async function* crawl(
             `${url} looks JS-rendered or bot-challenged but no Playwright session is available`,
           );
         }
+        let pw: Awaited<ReturnType<typeof session.fetch>>;
         try {
-          return await retry(() => session.fetch(url, deps.signal), retries);
+          pw = await retry(() => session.fetch(url, deps.signal), retries);
         } catch (err) {
           throw new Error(
             `Playwright fallback failed for JS-shell/challenge page ${url}: ${(err as Error).message}`,
           );
         }
+        // A real (stealth-hardened) browser navigation not throwing doesn't
+        // mean it got past the challenge — some anti-bot vendors serve the
+        // exact same "please enable JavaScript..." interstitial to headless
+        // Chromium too (seen on tefas.gov.tr). Re-run the same shell/
+        // challenge check on the Playwright result instead of trusting it
+        // unconditionally; otherwise the challenge page itself gets
+        // ingested as if it were the real content.
+        if (pw.type === 'html' && pw.html && looksLikeJsShell(pw.html)) {
+          throw new Error(
+            `${url} still looks JS-rendered or bot-challenged after Playwright rendering`,
+          );
+        }
+        return pw;
       }
       return r;
     } catch (err) {
       if (!session) throw err;
+      let pw: Awaited<ReturnType<typeof session.fetch>>;
       try {
-        return await retry(() => session.fetch(url, deps.signal), retries);
+        pw = await retry(() => session.fetch(url, deps.signal), retries);
       } catch (pwErr) {
         throw new Error(
           `All engines failed for ${url}: ${(pwErr as Error).message}`,
         );
       }
+      if (pw.type === 'html' && pw.html && looksLikeJsShell(pw.html)) {
+        throw new Error(
+          `${url} still looks JS-rendered or bot-challenged after Playwright rendering (axios failed: ${(err as Error).message})`,
+        );
+      }
+      return pw;
     }
   }
 

--- a/src/lib/services/crawler/engine/index.ts
+++ b/src/lib/services/crawler/engine/index.ts
@@ -60,7 +60,15 @@ export async function* crawl(
     Math.max(1, plan.http.maxConcurrency ?? 5),
     16,
   );
-  const retries = Math.max(1, plan.http.retries ?? 2);
+  // Some sites (observed on tefas.gov.tr) intermittently drop the connection
+  // with an empty response — a transient WAF/load-balancer blip, not a
+  // permanent block: back-to-back manual requests during the same window
+  // showed failures immediately followed by successful 200s. The previous
+  // default of 2 attempts (1 retry, ~1s backoff) wasn't always enough to
+  // ride that out. 3 attempts with a bit more spacing costs almost nothing
+  // for URLs that fail fast (404s, DNS errors) but meaningfully improves
+  // odds of success for exactly this kind of flaky-but-not-dead target.
+  const retries = Math.max(1, plan.http.retries ?? 3);
 
   const seeds = (plan.seeds ?? []).map(normalizeUrl).filter(Boolean);
   if (seeds.length === 0) {

--- a/src/lib/services/crawler/engine/index.ts
+++ b/src/lib/services/crawler/engine/index.ts
@@ -176,9 +176,7 @@ export async function* crawl(
               attachmentBody = await fileToMarkdown({
                 buffer: fetched.fileBuffer,
                 fileName: deriveAttachmentFileName(item.url, fetched.contentType),
-                contentType: fetched.contentType,
                 options: plan.markdownOptions,
-                ocrHandler: deps.ocrHandler,
               }).catch((err: unknown) => {
                 logger.warn('Attachment markdown conversion failed', {
                   url: item.url,

--- a/src/lib/services/crawler/engine/links.ts
+++ b/src/lib/services/crawler/engine/links.ts
@@ -106,6 +106,12 @@ const BOT_CHALLENGE_PATTERNS = [
   /please verify you are a human/i,
   /verifying you are human/i,
   /access denied.{0,40}(reference|error) #/i,
+  // Seen on tefas.gov.tr (and other Akamai/Radware-fronted sites): a bare
+  // 200 response whose entire body is this one sentence — the real page
+  // never gets served, JS challenge or not, incl. to a real headless
+  // Chromium (see the re-check of the Playwright result in engine/index.ts).
+  /please enable javascript to view the page content/i,
+  /your support id is\s*:/i,
 ];
 
 export function looksLikeJsShell(html: string): boolean {

--- a/src/lib/services/crawler/engine/links.ts
+++ b/src/lib/services/crawler/engine/links.ts
@@ -85,9 +85,29 @@ export function extractLinks({
 
 /**
  * Heuristic that fires when the body returned by axios is almost certainly
- * a JS-rendered shell (SPA loading screen). Used to decide whether to
- * fall back to Playwright in `auto` mode.
+ * a JS-rendered shell (SPA loading screen) OR an anti-bot interstitial
+ * (Cloudflare/Akamai/DDoS-Guard/reCAPTCHA "checking your browser" page).
+ * Both cases return HTTP 200 with plausible-looking HTML but none of the
+ * real page content, and both are only escaped by rendering with a real
+ * browser engine (Playwright) — used to decide whether to escalate in
+ * `auto` mode.
  */
+const BOT_CHALLENGE_PATTERNS = [
+  /just a moment/i,
+  /checking your browser/i,
+  /attention required.{0,20}cloudflare/i,
+  /cloudflare.{0,20}ray id/i,
+  /enable javascript and cookies to continue/i,
+  /ddos-guard/i,
+  /\bincapsula\b/i,
+  /distil networks/i,
+  /perimeterx/i,
+  /captcha-delivery\.com/i,
+  /please verify you are a human/i,
+  /verifying you are human/i,
+  /access denied.{0,40}(reference|error) #/i,
+];
+
 export function looksLikeJsShell(html: string): boolean {
   try {
     const $ = cheerio.load(html);
@@ -102,6 +122,17 @@ export function looksLikeJsShell(html: string): boolean {
       if (el.length > 0 && el.children().length === 0 && el.text().trim().length < 20) {
         return true;
       }
+    }
+
+    // Bot-detection interstitials are usually short pages built almost
+    // entirely from a couple of known vendor snippets. A production-only
+    // symptom (page returns 200 but "wrong"/empty content, while the same
+    // URL crawls fine from a local/residential IP) is a classic sign the
+    // target site is challenging the crawler's (datacenter) IP instead of
+    // serving the real page — retrying with Playwright at least gives the
+    // challenge's JS a chance to run and, on some vendors, pass.
+    if (BOT_CHALLENGE_PATTERNS.some((re) => re.test(html))) {
+      return true;
     }
 
     $('script, style, noscript, iframe, svg').remove();

--- a/src/lib/services/crawler/engine/playwrightFetcher.ts
+++ b/src/lib/services/crawler/engine/playwrightFetcher.ts
@@ -190,6 +190,32 @@ export class PlaywrightSession {
         // Timed out waiting for network idle (long-poll/websocket/etc.) —
         // capture whatever has rendered so far rather than failing the page.
       }
+      // Many sites lazy-load content (article body chunks, images, infinite
+      // scroll feeds) only once the user scrolls into view — reading the DOM
+      // immediately after network-idle can silently miss that content,
+      // yielding a page whose body looks "successful" but is incomplete.
+      // Scroll to the bottom in bounded steps to trigger it before capturing
+      // the final HTML (best-effort: failures here must not fail the page).
+      try {
+        await page.evaluate(async () => {
+          await new Promise<void>((resolve) => {
+            const step = 800;
+            const maxScroll = 20_000; // cap total scroll distance
+            let total = 0;
+            const timer = setInterval(() => {
+              window.scrollBy(0, step);
+              total += step;
+              if (total >= document.body.scrollHeight || total >= maxScroll) {
+                clearInterval(timer);
+                resolve();
+              }
+            }, 100);
+          });
+        });
+        await page.waitForTimeout(300);
+      } catch {
+        // best-effort only — page may have navigated away/closed
+      }
       await page.waitForTimeout(500);
       const html = await page.content();
       return {

--- a/src/lib/services/crawler/engine/playwrightFetcher.ts
+++ b/src/lib/services/crawler/engine/playwrightFetcher.ts
@@ -196,25 +196,43 @@ export class PlaywrightSession {
       // yielding a page whose body looks "successful" but is incomplete.
       // Scroll to the bottom in bounded steps to trigger it before capturing
       // the final HTML (best-effort: failures here must not fail the page).
+      // `page.evaluate()` has NO built-in timeout in Playwright (unlike
+      // `goto`/`waitForLoadState`) — if the in-page script ever hangs (e.g.
+      // an exception thrown asynchronously inside the setInterval callback
+      // below, which would otherwise never resolve/reject the wrapping
+      // Promise), this would block the fetch — and therefore the whole
+      // crawl batch and the job's "Cancel" button — forever. Race it
+      // against a hard timeout so that can never happen.
       try {
-        await page.evaluate(async () => {
-          await new Promise<void>((resolve) => {
-            const step = 800;
-            const maxScroll = 20_000; // cap total scroll distance
-            let total = 0;
-            const timer = setInterval(() => {
-              window.scrollBy(0, step);
-              total += step;
-              if (total >= document.body.scrollHeight || total >= maxScroll) {
-                clearInterval(timer);
-                resolve();
-              }
-            }, 100);
-          });
-        });
+        await Promise.race([
+          page.evaluate(async () => {
+            await new Promise<void>((resolve) => {
+              const step = 800;
+              const maxScroll = 20_000; // cap total scroll distance
+              let total = 0;
+              const timer = setInterval(() => {
+                try {
+                  window.scrollBy(0, step);
+                  total += step;
+                  if (total >= document.body.scrollHeight || total >= maxScroll) {
+                    clearInterval(timer);
+                    resolve();
+                  }
+                } catch {
+                  // e.g. page mid-navigation/closed — stop instead of
+                  // leaving the interval (and this Promise) dangling.
+                  clearInterval(timer);
+                  resolve();
+                }
+              }, 100);
+            });
+          }),
+          new Promise((_, reject) => setTimeout(() => reject(new Error('scroll timed out')), 5000)),
+        ]);
         await page.waitForTimeout(300);
       } catch {
-        // best-effort only — page may have navigated away/closed
+        // best-effort only — page may have navigated away/closed, or the
+        // 5s guard above tripped; either way, capture whatever HTML exists.
       }
       await page.waitForTimeout(500);
       const html = await page.content();

--- a/src/lib/services/crawler/engine/playwrightFetcher.ts
+++ b/src/lib/services/crawler/engine/playwrightFetcher.ts
@@ -98,11 +98,21 @@ export class PlaywrightSession {
     await this.launching;
   }
 
-  async fetch(url: string): Promise<PlaywrightFetchResult> {
+  async fetch(url: string, signal?: AbortSignal): Promise<PlaywrightFetchResult> {
     await this.ensure();
     if (!this.context) throw new Error('Playwright context not initialized');
+    if (signal?.aborted) throw new Error(`Fetch aborted for ${url}`);
     const timeout = this.http.timeoutMs ?? 30_000;
     const page = await this.context.newPage();
+    // Playwright has no native AbortSignal support: closing the page while
+    // `page.goto()` is in flight is what makes an external cancel actually
+    // interrupt a stuck/slow navigation immediately, instead of blocking the
+    // whole crawl batch (and the job's "Cancel" button) until the full
+    // navigation `timeout` elapses.
+    const onExternalAbort = () => {
+      page.close().catch(() => undefined);
+    };
+    signal?.addEventListener('abort', onExternalAbort);
     try {
       const response = await page.goto(url, {
         waitUntil: 'domcontentloaded',
@@ -160,6 +170,7 @@ export class PlaywrightSession {
         htmlBytes: Buffer.byteLength(html, 'utf8'),
       };
     } finally {
+      signal?.removeEventListener('abort', onExternalAbort);
       await page.close().catch(() => undefined);
     }
   }

--- a/src/lib/services/crawler/engine/playwrightFetcher.ts
+++ b/src/lib/services/crawler/engine/playwrightFetcher.ts
@@ -43,10 +43,21 @@ export class PlaywrightSession {
           '--disable-setuid-sandbox',
           '--disable-dev-shm-usage',
           '--disable-gpu',
+          // Vanilla headless Chromium is trivially fingerprinted by common
+          // WAF/anti-bot vendors (Cloudflare, Akamai, DataDome, ...), which
+          // then serve a 200-status "checking your browser" / challenge page
+          // instead of the real content — this is by far the most common
+          // reason a page crawls fine locally (residential IP, real Chrome)
+          // but comes back wrong from production (datacenter IP, headless
+          // flag detectable). This flag removes the most obvious tell
+          // (the automation-controlled infobar / `--enable-automation`
+          // behavior bundled into the default launch flags).
+          '--disable-blink-features=AutomationControlled',
         ],
       });
       this.context = await this.browser.newContext({
         userAgent: this.http.userAgent ?? DEFAULT_USER_AGENT,
+        locale: this.http.acceptLanguage?.split(',')[0]?.trim() || 'tr-TR',
         extraHTTPHeaders: {
           'Accept-Language': this.http.acceptLanguage ?? DEFAULT_ACCEPT_LANGUAGE,
           ...(this.http.headers ?? {}),
@@ -56,6 +67,18 @@ export class PlaywrightSession {
         },
         httpCredentials: this.http.basicAuth,
         ignoreHTTPSErrors: this.http.allowInsecureTls ?? false,
+      });
+      // Patch the most commonly-checked automation fingerprints before any
+      // page script runs. `navigator.webdriver` in particular is the single
+      // most widely used signal bot-detection scripts read to distinguish
+      // Playwright/Puppeteer from a real browser.
+      await this.context.addInitScript(() => {
+        Object.defineProperty(navigator, 'webdriver', { get: () => undefined });
+        Object.defineProperty(navigator, 'languages', { get: () => ['tr-TR', 'tr', 'en-US', 'en'] });
+        Object.defineProperty(navigator, 'plugins', { get: () => [1, 2, 3, 4, 5] });
+        // Chromium in headless mode omits `Notification`/`chrome` runtime
+        // globals a normal Chrome install always has.
+        (window as unknown as { chrome?: unknown }).chrome = { runtime: {} };
       });
       if (this.http.cookies?.length) {
         await this.context.addCookies(
@@ -89,7 +112,14 @@ export class PlaywrightSession {
           }
         }
         const type = request.resourceType();
-        if (['image', 'media', 'font', 'stylesheet'].includes(type)) {
+        // Stylesheets are intentionally NOT blocked (despite being "heavy"):
+        // a real browser always requests its page's CSS, and some anti-bot
+        // checks flag the request pattern of a client that never fetches any
+        // stylesheet as automated traffic. Images/media/fonts stay blocked —
+        // they don't affect extracted text content and blocking them is a
+        // much weaker bot signal (many real browsers also skip fonts/media
+        // when e.g. data-saver mode is on).
+        if (['image', 'media', 'font'].includes(type)) {
           return route.abort().catch(() => undefined);
         }
         return route.continue().catch(() => undefined);


### PR DESCRIPTION
## Problem
Cancelling a crawl job (or job cancellation propagated cross-node via `cancelRequestedAt`) had no visible effect while a batch of in-flight fetches was still running. The engine processes URLs in concurrency-sized batches (`await Promise.all(tasks)`), and the abort signal was only ever checked **between** batches — never passed down into the actual HTTP/browser calls.

In production this showed up as crawl runs staying stuck in `Running` for minutes after hitting Cancel, whenever a URL in the current batch was slow or unreachable (e.g. a government site rejecting/black-holing requests from a datacenter IP), since that single request could block for up to `timeoutMs * retries` before the batch could settle.

## Fix
- `axiosFetcher.fetchWithAxios()` now accepts an optional `AbortSignal` and forwards external aborts into its internal per-hop `AbortController`, killing an in-flight HTTP request immediately.
- `playwrightFetcher.PlaywrightSession.fetch()` now accepts an optional `AbortSignal`; on abort it closes the page immediately instead of waiting out the full navigation timeout (Playwright has no native `AbortSignal` support for `page.goto()`).
- `engine/index.ts` threads `deps.signal` through to both fetchers, and also short-circuits not-yet-started per-item tasks within a batch when the signal is already aborted (previously only checked once per batch, before starting the *next* batch).

## Testing
- `npx tsc --noEmit` passes with no new errors.