### PR TITLE
fix(crawler): reconcile orphaned running/queued jobs on server restart

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,4 +70,13 @@ USER node
 RUN npx playwright install chromium
 
 EXPOSE 3000
-CMD ["npm", "start"]
+# Invoke node directly instead of `npm start`. `npm` as PID 1 does not
+# reliably forward SIGTERM to the child node process, so on every restart/
+# redeploy the orchestrator's SIGTERM was effectively swallowed and the
+# container sat until the hard-kill grace period expired — `initLifecycle()`'s
+# graceful shutdown handlers (queue drain, cache/db disconnect, etc., see
+# src/lib/core/lifecycle.ts) never ran. Any crawl job `running` at that
+# moment was hard-killed mid-crawl instead of shutting down cleanly, which is
+# consistent with production crawls stopping partway through instead of
+# completing all pages. Running node as PID 1 lets SIGTERM reach it directly.
+CMD ["node", "--import", "tsx", "src/server/index.ts"]

--- a/src/lib/services/crawler/crawlerJobReconciler.ts
+++ b/src/lib/services/crawler/crawlerJobReconciler.ts
@@ -1,0 +1,100 @@
+/**
+ * Startup reconciliation for orphaned crawl jobs.
+ *
+ * Mirrors `reconcileOrphanedBrowserSessions()`: on a fresh boot (crash,
+ * OOM kill, redeploy, manual restart, ...) any job this node was in the
+ * middle of running has no way to ever reach a terminal state on its own —
+ * `runCrawlJobLocal`'s `finally` block (which persists `succeeded` /
+ * `partial` / `failed` / `canceled`) never got a chance to run, so the DB
+ * row is stuck at `running` forever. Cancel doesn't help either: it only
+ * stamps `cancelRequestedAt`, which the (now-dead) runner's poll loop was
+ * responsible for observing.
+ *
+ * On top of that, this deployment's default queue provider is the
+ * in-memory one (no Redis configured — see docker-compose.yml). A job
+ * dispatched with `mode: 'async'` (the dashboard default) is published to
+ * an in-process queue; if the process dies before the message is consumed,
+ * the message is lost outright but the job's DB row is still `queued`,
+ * so it sits there forever too.
+ *
+ * This reconciler runs once at bootstrap, before the queue consumer/
+ * scheduler start taking new work, and:
+ *  - marks any `running` job as `failed` (nothing is executing it anymore);
+ *  - re-publishes any `queued` job so it actually gets picked up now that
+ *    the crawler queue consumer is back online.
+ */
+
+import { getDatabase, getTenantDatabase } from '@/lib/database';
+import { createLogger } from '@/lib/core/logger';
+import { getQueue, type QueuePayload } from '@/lib/core/queue';
+import { queueNameFor } from '@/lib/core/cluster';
+import type { CrawlerContext } from './types';
+
+const logger = createLogger('crawler:reconcile');
+
+const ORPHANED_RUNNING_MESSAGE =
+  'Crawl job orphaned by a server restart before it finished. Please re-run the crawler.';
+
+export async function reconcileOrphanedCrawlJobs(): Promise<{
+  tenantsScanned: number;
+  failedRunningJobs: number;
+  requeuedJobs: number;
+}> {
+  const mainDb = await getDatabase();
+  const tenants = await mainDb.listTenants();
+  const queue = await getQueue();
+
+  let tenantsScanned = 0;
+  let failedRunningJobs = 0;
+  let requeuedJobs = 0;
+
+  for (const tenant of tenants) {
+    if (!tenant.dbName || !tenant._id) continue;
+    tenantsScanned += 1;
+    const tenantId = String(tenant._id);
+
+    try {
+      const tenantDb = await getTenantDatabase(tenant.dbName);
+
+      const runningJobs = await tenantDb.listCrawlJobs(tenantId, { status: 'running' });
+      for (const job of runningJobs) {
+        const endedAt = new Date();
+        const finalized = await tenantDb.finalizeCrawlJob(String(job._id), tenantId, {
+          status: 'failed',
+          endedAt,
+          durationMs: job.startedAt ? endedAt.getTime() - job.startedAt.getTime() : undefined,
+          errorMessage: ORPHANED_RUNNING_MESSAGE,
+        });
+        if (finalized) failedRunningJobs += 1;
+      }
+
+      const queuedJobs = await tenantDb.listCrawlJobs(tenantId, { status: 'queued' });
+      for (const job of queuedJobs) {
+        const ctx: CrawlerContext = {
+          tenantDbName: tenant.dbName,
+          tenantId,
+          projectId: job.projectId,
+        };
+        const payload = { ctx, jobId: String(job._id) } as unknown as QueuePayload;
+        await queue.publish(queueNameFor('crawler'), 'crawler.run', payload, { attempts: 1 });
+        requeuedJobs += 1;
+      }
+    } catch (error) {
+      logger.warn('Failed to reconcile tenant crawl jobs', {
+        error: error instanceof Error ? error.message : String(error),
+        tenantDbName: tenant.dbName,
+        tenantSlug: tenant.slug,
+      });
+    }
+  }
+
+  if (failedRunningJobs > 0 || requeuedJobs > 0) {
+    logger.info('Reconciled orphaned crawl jobs', {
+      tenantsScanned,
+      failedRunningJobs,
+      requeuedJobs,
+    });
+  }
+
+  return { tenantsScanned, failedRunningJobs, requeuedJobs };
+}

--- a/src/lib/services/crawler/index.ts
+++ b/src/lib/services/crawler/index.ts
@@ -18,6 +18,7 @@ export {
   listCrawlerUrls,
 } from './crawlerService';
 export { startCrawlerQueueConsumer } from './crawlerConsumer';
+export { reconcileOrphanedCrawlJobs } from './crawlerJobReconciler';
 export {
   startCrawlerScheduler,
   stopCrawlerScheduler,

--- a/src/server/bootstrap.ts
+++ b/src/server/bootstrap.ts
@@ -16,7 +16,11 @@ import { listAutomations } from '@/lib/services/automations';
 import { browserManager } from '@/lib/services/browser/browserManager';
 import { reconcileOrphanedBrowserSessions } from '@/lib/services/browser/browserOperationsService';
 import { startBrowserQueueConsumer } from '@/lib/services/browser/browserConsumer';
-import { startCrawlerQueueConsumer, startCrawlerScheduler } from '@/lib/services/crawler';
+import {
+  startCrawlerQueueConsumer,
+  startCrawlerScheduler,
+  reconcileOrphanedCrawlJobs,
+} from '@/lib/services/crawler';
 import { startOcrJobQueueConsumer } from '@/lib/services/ocrJobs';
 import { startBatchQueueConsumer } from '@/lib/services/batch';
 import { startDatasetGenerationConsumer } from '@/lib/services/evaluation/datasetGenerationConsumer';
@@ -174,6 +178,14 @@ export async function bootstrapApplication(): Promise<void> {
     await reconcileOrphanedBrowserSessions();
   } catch (error) {
     logger.warn('Browser session reconciliation failed during startup', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+
+  try {
+    await reconcileOrphanedCrawlJobs();
+  } catch (error) {
+    logger.warn('Crawl job reconciliation failed during startup', {
       error: error instanceof Error ? error.message : String(error),
     });
   }


### PR DESCRIPTION
## Problem

Production crawl jobs get stuck at `Running` (frozen page counts like 58/68/78) and clicking Cancel does nothing — the job stays `Running` forever, and new runs pile up as `Queued` and never start. This does not reproduce locally because local dev is a single long-lived process that never restarts mid-crawl.

## Root cause

1. `runCrawlJobLocal`'s `finally` block is the only place a job's terminal status (`succeeded`/`partial`/`failed`/`canceled`) gets persisted. If the Node process that owns a `running` job dies mid-crawl (OOM kill, redeploy, crash, manual restart), that `finally` never runs — the job is stuck at `running` in the DB **forever**, with nothing left to reconcile it.
2. Cancel only stamps `cancelRequestedAt` in the DB; it relies on the *owning* runner's in-process poll loop to notice and abort. If that runner process is already dead, nobody ever observes the flag, so Cancel has no effect on an orphaned job.
3. This deployment's queue provider defaults to **in-memory** (no Redis configured in `docker-compose.yml`, so `QUEUE_PROVIDER=auto` resolves to `memory`). Jobs dispatched via `mode: 'async'` (the dashboard's default) are published to an in-process queue; if the process dies before the message is drained, the message is lost outright — but the job's DB row is still `queued`, so it sits there forever too.

## Fix

Adds `reconcileOrphanedCrawlJobs()` (`src/lib/services/crawler/crawlerJobReconciler.ts`), mirroring the existing `reconcileOrphanedBrowserSessions()` pattern. Runs once at server bootstrap, before the crawler queue consumer starts taking new work:

- any job still `running` is marked `failed` (nothing is executing it anymore — matches user-visible reality instead of lying forever);
- any job still `queued` is re-published to the crawler queue so it actually gets picked up once the consumer is back online.

## Testing

- `npx tsc --noEmit` passes with no new errors.
- Verified push protection: `main` is a protected branch requiring PRs (this PR).