### PR TITLE
fix(crawler): detect anti-bot challenge pages and reduce headless fingerprint

### DIFF
--- a/src/lib/services/crawler/engine/links.ts
+++ b/src/lib/services/crawler/engine/links.ts
@@ -85,9 +85,29 @@ export function extractLinks({
 
 /**
  * Heuristic that fires when the body returned by axios is almost certainly
- * a JS-rendered shell (SPA loading screen). Used to decide whether to
- * fall back to Playwright in `auto` mode.
+ * a JS-rendered shell (SPA loading screen) OR an anti-bot interstitial
+ * (Cloudflare/Akamai/DDoS-Guard/reCAPTCHA "checking your browser" page).
+ * Both cases return HTTP 200 with plausible-looking HTML but none of the
+ * real page content, and both are only escaped by rendering with a real
+ * browser engine (Playwright) — used to decide whether to escalate in
+ * `auto` mode.
  */
+const BOT_CHALLENGE_PATTERNS = [
+  /just a moment/i,
+  /checking your browser/i,
+  /attention required.{0,20}cloudflare/i,
+  /cloudflare.{0,20}ray id/i,
+  /enable javascript and cookies to continue/i,
+  /ddos-guard/i,
+  /\bincapsula\b/i,
+  /distil networks/i,
+  /perimeterx/i,
+  /captcha-delivery\.com/i,
+  /please verify you are a human/i,
+  /verifying you are human/i,
+  /access denied.{0,40}(reference|error) #/i,
+];
+
 export function looksLikeJsShell(html: string): boolean {
   try {
     const $ = cheerio.load(html);
@@ -102,6 +122,17 @@ export function looksLikeJsShell(html: string): boolean {
       if (el.length > 0 && el.children().length === 0 && el.text().trim().length < 20) {
         return true;
       }
+    }
+
+    // Bot-detection interstitials are usually short pages built almost
+    // entirely from a couple of known vendor snippets. A production-only
+    // symptom (page returns 200 but "wrong"/empty content, while the same
+    // URL crawls fine from a local/residential IP) is a classic sign the
+    // target site is challenging the crawler's (datacenter) IP instead of
+    // serving the real page — retrying with Playwright at least gives the
+    // challenge's JS a chance to run and, on some vendors, pass.
+    if (BOT_CHALLENGE_PATTERNS.some((re) => re.test(html))) {
+      return true;
     }
 
     $('script, style, noscript, iframe, svg').remove();

--- a/src/lib/services/crawler/engine/playwrightFetcher.ts
+++ b/src/lib/services/crawler/engine/playwrightFetcher.ts
@@ -43,10 +43,21 @@ export class PlaywrightSession {
           '--disable-setuid-sandbox',
           '--disable-dev-shm-usage',
           '--disable-gpu',
+          // Vanilla headless Chromium is trivially fingerprinted by common
+          // WAF/anti-bot vendors (Cloudflare, Akamai, DataDome, ...), which
+          // then serve a 200-status "checking your browser" / challenge page
+          // instead of the real content — this is by far the most common
+          // reason a page crawls fine locally (residential IP, real Chrome)
+          // but comes back wrong from production (datacenter IP, headless
+          // flag detectable). This flag removes the most obvious tell
+          // (the automation-controlled infobar / `--enable-automation`
+          // behavior bundled into the default launch flags).
+          '--disable-blink-features=AutomationControlled',
         ],
       });
       this.context = await this.browser.newContext({
         userAgent: this.http.userAgent ?? DEFAULT_USER_AGENT,
+        locale: this.http.acceptLanguage?.split(',')[0]?.trim() || 'tr-TR',
         extraHTTPHeaders: {
           'Accept-Language': this.http.acceptLanguage ?? DEFAULT_ACCEPT_LANGUAGE,
           ...(this.http.headers ?? {}),
@@ -56,6 +67,18 @@ export class PlaywrightSession {
         },
         httpCredentials: this.http.basicAuth,
         ignoreHTTPSErrors: this.http.allowInsecureTls ?? false,
+      });
+      // Patch the most commonly-checked automation fingerprints before any
+      // page script runs. `navigator.webdriver` in particular is the single
+      // most widely used signal bot-detection scripts read to distinguish
+      // Playwright/Puppeteer from a real browser.
+      await this.context.addInitScript(() => {
+        Object.defineProperty(navigator, 'webdriver', { get: () => undefined });
+        Object.defineProperty(navigator, 'languages', { get: () => ['tr-TR', 'tr', 'en-US', 'en'] });
+        Object.defineProperty(navigator, 'plugins', { get: () => [1, 2, 3, 4, 5] });
+        // Chromium in headless mode omits `Notification`/`chrome` runtime
+        // globals a normal Chrome install always has.
+        (window as unknown as { chrome?: unknown }).chrome = { runtime: {} };
       });
       if (this.http.cookies?.length) {
         await this.context.addCookies(
@@ -89,7 +112,14 @@ export class PlaywrightSession {
           }
         }
         const type = request.resourceType();
-        if (['image', 'media', 'font', 'stylesheet'].includes(type)) {
+        // Stylesheets are intentionally NOT blocked (despite being "heavy"):
+        // a real browser always requests its page's CSS, and some anti-bot
+        // checks flag the request pattern of a client that never fetches any
+        // stylesheet as automated traffic. Images/media/fonts stay blocked —
+        // they don't affect extracted text content and blocking them is a
+        // much weaker bot signal (many real browsers also skip fonts/media
+        // when e.g. data-saver mode is on).
+        if (['image', 'media', 'font'].includes(type)) {
           return route.abort().catch(() => undefined);
         }
         return route.continue().catch(() => undefined);


### PR DESCRIPTION
## Problem
Production-only crawls sometimes come back with the wrong/empty content for a page that crawls fine locally, even though the HTTP status is 200. The most likely cause is the target site's WAF/anti-bot layer (Cloudflare, Akamai, DDoS-Guard, PerimeterX, ...) treating the crawler's (typically datacenter) IP as suspicious and serving a JS-challenge/interstitial page instead of the real content — still HTTP 200, so nothing in the existing pipeline flagged it as an error. This is a distinct issue from #185 (which fixed cancellation not stopping in-flight requests).

## Fix
- `links.ts`: `looksLikeJsShell()` now also recognizes common bot-challenge page signatures (Cloudflare "Just a moment"/"checking your browser", DDoS-Guard, Incapsula, PerimeterX, generic captcha/"verify you are human" pages) so `auto` engine mode escalates these to Playwright instead of silently accepting the challenge page as the final result.
- `playwrightFetcher.ts`: patches the most commonly checked headless fingerprints before any page script runs (`navigator.webdriver`, `navigator.plugins`/`languages`, `window.chrome`), adds `--disable-blink-features=AutomationControlled` to the Chromium launch args, and stops blocking stylesheet requests (a real browser always fetches its own CSS; never requesting it is itself a bot signal some WAFs check for) while still blocking images/media/fonts for speed.

## Note
These are defensive/heuristic improvements, not a guaranteed fix — some WAFs (e.g. Cloudflare Turnstile) can still detect and block headless browsers regardless. If a specific URL keeps failing in production after this, the next step would be inspecting the raw HTML that URL returns in prod.

## Testing
- `npx tsc --noEmit` passes with no new errors.