### PR TITLE
feat(redteam): "Policy Probes" nav entry for Aegis policy red-team

### DIFF
--- a/src/components/layout/launcher/ServiceSubNav.tsx
+++ b/src/components/layout/launcher/ServiceSubNav.tsx
@@ -32,6 +32,7 @@ import {
   IconServer,
   IconSettings,
   IconShield,
+  IconShieldLock,
   IconStack2,
   IconTimeline,
   IconVector,
@@ -126,7 +127,15 @@ export const SUBNAV_CONFIG: Record<string, SubNavItem[]> = {
           !p.startsWith('/dashboard/redteam/runs') &&
           !p.startsWith('/dashboard/redteam/probes') &&
           !p.startsWith('/dashboard/redteam/overview') &&
+          !p.startsWith('/dashboard/redteam/policy') &&
           !p.startsWith('/dashboard/redteam/api')),
+    },
+    {
+      id: 'policy',
+      label: 'Policy Probes',
+      href: '/dashboard/redteam/policy',
+      icon: IconShieldLock,
+      matcher: (p) => p.startsWith('/dashboard/redteam/policy'),
     },
     {
       id: 'runs',


### PR DESCRIPTION
Adds a **Red Team → Policy Probes** sub-nav entry pointing to `/dashboard/redteam/policy`. The page itself lives in the enterprise overlay (console-ee) and runs the Aegis policy red-team battery against a chosen shield.

Community-side change is nav-only:
- `ServiceSubNav.tsx`: new `policy` entry (IconShieldLock) + `/policy` excluded from the Campaigns matcher.

Pairs with the console-ee PR (Aegis model-context fix + red-team relocation + hide AI assistant).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kn4EaWFcLPFzQxr52qcDsY