### PR TITLE
fix(server): polyfill Promise.try for Node 22 runtime

### DIFF
--- a/src/lib/services/crawler/engine/index.ts
+++ b/src/lib/services/crawler/engine/index.ts
@@ -37,6 +37,39 @@ import {
 // rendering (axios failed: ...after Playwright rendering)" message).
 class FetchStageError extends Error {}
 
+// Bounds how long a single page/attachment's markdown conversion may run.
+// Observed in production: a bug in a transitive PDF-parsing dependency
+// (unpdf, used for PDF text extraction/OCR) could leave `await
+// convertToMarkdown(...)` pending forever — the rejection it eventually
+// threw came from a promise detached from the one being awaited, so it
+// surfaced only as an "unhandledRejection" at the process level while the
+// awaited call itself never resolved nor rejected. Since `fileToMarkdown`/
+// `htmlToMarkdown` already catch real errors internally, that hang was the
+// ONE failure mode not covered — it froze the whole crawl job's for-await
+// loop indefinitely (job stuck in "Running" with no further progress and
+// no "Crawl job ended" log ever printed). This timeout guarantees forward
+// progress regardless of the root cause: if conversion doesn't finish in
+// time, the page is kept with no body (rather than the crawl stalling).
+const MARKDOWN_CONVERSION_TIMEOUT_MS = 60_000;
+
+function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new Error(`${label} timed out after ${ms}ms`));
+    }, ms);
+    promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (err) => {
+        clearTimeout(timer);
+        reject(err);
+      },
+    );
+  });
+}
+
 export * from './types';
 
 /**
@@ -227,11 +260,15 @@ export async function* crawl(
           if (fetched.type === 'file') {
             let attachmentBody: string | undefined;
             if (fetched.fileBuffer) {
-              attachmentBody = await fileToMarkdown({
-                buffer: fetched.fileBuffer,
-                fileName: deriveAttachmentFileName(item.url, fetched.contentType),
-                options: plan.markdownOptions,
-              }).catch((err: unknown) => {
+              attachmentBody = await withTimeout(
+                fileToMarkdown({
+                  buffer: fetched.fileBuffer,
+                  fileName: deriveAttachmentFileName(item.url, fetched.contentType),
+                  options: plan.markdownOptions,
+                }),
+                MARKDOWN_CONVERSION_TIMEOUT_MS,
+                `Attachment markdown conversion for ${item.url}`,
+              ).catch((err: unknown) => {
                 logger.warn('Attachment markdown conversion failed', {
                   url: item.url,
                   error: (err as Error).message,
@@ -253,9 +290,16 @@ export async function* crawl(
           }
           const html = fetched.html ?? '';
           const meta = extractMeta(html);
-          const body = await htmlToMarkdown({
-            html,
-            options: plan.markdownOptions,
+          const body = await withTimeout(
+            htmlToMarkdown({ html, options: plan.markdownOptions }),
+            MARKDOWN_CONVERSION_TIMEOUT_MS,
+            `HTML markdown conversion for ${item.url}`,
+          ).catch((err: unknown) => {
+            logger.warn('HTML markdown conversion failed; keeping page with no body', {
+              url: item.url,
+              error: (err as Error).message,
+            });
+            return '';
           });
           // Discover children only if autoCrawl and we have depth budget
           let children: string[] = [];

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,3 +1,4 @@
+import './polyfills';
 import { createLogger } from '@/lib/core/logger';
 import { createServer } from './app';
 import { ensureServerEnvLoaded } from './env';

--- a/src/server/polyfills.ts
+++ b/src/server/polyfills.ts
@@ -1,0 +1,27 @@
+/**
+ * Runtime polyfills for JS features newer than the Node.js version pinned in
+ * the production Docker image (currently `node:22`).
+ *
+ * Must be imported first, before any other module, so the polyfill is in
+ * place before dependencies that assume a newer runtime get evaluated.
+ */
+
+// `Promise.try` landed as an unflagged, stable built-in in Node.js 23
+// (V8 13.x) and is NOT available in Node 22. `unpdf` (a transitive
+// dependency of `@cognipeer/to-markdown`, used for PDF parsing) calls it
+// unconditionally, which crashed the process in production with:
+//   TypeError: Promise.try is not a function
+//     at unpdf/dist/pdfjs.mjs
+if (typeof (Promise as unknown as { try?: unknown }).try !== 'function') {
+  (Promise as unknown as { try: <T>(fn: () => T | PromiseLike<T>) => Promise<T> }).try = function try_<T>(
+    fn: () => T | PromiseLike<T>,
+  ): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+      try {
+        resolve(fn());
+      } catch (err) {
+        reject(err);
+      }
+    });
+  };
+}


### PR DESCRIPTION
## Problem 1: Production crash — `TypeError: Promise.try is not a function`
Unhandled promise rejection at `unpdf/dist/pdfjs.mjs` (scope `lifecycle`). Root cause: `Promise.try` only became a stable Node.js built-in in Node 23 (V8 13.x); our Dockerfile pins `node:22`. `unpdf` (transitive dep of `@cognipeer/to-markdown`, used for PDF parsing/OCR) calls it unconditionally.

**Fix**: `src/server/polyfills.ts` (new) implements `Promise.try`, imported as the very first statement in `src/server/index.ts`.

## Problem 2: Crawl jobs stuck in "Running" forever
Consequence of problem 1: the `Promise.try` bug threw from a promise detached from the one our code awaits inside `convertToMarkdown()` — so it never resolved *or* rejected. Existing try/catch around markdown conversion couldn't help since nothing ever settled. Result: any crawl job that hit a PDF attachment got permanently stuck (visible in the Runs tab as "Running" with no further page-count progress and no "Crawl job ended" log ever printed — matches the exact stuck-job reports from prod).

**Fix**: wrap both attachment (PDF/DOCX/etc) and HTML markdown conversion with a 60s timeout in the crawl engine (`src/lib/services/crawler/engine/index.ts`) — a single problematic page can no longer block an entire crawl run, regardless of the underlying cause. This is defense-in-depth on top of the polyfill fix above.

## Note
This PR was originally just the polyfill (previously the 2nd commit on PR #190, which merged before GitHub indexed that commit — see PR #190 for that history). Both fixes are consolidated here per request.