### PR TITLE
feat(providers): zero-config built-in vector and file providers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,9 @@
 # All variables have sensible defaults unless marked (required).
 # ============================================================
 
+# ---- Storage -------------------------------------------------
+# DATA_DIR=./data                                   # Root directory for built-in on-disk data (vector indexes, file storage). Docker image defaults to /app/data.
+
 # ---- Database ------------------------------------------------
 # Provider: sqlite (default, zero-dependency) | mongodb
 DB_PROVIDER=sqlite                                 # Database backend

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1
 ENV PORT=3000
 ENV HOST=0.0.0.0
+ENV DATA_DIR=/app/data
 ENV PLAYWRIGHT_BROWSERS_PATH=/home/node/.cache/ms-playwright
 
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl gnupg \

--- a/src/__tests__/api/files-buckets-dashboard.test.ts
+++ b/src/__tests__/api/files-buckets-dashboard.test.ts
@@ -6,6 +6,10 @@ vi.mock('@/lib/services/files', () => ({
   createFileBucket: vi.fn(),
 }));
 
+vi.mock('@/lib/services/providers/builtinProviders', () => ({
+  ensureBuiltinProviders: vi.fn().mockResolvedValue(undefined),
+}));
+
 vi.mock('@/lib/services/projects/projectContext', () => {
   class ProjectContextError extends Error {
     status: number;

--- a/src/__tests__/api/files-providers.test.ts
+++ b/src/__tests__/api/files-providers.test.ts
@@ -6,6 +6,10 @@ vi.mock('@/lib/services/files', () => ({
   createFileProvider: vi.fn(),
 }));
 
+vi.mock('@/lib/services/providers/builtinProviders', () => ({
+  ensureBuiltinProviders: vi.fn().mockResolvedValue(undefined),
+}));
+
 vi.mock('@/lib/services/projects/projectContext', () => {
   class ProjectContextError extends Error {
     status: number;

--- a/src/__tests__/api/vector-providers-routes.test.ts
+++ b/src/__tests__/api/vector-providers-routes.test.ts
@@ -6,6 +6,10 @@ vi.mock('@/lib/services/vector', () => ({
   listVectorProviders: vi.fn(),
 }));
 
+vi.mock('@/lib/services/providers/builtinProviders', () => ({
+  ensureBuiltinProviders: vi.fn().mockResolvedValue(undefined),
+}));
+
 vi.mock('@/lib/services/projects/projectContext', () => {
   class ProjectContextError extends Error {
     status: number;

--- a/src/__tests__/unit/builtin-providers.test.ts
+++ b/src/__tests__/unit/builtin-providers.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Unit tests — built-in provider auto-provisioning
+ *
+ * Verifies that ensureBuiltinProviders idempotently creates the built-in
+ * vector/file provider records and the default bucket, extends project
+ * assignments on existing records, tolerates concurrent-create races and
+ * never throws into the calling read path.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockDb = {
+  switchToTenant: vi.fn(),
+  findProviderByKey: vi.fn(),
+  findFileBucketByKey: vi.fn(),
+};
+
+vi.mock('@/lib/database', () => ({
+  getDatabase: vi.fn(async () => mockDb),
+}));
+
+vi.mock('@/lib/services/providers/providerService', () => ({
+  createProviderConfig: vi.fn(),
+  updateProviderConfig: vi.fn(),
+}));
+
+vi.mock('@/lib/services/files', () => ({
+  createFileBucket: vi.fn(),
+}));
+
+import {
+  ensureBuiltinProviders,
+  BUILTIN_VECTOR_PROVIDER_KEY,
+  BUILTIN_FILE_PROVIDER_KEY,
+  BUILTIN_FILE_BUCKET_KEY,
+} from '@/lib/services/providers/builtinProviders';
+import {
+  createProviderConfig,
+  updateProviderConfig,
+} from '@/lib/services/providers/providerService';
+import { createFileBucket } from '@/lib/services/files';
+
+const mockCreateProviderConfig = vi.mocked(createProviderConfig);
+const mockUpdateProviderConfig = vi.mocked(updateProviderConfig);
+const mockCreateFileBucket = vi.mocked(createFileBucket);
+
+const TENANT_ID = 'tenant-1';
+const USER_ID = 'user-1';
+
+// ensureBuiltinProviders memoises successful runs per tenantDb/project pair
+// for the process lifetime, so every test uses a unique pair.
+let testCounter = 0;
+function freshScope() {
+  testCounter += 1;
+  return {
+    tenantDbName: `tenant_db_${testCounter}`,
+    projectId: `project-${testCounter}`,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockDb.switchToTenant.mockResolvedValue(undefined);
+  mockDb.findProviderByKey.mockResolvedValue(null);
+  mockDb.findFileBucketByKey.mockResolvedValue(null);
+  mockCreateProviderConfig.mockResolvedValue({} as never);
+  mockUpdateProviderConfig.mockResolvedValue({} as never);
+  mockCreateFileBucket.mockResolvedValue({} as never);
+});
+
+describe('ensureBuiltinProviders', () => {
+  it('creates both built-in providers and the default bucket for a fresh tenant', async () => {
+    const { tenantDbName, projectId } = freshScope();
+
+    await ensureBuiltinProviders(tenantDbName, TENANT_ID, projectId, USER_ID);
+
+    expect(mockCreateProviderConfig).toHaveBeenCalledTimes(2);
+    const createdKeys = mockCreateProviderConfig.mock.calls.map(
+      ([, , payload]) => payload.key,
+    );
+    expect(createdKeys).toContain(BUILTIN_VECTOR_PROVIDER_KEY);
+    expect(createdKeys).toContain(BUILTIN_FILE_PROVIDER_KEY);
+
+    const vectorPayload = mockCreateProviderConfig.mock.calls.find(
+      ([, , payload]) => payload.key === BUILTIN_VECTOR_PROVIDER_KEY,
+    )![2];
+    expect(vectorPayload.type).toBe('vector');
+    expect(vectorPayload.driver).toBe('sqlite-vector');
+    expect(vectorPayload.credentials).toEqual({});
+    expect(vectorPayload.projectId).toBe(projectId);
+
+    const filePayload = mockCreateProviderConfig.mock.calls.find(
+      ([, , payload]) => payload.key === BUILTIN_FILE_PROVIDER_KEY,
+    )![2];
+    expect(filePayload.type).toBe('file');
+    expect(filePayload.driver).toBe('local-filesystem');
+
+    expect(mockCreateFileBucket).toHaveBeenCalledWith(
+      tenantDbName,
+      TENANT_ID,
+      projectId,
+      expect.objectContaining({
+        key: BUILTIN_FILE_BUCKET_KEY,
+        providerKey: BUILTIN_FILE_PROVIDER_KEY,
+        createdBy: USER_ID,
+      }),
+    );
+  });
+
+  it('assigns an existing built-in provider to a new project', async () => {
+    const { tenantDbName, projectId } = freshScope();
+
+    mockDb.findProviderByKey.mockResolvedValue({
+      _id: 'provider-record-1',
+      projectIds: ['some-other-project'],
+    });
+    mockDb.findFileBucketByKey.mockResolvedValue({ _id: 'bucket-1' });
+
+    await ensureBuiltinProviders(tenantDbName, TENANT_ID, projectId, USER_ID);
+
+    expect(mockCreateProviderConfig).not.toHaveBeenCalled();
+    expect(mockUpdateProviderConfig).toHaveBeenCalledTimes(2);
+    expect(mockUpdateProviderConfig).toHaveBeenCalledWith(
+      tenantDbName,
+      'provider-record-1',
+      expect.objectContaining({
+        projectIds: ['some-other-project', projectId],
+      }),
+    );
+  });
+
+  it('does nothing when providers and bucket already exist for the project', async () => {
+    const { tenantDbName, projectId } = freshScope();
+
+    mockDb.findProviderByKey.mockResolvedValue({
+      _id: 'provider-record-1',
+      projectIds: [projectId],
+    });
+    mockDb.findFileBucketByKey.mockResolvedValue({ _id: 'bucket-1' });
+
+    await ensureBuiltinProviders(tenantDbName, TENANT_ID, projectId, USER_ID);
+
+    expect(mockCreateProviderConfig).not.toHaveBeenCalled();
+    expect(mockUpdateProviderConfig).not.toHaveBeenCalled();
+    expect(mockCreateFileBucket).not.toHaveBeenCalled();
+  });
+
+  it('tolerates losing a concurrent-create race', async () => {
+    const { tenantDbName, projectId } = freshScope();
+
+    mockCreateProviderConfig.mockRejectedValue(
+      new Error('Provider with key "builtin-vector" already exists.'),
+    );
+    mockCreateFileBucket.mockRejectedValue(
+      new Error('Bucket with key "builtin-storage" already exists.'),
+    );
+
+    await expect(
+      ensureBuiltinProviders(tenantDbName, TENANT_ID, projectId, USER_ID),
+    ).resolves.toBeUndefined();
+  });
+
+  it('swallows unexpected provisioning failures instead of breaking the caller', async () => {
+    const { tenantDbName, projectId } = freshScope();
+
+    mockCreateProviderConfig.mockRejectedValue(new Error('disk on fire'));
+
+    await expect(
+      ensureBuiltinProviders(tenantDbName, TENANT_ID, projectId, USER_ID),
+    ).resolves.toBeUndefined();
+  });
+
+  it('memoises successful provisioning per tenant/project pair', async () => {
+    const { tenantDbName, projectId } = freshScope();
+
+    await ensureBuiltinProviders(tenantDbName, TENANT_ID, projectId, USER_ID);
+    const lookupsAfterFirstRun = mockDb.findProviderByKey.mock.calls.length;
+    expect(lookupsAfterFirstRun).toBeGreaterThan(0);
+
+    await ensureBuiltinProviders(tenantDbName, TENANT_ID, projectId, USER_ID);
+    expect(mockDb.findProviderByKey.mock.calls.length).toBe(lookupsAfterFirstRun);
+  });
+});

--- a/src/__tests__/unit/sqlite-vector-contract.test.ts
+++ b/src/__tests__/unit/sqlite-vector-contract.test.ts
@@ -6,9 +6,11 @@
  */
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdtempSync, rmSync, existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
+import Database from 'better-sqlite3';
+import { reloadConfig } from '@/lib/core/config';
 import { SqliteVectorProviderContract } from '@/lib/providers/contracts/sqliteVector.contract';
 import type { VectorProviderRuntime } from '@/lib/providers/domains/vector';
 
@@ -38,7 +40,7 @@ afterAll(() => {
 describe('SqliteVectorProviderContract shape', () => {
   it('has the correct id and version', () => {
     expect(SqliteVectorProviderContract.id).toBe('sqlite-vector');
-    expect(SqliteVectorProviderContract.version).toBe('1.0.0');
+    expect(SqliteVectorProviderContract.version).toBe('1.1.0');
   });
 
   it('declares vector domain', () => {
@@ -50,14 +52,19 @@ describe('SqliteVectorProviderContract shape', () => {
     expect(SqliteVectorProviderContract.display.description).toBeTruthy();
   });
 
-  it('has form schema with basePath field', () => {
+  it('has form schema with optional basePath field', () => {
     const fields = SqliteVectorProviderContract.form.sections.flatMap(
       (s) => s.fields,
     );
     const basePathField = fields.find((f) => f.name === 'basePath');
     expect(basePathField).toBeDefined();
     expect(basePathField!.scope).toBe('settings');
-    expect(basePathField!.required).toBe(true);
+    // Zero-config: falls back to DATA_DIR/vectors when left empty.
+    expect(basePathField!.required).toBe(false);
+  });
+
+  it('declares the builtin capability', () => {
+    expect(SqliteVectorProviderContract.capabilities?.builtin).toBe(true);
   });
 
   it('declares capabilities', () => {
@@ -320,5 +327,110 @@ describe('Edge cases', () => {
     const h2 = await runtime.createIndex({ name: 'cascade-test', dimension: 2 });
     const result = await runtime.queryVectors(h2, { vector: [1, 0], topK: 10 });
     expect(result.matches).toHaveLength(0);
+  });
+});
+
+// ── Zero-config fallback (DATA_DIR) ─────────────────────────────────────
+
+describe('Zero-config basePath fallback', () => {
+  it('falls back to DATA_DIR/vectors when basePath is empty', async () => {
+    const fallbackRoot = mkdtempSync(
+      path.join(tmpdir(), 'cognipeer-console-vec-fallback-'),
+    );
+    const previousDataDir = process.env.DATA_DIR;
+    process.env.DATA_DIR = fallbackRoot;
+    reloadConfig();
+
+    try {
+      const rt = await SqliteVectorProviderContract.createRuntime({
+        tenantId: TENANT_ID,
+        providerKey: 'fallback-provider',
+        credentials: {} as Record<string, never>,
+        settings: {},
+      });
+
+      const h = await rt.createIndex({ name: 'fallback-index', dimension: 2 });
+      await rt.upsertVectors(h, [{ id: 'f1', values: [1, 0] }]);
+      const result = await rt.queryVectors(h, { vector: [1, 0], topK: 1 });
+      expect(result.matches[0].id).toBe('f1');
+
+      expect(
+        existsSync(
+          path.join(
+            fallbackRoot,
+            'vectors',
+            TENANT_ID,
+            'fallback-provider-vectors.sqlite',
+          ),
+        ),
+      ).toBe(true);
+    } finally {
+      if (previousDataDir === undefined) {
+        delete process.env.DATA_DIR;
+      } else {
+        process.env.DATA_DIR = previousDataDir;
+      }
+      reloadConfig();
+      rmSync(fallbackRoot, { recursive: true, force: true });
+    }
+  });
+});
+
+// ── Legacy storage compatibility ───────────────────────────────────────
+
+describe('Legacy JSON vector rows', () => {
+  it('queries rows stored as JSON text by earlier versions', async () => {
+    const h = await runtime.createIndex({ name: 'legacy-mix', dimension: 2 });
+
+    // New rows are written as Float32 BLOBs through the runtime …
+    await runtime.upsertVectors(h, [{ id: 'blob-row', values: [0, 1] }]);
+
+    // … while this row simulates data written by contract version 1.0.0,
+    // which stored vectors as JSON text in the same column.
+    const legacyDb = new Database(
+      path.join(tmpDir, TENANT_ID, `${PROVIDER_KEY}-vectors.sqlite`),
+    );
+    legacyDb
+      .prepare(
+        `INSERT INTO vector_entries (id, index_id, vec_values, metadata) VALUES (?, ?, ?, ?)`,
+      )
+      .run('json-row', h.externalId, JSON.stringify([1, 0]), JSON.stringify({ legacy: true }));
+    legacyDb.close();
+
+    const result = await runtime.queryVectors(h, { vector: [1, 0], topK: 2 });
+    expect(result.matches[0].id).toBe('json-row');
+    expect(result.matches[0].score).toBeCloseTo(1.0, 4);
+    expect(result.matches[0].metadata).toEqual({ legacy: true });
+    expect(result.matches[1].id).toBe('blob-row');
+  });
+});
+
+// ── Top-K selection on larger indexes ──────────────────────────────────
+
+describe('Top-K selection with many vectors', () => {
+  it('returns the true top-K ordered by score', async () => {
+    const h = await runtime.createIndex({
+      name: 'bulk-topk',
+      dimension: 2,
+      metric: 'dot',
+    });
+
+    // Scores against query [1, 0] are simply the x component: 0..199.
+    const items = Array.from({ length: 200 }, (_, i) => ({
+      id: `bulk-${i}`,
+      values: [i, 1],
+    }));
+    await runtime.upsertVectors(h, items);
+
+    const result = await runtime.queryVectors(h, { vector: [1, 0], topK: 5 });
+
+    expect(result.matches.map((m) => m.id)).toEqual([
+      'bulk-199',
+      'bulk-198',
+      'bulk-197',
+      'bulk-196',
+      'bulk-195',
+    ]);
+    expect(result.usage?.candidateCount).toBe(200);
   });
 });

--- a/src/config/service-catalog.json
+++ b/src/config/service-catalog.json
@@ -214,12 +214,12 @@
       "id": "sqlite-vector",
       "driver": "sqlite-vector",
       "name": "SQLite Vector",
-      "tagline": "Local SQLite with vector extension",
-      "description": "Lightweight on-disk vector storage backed by SQLite.",
+      "tagline": "Built-in local vector store",
+      "description": "Persistent on-disk vector storage backed by SQLite. Zero configuration — works out of the box without any external service.",
       "domains": ["vector"],
       "color": "#0f80cc",
-      "tags": ["self-hosted", "embedded"],
-      "aliases": ["sqlite"]
+      "tags": ["built-in", "self-hosted", "embedded", "default"],
+      "aliases": ["sqlite", "builtin"]
     },
     {
       "id": "orama",
@@ -259,12 +259,12 @@
       "id": "local-filesystem",
       "driver": "local-filesystem",
       "name": "Local filesystem",
-      "tagline": "Store files on the server disk",
-      "description": "Persist files on the same host where Cognipeer runs.",
+      "tagline": "Built-in local file storage",
+      "description": "Persist files on the same host where Cognipeer runs. Zero configuration — works out of the box without any external service.",
       "domains": ["file"],
       "color": "#64748b",
-      "tags": ["self-hosted", "dev"],
-      "aliases": ["disk", "local"]
+      "tags": ["built-in", "self-hosted", "default"],
+      "aliases": ["disk", "local", "builtin"]
     },
     {
       "id": "mistral-ocr",

--- a/src/lib/core/config.ts
+++ b/src/lib/core/config.ts
@@ -46,6 +46,15 @@ export interface AppConfig {
     graceDays: number;
   };
 
+  storage: {
+    /**
+     * Root directory for all built-in on-disk data (vector indexes, file
+     * storage, model caches). In Docker this points at the mounted
+     * app-data volume (/app/data).
+     */
+    dataDir: string;
+  };
+
   database: {
     provider: 'mongodb' | 'sqlite';
     uri: string;
@@ -278,6 +287,10 @@ function buildConfig(source: ConfigSource): AppConfig {
       issuer: str(source, 'OFFLINE_LICENSE_ISSUER', 'cognipeer'),
       audience: str(source, 'OFFLINE_LICENSE_AUDIENCE', 'cognipeer-console'),
       graceDays: int(source, 'LICENSE_GRACE_DAYS', 14),
+    },
+
+    storage: {
+      dataDir: str(source, 'DATA_DIR', './data'),
     },
 
     database: {

--- a/src/lib/providers/contracts/localFile.contract.ts
+++ b/src/lib/providers/contracts/localFile.contract.ts
@@ -2,6 +2,7 @@ import { promises as fs } from 'node:fs';
 import path from 'node:path';
 import { createHash, randomUUID } from 'node:crypto';
 import slugify from 'slugify';
+import { getConfig } from '@/lib/core/config';
 import type { Stats } from 'node:fs';
 import type { ProviderContract } from '../types';
 import type {
@@ -13,7 +14,7 @@ import type {
 } from '../domains/file';
 
 interface LocalFileSettings {
-  basePath: string;
+  basePath?: string;
   subdirectory?: string;
 }
 
@@ -31,14 +32,10 @@ const SLUG_OPTIONS = {
   trim: true,
 };
 
-function ensurePathProvided(settings: LocalFileSettings): string {
-  const raw = settings.basePath?.trim();
-  if (!raw) {
-    throw new Error('Local file provider requires a basePath setting.');
-  }
-
-  const resolved = path.resolve(raw);
-  return resolved;
+function resolveBasePath(settings: LocalFileSettings): string {
+  const raw = settings.basePath?.trim()
+    || path.join(getConfig().storage.dataDir, 'files');
+  return path.resolve(raw);
 }
 
 function buildTenantRoot(
@@ -46,7 +43,7 @@ function buildTenantRoot(
   tenantId: string,
   providerKey: string,
 ): string {
-  const base = ensurePathProvided(settings);
+  const base = resolveBasePath(settings);
   const segments = [base];
 
   if (settings.subdirectory && settings.subdirectory.trim().length > 0) {
@@ -204,11 +201,14 @@ export const LocalFileProviderContract: ProviderContract<
   domains: ['file'],
   display: {
     label: 'Local filesystem',
-    description: 'Store files on the local server filesystem.',
+    description:
+      'Built-in local file storage on the server filesystem. Persistent and zero-configuration.',
     icon: 'tabler:device-harddrive',
   },
   capabilities: {
     supportsMarkdownConversion: true,
+    local: true,
+    builtin: true,
   },
   form: {
     sections: [
@@ -219,10 +219,10 @@ export const LocalFileProviderContract: ProviderContract<
             name: 'basePath',
             label: 'Base directory',
             type: 'text',
-            required: true,
-            placeholder: '/var/lib/cognipeer-console/files',
+            required: false,
+            placeholder: 'Defaults to DATA_DIR/files',
             description:
-              'Absolute directory path used to store files for this provider.',
+              'Optional directory path used to store files for this provider. Leave empty to use the built-in data directory (DATA_DIR/files).',
             scope: 'settings',
           },
           {

--- a/src/lib/providers/contracts/sqliteVector.contract.ts
+++ b/src/lib/providers/contracts/sqliteVector.contract.ts
@@ -1,6 +1,7 @@
 import path from 'node:path';
 import { mkdirSync, existsSync } from 'node:fs';
 import Database from 'better-sqlite3';
+import { getConfig } from '@/lib/core/config';
 import type { ProviderContract } from '../types';
 import type {
   CreateVectorIndexInput,
@@ -21,55 +22,70 @@ import type {
 type LocalVectorCredentials = Record<string, never>;
 
 interface LocalVectorSettings {
-  basePath: string;
+  basePath?: string;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Vector encoding                                                    */
+/* ------------------------------------------------------------------ */
+
+// Vectors are stored as Float32Array BLOBs (4 bytes/dimension). Rows written
+// by earlier versions hold JSON text in the same column; decodeVector accepts
+// both so existing databases keep working without migration.
+
+function encodeVector(values: number[]): Buffer {
+  return Buffer.from(new Float32Array(values).buffer);
+}
+
+function decodeVector(raw: unknown): Float32Array {
+  if (Buffer.isBuffer(raw)) {
+    // Copy into a fresh ArrayBuffer: pooled Buffers are not 4-byte aligned.
+    return new Float32Array(
+      raw.buffer.slice(raw.byteOffset, raw.byteOffset + raw.byteLength),
+    );
+  }
+  return Float32Array.from(JSON.parse(String(raw)) as number[]);
 }
 
 /* ------------------------------------------------------------------ */
 /*  Similarity helpers                                                 */
 /* ------------------------------------------------------------------ */
 
-function dotProduct(a: number[], b: number[]): number {
-  let sum = 0;
-  for (let i = 0; i < a.length; i++) sum += a[i] * b[i];
-  return sum;
-}
-
-function magnitude(v: number[]): number {
-  let sum = 0;
-  for (let i = 0; i < v.length; i++) sum += v[i] * v[i];
-  return Math.sqrt(sum);
-}
-
-function cosineSimilarity(a: number[], b: number[]): number {
-  const dot = dotProduct(a, b);
-  const magA = magnitude(a);
-  const magB = magnitude(b);
-  if (magA === 0 || magB === 0) return 0;
-  return dot / (magA * magB);
-}
-
-function euclideanDistance(a: number[], b: number[]): number {
-  let sum = 0;
-  for (let i = 0; i < a.length; i++) {
-    const d = a[i] - b[i];
-    sum += d * d;
-  }
-  return Math.sqrt(sum);
-}
-
 function computeScore(
-  a: number[],
-  b: number[],
+  query: Float32Array,
+  candidate: Float32Array,
   metric: 'cosine' | 'dot' | 'euclidean',
 ): number {
+  const len = Math.min(query.length, candidate.length);
+
   switch (metric) {
-    case 'cosine':
-      return cosineSimilarity(a, b);
-    case 'dot':
-      return dotProduct(a, b);
-    case 'euclidean':
+    case 'dot': {
+      let dot = 0;
+      for (let i = 0; i < len; i++) dot += query[i] * candidate[i];
+      return dot;
+    }
+    case 'euclidean': {
+      let sum = 0;
+      for (let i = 0; i < len; i++) {
+        const d = query[i] - candidate[i];
+        sum += d * d;
+      }
       // Convert distance to a similarity-style score: 1 / (1 + distance)
-      return 1 / (1 + euclideanDistance(a, b));
+      return 1 / (1 + Math.sqrt(sum));
+    }
+    case 'cosine':
+    default: {
+      let dot = 0;
+      let magQ = 0;
+      let magC = 0;
+      for (let i = 0; i < len; i++) {
+        dot += query[i] * candidate[i];
+        magQ += query[i] * query[i];
+        magC += candidate[i] * candidate[i];
+      }
+      if (magQ === 0 || magC === 0) return 0;
+      return dot / (Math.sqrt(magQ) * Math.sqrt(magC));
+    }
   }
 }
 
@@ -112,6 +128,10 @@ function openDb(dbPath: string): Database.Database {
   }
 
   const db = new Database(dbPath);
+  // Must be set before the first table is created to take effect; lets
+  // deleteIndex reclaim disk space via incremental_vacuum when many
+  // indexes come and go. A no-op on databases created without it.
+  db.pragma('auto_vacuum = INCREMENTAL');
   db.pragma('journal_mode = WAL');
   db.pragma('foreign_keys = ON');
   db.exec(INDEXES_DDL);
@@ -124,10 +144,8 @@ function buildDbPath(
   tenantId: string,
   providerKey: string,
 ): string {
-  const base = settings.basePath?.trim();
-  if (!base) {
-    throw new Error('SQLite vector provider requires a basePath setting.');
-  }
+  const base = settings.basePath?.trim()
+    || path.join(getConfig().storage.dataDir, 'vectors');
   return path.resolve(base, tenantId, `${providerKey}-vectors.sqlite`);
 }
 
@@ -146,7 +164,7 @@ interface IndexRow {
 interface EntryRow {
   id: string;
   index_id: string;
-  vec_values: string;
+  vec_values: Buffer | string;
   metadata: string | null;
 }
 
@@ -160,12 +178,12 @@ export const SqliteVectorProviderContract: ProviderContract<
   LocalVectorSettings
 > = {
   id: 'sqlite-vector',
-  version: '1.0.0',
+  version: '1.1.0',
   domains: ['vector'],
   display: {
     label: 'SQLite Vector Store',
     description:
-      'Local vector store using SQLite with brute-force similarity search. No external dependencies required.',
+      'Built-in local vector store backed by SQLite. Persistent, zero-configuration, no external dependencies required.',
   },
   form: {
     sections: [
@@ -177,10 +195,10 @@ export const SqliteVectorProviderContract: ProviderContract<
             name: 'basePath',
             label: 'Data Directory',
             type: 'text',
-            required: true,
-            placeholder: './data/vectors',
+            required: false,
+            placeholder: 'Defaults to DATA_DIR/vectors',
             description:
-              'Base directory for vector SQLite files. A subdirectory is created per tenant.',
+              'Optional base directory for vector SQLite files. Leave empty to use the built-in data directory (DATA_DIR/vectors). A subdirectory is created per tenant.',
             scope: 'settings',
           },
         ],
@@ -194,6 +212,7 @@ export const SqliteVectorProviderContract: ProviderContract<
     supportsMetadataFilter: false,
     maxDimension: 4096,
     local: true,
+    builtin: true,
   },
 
   createRuntime({ tenantId, providerKey, settings, logger }) {
@@ -236,6 +255,12 @@ export const SqliteVectorProviderContract: ProviderContract<
       async deleteIndex({ externalId }: VectorDeleteIndexInput): Promise<void> {
         // Foreign key cascade deletes entries
         db.prepare(`DELETE FROM vector_indexes WHERE id = ?`).run(externalId);
+        try {
+          db.pragma('incremental_vacuum');
+        } catch {
+          // Databases created before auto_vacuum was enabled cannot vacuum
+          // incrementally; the space is reused by future inserts instead.
+        }
         logger?.info?.('Deleted vector index', { providerKey, externalId });
       },
 
@@ -273,7 +298,7 @@ export const SqliteVectorProviderContract: ProviderContract<
             stmt.run(
               item.id,
               handle.externalId,
-              JSON.stringify(item.values),
+              encodeVector(item.values),
               item.metadata ? JSON.stringify(item.metadata) : null,
             );
           }
@@ -315,29 +340,55 @@ export const SqliteVectorProviderContract: ProviderContract<
           );
         }
 
+        const queryVec = Float32Array.from(query.vector);
+        const metric = handle.metric ?? 'cosine';
+        const topK = Math.max(1, query.topK);
+
+        // Stream rows and keep only the current top-K candidates so memory
+        // stays flat no matter how large the index grows. Metadata JSON is
+        // parsed lazily for the final matches only.
+        const best: Array<{ id: string; score: number; metadataRaw: string | null }> = [];
+        let minIdx = 0;
+        let candidateCount = 0;
+
         const rows = db
           .prepare(`SELECT id, vec_values, metadata FROM vector_entries WHERE index_id = ?`)
-          .all(handle.externalId) as EntryRow[];
+          .iterate(handle.externalId) as IterableIterator<EntryRow>;
 
-        const metric = handle.metric ?? 'cosine';
+        for (const row of rows) {
+          candidateCount += 1;
+          const score = computeScore(queryVec, decodeVector(row.vec_values), metric);
 
-        // Compute scores using brute-force similarity
-        const scored = rows.map((row) => {
-          const values: number[] = JSON.parse(row.vec_values);
-          return {
-            id: row.id,
-            score: computeScore(query.vector, values, metric),
-            metadata: row.metadata ? JSON.parse(row.metadata) : undefined,
-          };
-        });
+          if (best.length < topK) {
+            best.push({ id: row.id, score, metadataRaw: row.metadata });
+            if (best.length === topK) {
+              minIdx = 0;
+              for (let i = 1; i < best.length; i++) {
+                if (best[i].score < best[minIdx].score) minIdx = i;
+              }
+            }
+            continue;
+          }
 
-        // Sort by score descending (higher = more similar)
-        scored.sort((a, b) => b.score - a.score);
+          if (score > best[minIdx].score) {
+            best[minIdx] = { id: row.id, score, metadataRaw: row.metadata };
+            minIdx = 0;
+            for (let i = 1; i < best.length; i++) {
+              if (best[i].score < best[minIdx].score) minIdx = i;
+            }
+          }
+        }
+
+        best.sort((a, b) => b.score - a.score);
 
         return {
-          matches: scored.slice(0, query.topK),
+          matches: best.map((entry) => ({
+            id: entry.id,
+            score: entry.score,
+            metadata: entry.metadataRaw ? JSON.parse(entry.metadataRaw) : undefined,
+          })),
           usage: {
-            candidateCount: rows.length,
+            candidateCount,
             metric,
           },
         };
@@ -369,7 +420,7 @@ export const SqliteVectorProviderContract: ProviderContract<
 
         const items = pageRows.map((row) => ({
           id: row.id,
-          values: JSON.parse(row.vec_values) as number[],
+          values: Array.from(decodeVector(row.vec_values)),
           metadata: row.metadata ? (JSON.parse(row.metadata) as Record<string, unknown>) : undefined,
         }));
 

--- a/src/lib/services/providers/builtinProviders.ts
+++ b/src/lib/services/providers/builtinProviders.ts
@@ -1,0 +1,175 @@
+import { getDatabase } from '@/lib/database';
+import { createLogger } from '@/lib/core/logger';
+import {
+  createProviderConfig,
+  updateProviderConfig,
+} from './providerService';
+import { createFileBucket } from '@/lib/services/files';
+
+/**
+ * Built-in zero-configuration providers.
+ *
+ * Every tenant/project gets a local vector provider (SQLite) and a local
+ * file provider (server filesystem) without any manual setup, so knowledge
+ * bases can be created out of the box — no external services, credentials
+ * or settings required. Data lives under DATA_DIR (the mounted app-data
+ * volume in Docker).
+ */
+
+export const BUILTIN_VECTOR_PROVIDER_KEY = 'builtin-vector';
+export const BUILTIN_FILE_PROVIDER_KEY = 'builtin-files';
+export const BUILTIN_FILE_BUCKET_KEY = 'builtin-storage';
+
+const logger = createLogger('builtin-providers');
+
+// Skip repeated lookups once a tenant/project pair has been ensured by this
+// process. Cheap re-checks happen again after a restart, which also heals
+// records deleted while the process was down.
+const ensured = new Set<string>();
+
+interface BuiltinProviderSpec {
+  key: string;
+  type: 'vector' | 'file';
+  driver: string;
+  label: string;
+  description: string;
+}
+
+const BUILTIN_PROVIDER_SPECS: BuiltinProviderSpec[] = [
+  {
+    key: BUILTIN_VECTOR_PROVIDER_KEY,
+    type: 'vector',
+    driver: 'sqlite-vector',
+    label: 'Built-in Vector Store',
+    description:
+      'Local persistent vector store (SQLite). No external service or credentials required.',
+  },
+  {
+    key: BUILTIN_FILE_PROVIDER_KEY,
+    type: 'file',
+    driver: 'local-filesystem',
+    label: 'Built-in File Storage',
+    description:
+      'Local persistent file storage on the server disk. No external service or credentials required.',
+  },
+];
+
+function isAlreadyExistsError(error: unknown): boolean {
+  return error instanceof Error && /already exists/i.test(error.message);
+}
+
+async function ensureProviderRecord(
+  tenantDbName: string,
+  tenantId: string,
+  projectId: string,
+  userId: string,
+  spec: BuiltinProviderSpec,
+): Promise<void> {
+  const db = await getDatabase();
+  await db.switchToTenant(tenantDbName);
+
+  // Provider keys are tenant-level; look the record up without a project
+  // filter so an existing record only needs its project assignment extended.
+  const existing = await db.findProviderByKey(tenantId, spec.key);
+
+  if (!existing) {
+    try {
+      await createProviderConfig(tenantDbName, tenantId, {
+        projectId,
+        key: spec.key,
+        type: spec.type,
+        driver: spec.driver,
+        label: spec.label,
+        description: spec.description,
+        credentials: {},
+        settings: {},
+        createdBy: userId,
+      });
+      logger.info('Provisioned built-in provider', {
+        key: spec.key,
+        tenantId,
+        projectId,
+      });
+    } catch (error) {
+      // Lost a concurrent-create race — the record exists now, which is all
+      // this function is responsible for.
+      if (!isAlreadyExistsError(error)) throw error;
+    }
+    return;
+  }
+
+  const assignedProjects = existing.projectIds ?? [];
+  const isAssigned =
+    assignedProjects.includes(projectId) || existing.projectId === projectId;
+
+  if (!isAssigned && existing._id) {
+    await updateProviderConfig(tenantDbName, String(existing._id), {
+      projectIds: [...assignedProjects, projectId],
+      updatedBy: userId,
+    });
+    logger.info('Assigned built-in provider to project', {
+      key: spec.key,
+      tenantId,
+      projectId,
+    });
+  }
+}
+
+async function ensureBuiltinBucket(
+  tenantDbName: string,
+  tenantId: string,
+  projectId: string,
+  userId: string,
+): Promise<void> {
+  const db = await getDatabase();
+  await db.switchToTenant(tenantDbName);
+
+  const existing = await db.findFileBucketByKey(
+    tenantId,
+    BUILTIN_FILE_BUCKET_KEY,
+    projectId,
+  );
+  if (existing) return;
+
+  try {
+    await createFileBucket(tenantDbName, tenantId, projectId, {
+      key: BUILTIN_FILE_BUCKET_KEY,
+      name: 'Built-in Storage',
+      providerKey: BUILTIN_FILE_PROVIDER_KEY,
+      description: 'Default bucket on the built-in local file storage.',
+      createdBy: userId,
+    });
+    logger.info('Provisioned built-in file bucket', { tenantId, projectId });
+  } catch (error) {
+    if (!isAlreadyExistsError(error)) throw error;
+  }
+}
+
+/**
+ * Idempotently creates the built-in vector/file providers and the default
+ * file bucket for a tenant project. Safe to call on read paths: failures are
+ * logged and swallowed so listings never break because provisioning did.
+ */
+export async function ensureBuiltinProviders(
+  tenantDbName: string,
+  tenantId: string,
+  projectId: string,
+  userId: string,
+): Promise<void> {
+  const memoKey = `${tenantDbName}:${projectId}`;
+  if (ensured.has(memoKey)) return;
+
+  try {
+    for (const spec of BUILTIN_PROVIDER_SPECS) {
+      await ensureProviderRecord(tenantDbName, tenantId, projectId, userId, spec);
+    }
+    await ensureBuiltinBucket(tenantDbName, tenantId, projectId, userId);
+    ensured.add(memoKey);
+  } catch (error) {
+    logger.warn('Failed to provision built-in providers', {
+      tenantId,
+      projectId,
+      error: error instanceof Error ? error.message : error,
+    });
+  }
+}

--- a/src/server/api/routes/files/buckets/route.ts
+++ b/src/server/api/routes/files/buckets/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse, type NextRequest } from '@/server/api/http';
 import { createFileBucket, listFileBuckets } from '@/lib/services/files';
+import { ensureBuiltinProviders } from '@/lib/services/providers/builtinProviders';
 import { requireProjectContext, ProjectContextError } from '@/lib/services/projects/projectContext';
 import type { LicenseType } from '@/lib/license/license-manager';
 import { checkResourceQuota } from '@/lib/quota/quotaGuard';
@@ -22,6 +23,13 @@ export async function GET(request: NextRequest) {
       tenantId,
       userId,
     });
+
+    await ensureBuiltinProviders(
+      tenantDbName,
+      tenantId,
+      projectContext.projectId,
+      userId,
+    );
 
     const buckets = await listFileBuckets(
       tenantDbName,

--- a/src/server/api/routes/files/providers/route.ts
+++ b/src/server/api/routes/files/providers/route.ts
@@ -4,6 +4,7 @@ import {
   listFileProviders,
 } from '@/lib/services/files';
 import type { ProviderStatus } from '@/lib/services/providers/providerService';
+import { ensureBuiltinProviders } from '@/lib/services/providers/builtinProviders';
 import { requireProjectContext, ProjectContextError } from '@/lib/services/projects/projectContext';
 import { createLogger } from '@/lib/core/logger';
 
@@ -28,6 +29,13 @@ export async function GET(request: NextRequest) {
     const { searchParams } = new URL(request.url);
     const statusParam = searchParams.get('status');
     const driver = searchParams.get('driver') ?? undefined;
+
+    await ensureBuiltinProviders(
+      tenantDbName,
+      tenantId,
+      projectContext.projectId,
+      userId,
+    );
 
     const providers = await listFileProviders(
       tenantDbName,

--- a/src/server/api/routes/vector/providers/route.ts
+++ b/src/server/api/routes/vector/providers/route.ts
@@ -4,6 +4,7 @@ import {
   listVectorProviders,
 } from '@/lib/services/vector';
 import type { ProviderStatus } from '@/lib/services/providers/providerService';
+import { ensureBuiltinProviders } from '@/lib/services/providers/builtinProviders';
 import { ProjectContextError, requireProjectContext } from '@/lib/services/projects/projectContext';
 import { createLogger } from '@/lib/core/logger';
 
@@ -37,6 +38,8 @@ export async function GET(request: NextRequest) {
     const { searchParams } = new URL(request.url);
     const statusParam = searchParams.get('status');
     const driver = searchParams.get('driver') ?? undefined;
+
+    await ensureBuiltinProviders(tenantDbName, tenantId, projectId, userId);
 
     const providers = await listVectorProviders(tenantDbName, tenantId, projectId, {
       status: statusParam as ProviderStatus | undefined,


### PR DESCRIPTION
Small and mid-size deployments can now create knowledge bases without any
external vector database or object storage:

- Add a DATA_DIR config key (default ./data, /app/data in the Docker
  image) as the root for all built-in on-disk data, living on the
  existing app-data volume.
- sqlite-vector: basePath is now optional and falls back to
  DATA_DIR/vectors. Vectors are stored as Float32 BLOBs (legacy JSON
  rows still readable), queries stream rows and keep a top-K selection
  so memory stays flat on large indexes, and incremental auto-vacuum
  reclaims disk space when indexes are deleted.
- local-filesystem: basePath is now optional and falls back to
  DATA_DIR/files.
- Auto-provision per tenant/project: the provider list endpoints lazily
  create a "builtin-vector" provider, "builtin-files" provider and a
  default "builtin-storage" bucket, so the UI works out of the box.
- Catalog entries tagged built-in/default with updated descriptions.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RQ7GdbWeeQdxgFGfEiUZHP