### PR TITLE
fix(crawler): don't fail running jobs owned by still-alive nodes

### DIFF
--- a/src/lib/core/cluster/nodeRegistry.ts
+++ b/src/lib/core/cluster/nodeRegistry.ts
@@ -13,11 +13,11 @@
 import os from 'node:os';
 import { getConfig } from '../config';
 import { createLogger } from '../logger';
+import { getThisNodeIdentity, resetNodeIdentityForTests } from '../nodeIdentity';
 import { getDatabase, type INodeRecord, type NodeRole, type NodeStatus } from '@/lib/database';
 
 const log = createLogger('cluster.node-registry');
 
-let resolvedNodeName: string | null = null;
 let heartbeatTimer: NodeJS.Timeout | null = null;
 let staleSweepTimer: NodeJS.Timeout | null = null;
 let registered = false;
@@ -38,14 +38,7 @@ function readPackageVersion(): string {
  * Stable for the lifetime of the process.
  */
 export function getThisNodeName(): string {
-  if (resolvedNodeName) return resolvedNodeName;
-  const cfg = getConfig();
-  if (cfg.node.name.trim().length > 0) {
-    resolvedNodeName = cfg.node.name.trim();
-  } else {
-    resolvedNodeName = `${os.hostname()}-${process.pid}`;
-  }
-  return resolvedNodeName;
+  return getThisNodeIdentity();
 }
 
 export function getThisNodeRole(): NodeRole {
@@ -158,7 +151,7 @@ export async function findClusterNode(name: string): Promise<INodeRecord | null>
 
 /** Useful for tests. */
 export function resetNodeRegistryForTests(): void {
-  resolvedNodeName = null;
+  resetNodeIdentityForTests();
   registered = false;
   if (heartbeatTimer) {
     clearInterval(heartbeatTimer);

--- a/src/lib/core/nodeIdentity.ts
+++ b/src/lib/core/nodeIdentity.ts
@@ -1,0 +1,25 @@
+/**
+ * This process's stable node identity (env-configured name, or derived
+ * from hostname/pid). Deliberately lives outside `cluster/nodeRegistry`
+ * so the database layer can read it too, without a
+ * database -> cluster -> database import cycle
+ * (`cluster/nodeRegistry` imports `@/lib/database` for heartbeats).
+ */
+
+import os from 'node:os';
+import { getConfig } from './config';
+
+let resolvedNodeName: string | null = null;
+
+export function getThisNodeIdentity(): string {
+  if (resolvedNodeName) return resolvedNodeName;
+  const cfg = getConfig();
+  resolvedNodeName =
+    cfg.node.name.trim().length > 0 ? cfg.node.name.trim() : `${os.hostname()}-${process.pid}`;
+  return resolvedNodeName;
+}
+
+/** Useful for tests. */
+export function resetNodeIdentityForTests(): void {
+  resolvedNodeName = null;
+}

--- a/src/lib/database/mongodb/crawler.mixin.ts
+++ b/src/lib/database/mongodb/crawler.mixin.ts
@@ -10,6 +10,7 @@ import type {
 } from '../provider.interface';
 import type { Constructor } from './types';
 import { MongoDBProviderBase, COLLECTIONS } from './base';
+import { getThisNodeIdentity } from '@/lib/core/nodeIdentity';
 
 function toId(value: ObjectId | string | undefined): string {
   if (!value) return '';
@@ -154,7 +155,14 @@ export function CrawlerMixin<TBase extends Constructor<MongoDBProviderBase>>(Bas
         .collection<ICrawlJob>(COLLECTIONS.crawlJobs)
         .findOneAndUpdate(
           { _id: objectId(id), tenantId, status: 'queued' },
-          { $set: { status: 'running', startedAt, updatedAt: new Date() } },
+          {
+            $set: {
+              status: 'running',
+              startedAt,
+              updatedAt: new Date(),
+              nodeId: getThisNodeIdentity(),
+            },
+          },
           { returnDocument: 'after' },
         );
       if (!result) return null;

--- a/src/lib/database/provider/types.domain.ts
+++ b/src/lib/database/provider/types.domain.ts
@@ -1379,7 +1379,7 @@ export interface ICrawler {
 
   http: ICrawlerHttpConfig;
   /** Optional markdown extractor options forwarded to @cognipeer/to-markdown. */
-  markdownOptions?: { ocr?: { enabled: boolean; languages?: string[] } };
+  markdownOptions?: { ocr?: { enabled: boolean; modelKey?: string; languages?: string[] } };
 
   rag?: ICrawlerRagBinding;
   webhook?: ICrawlerWebhookConfig;
@@ -1415,7 +1415,7 @@ export interface ICrawlPlanSnapshot {
   scope: ICrawlerScope;
   http: ICrawlerHttpConfig;
   downloadableMimes?: string[];
-  markdownOptions?: { ocr?: { enabled: boolean; languages?: string[] } };
+  markdownOptions?: { ocr?: { enabled: boolean; modelKey?: string; languages?: string[] } };
   rag?: ICrawlerRagBinding;
   webhook?: ICrawlerWebhookConfig;
 }
@@ -1446,6 +1446,15 @@ export interface ICrawlJob {
    * A `queued` job is canceled outright instead (see `requestCrawlJobCancel`).
    */
   cancelRequestedAt?: Date;
+  /**
+   * Name of the node (`getThisNodeName()`) that atomically claimed this job
+   * via `claimCrawlJob`. Lets `reconcileOrphanedCrawlJobs()` tell a job that
+   * is genuinely still running on a live sibling node apart from one that
+   * was truly orphaned by a dead node — without it, ANY node's boot would
+   * blindly fail every `running` job across the whole fleet, including ones
+   * another still-alive node is actively (and successfully) executing.
+   */
+  nodeId?: string;
   /** Per-run callback override (ad-hoc tek-shot run desteği). */
   callbackUrl?: string;
   errorMessage?: string;

--- a/src/lib/database/sqlite/base.ts
+++ b/src/lib/database/sqlite/base.ts
@@ -634,6 +634,12 @@ export class SQLiteProviderBase {
       'cancelRequestedAt',
       'cancelRequestedAt TEXT',
     );
+    this.ensureTableColumn(
+      db,
+      TABLES.crawlJobs,
+      'nodeId',
+      'nodeId TEXT',
+    );
   }
 
   private migrateOcrJobsSchema(db: Database.Database): void {

--- a/src/lib/database/sqlite/crawler.mixin.ts
+++ b/src/lib/database/sqlite/crawler.mixin.ts
@@ -9,6 +9,7 @@ import type {
 } from '../provider.interface';
 import type { Constructor, SqliteRow } from './types';
 import { SQLiteProviderBase, TABLES } from './base';
+import { getThisNodeIdentity } from '@/lib/core/nodeIdentity';
 
 export function CrawlerMixin<TBase extends Constructor<SQLiteProviderBase>>(Base: TBase) {
   return class CrawlerOps extends Base {
@@ -237,9 +238,9 @@ export function CrawlerMixin<TBase extends Constructor<SQLiteProviderBase>>(Base
       const db = this.getTenantDb();
       const now = this.now();
       const result = db.prepare(`
-        UPDATE ${TABLES.crawlJobs} SET status = 'running', startedAt = @startedAt, updatedAt = @updatedAt
+        UPDATE ${TABLES.crawlJobs} SET status = 'running', startedAt = @startedAt, updatedAt = @updatedAt, nodeId = @nodeId
         WHERE id = @id AND tenantId = @tenantId AND status = 'queued'
-      `).run({ id, tenantId, startedAt: startedAt.toISOString(), updatedAt: now });
+      `).run({ id, tenantId, startedAt: startedAt.toISOString(), updatedAt: now, nodeId: getThisNodeIdentity() });
       if (result.changes !== 1) return null;
       return this.findCrawlJobById(id);
     }
@@ -367,6 +368,7 @@ export function CrawlerMixin<TBase extends Constructor<SQLiteProviderBase>>(Base
         errorsCount: Number(row.errorsCount) || 0,
         limitReached: Number(row.limitReached) === 1,
         cancelRequestedAt: row.cancelRequestedAt ? this.toDate(row.cancelRequestedAt) : undefined,
+        nodeId: (row.nodeId as string) ?? undefined,
         callbackUrl: (row.callbackUrl as string) ?? undefined,
         errorMessage: (row.errorMessage as string) ?? undefined,
         metadata: this.parseJson(row.metadata, {}),

--- a/src/lib/database/sqlite/schema.ts
+++ b/src/lib/database/sqlite/schema.ts
@@ -1603,6 +1603,7 @@ export const TENANT_SCHEMA_SQL = `
     errorsCount INTEGER NOT NULL DEFAULT 0,
     limitReached INTEGER NOT NULL DEFAULT 0,
     cancelRequestedAt TEXT,
+    nodeId TEXT,
     callbackUrl TEXT,
     errorMessage TEXT,
     metadata TEXT DEFAULT '{}',

--- a/src/lib/services/crawler/crawlerJobReconciler.ts
+++ b/src/lib/services/crawler/crawlerJobReconciler.ts
@@ -10,6 +10,16 @@
  * stamps `cancelRequestedAt`, which the (now-dead) runner's poll loop was
  * responsible for observing.
  *
+ * This is a MULTI-POD deployment, so a `running` job is not necessarily
+ * orphaned by the node that's currently booting — it may be genuinely,
+ * successfully executing on a live sibling node right now. `claimCrawlJob`
+ * stamps the claiming node's identity onto the job (`nodeId`); this
+ * reconciler only fails a `running` job when its owning node is NOT
+ * currently online (heartbeating), so it never steals/fails work that
+ * another still-alive pod is legitimately doing. Jobs claimed before this
+ * `nodeId` tracking existed have no recorded owner and are treated as
+ * orphaned (matches the old, pre-fix behavior).
+ *
  * On top of that, this deployment's default queue provider is the
  * in-memory one (no Redis configured — see docker-compose.yml). A job
  * dispatched with `mode: 'async'` (the dashboard default) is published to
@@ -19,9 +29,12 @@
  *
  * This reconciler runs once at bootstrap, before the queue consumer/
  * scheduler start taking new work, and:
- *  - marks any `running` job as `failed` (nothing is executing it anymore);
+ *  - marks any `running` job whose owning node is no longer online as
+ *    `failed` (nothing is executing it anymore);
  *  - re-publishes any `queued` job so it actually gets picked up now that
- *    the crawler queue consumer is back online.
+ *    the crawler queue consumer is back online (safe even if another node
+ *    concurrently republishes the same job — `claimCrawlJob`'s atomic CAS
+ *    ensures only one runner wins).
  */
 
 import { getDatabase, getTenantDatabase } from '@/lib/database';
@@ -44,6 +57,15 @@ export async function reconcileOrphanedCrawlJobs(): Promise<{
   const tenants = await mainDb.listTenants();
   const queue = await getQueue();
 
+  // This deployment is multi-pod (see `cluster.node-registry`): a job
+  // `running` in the DB may genuinely be executing on a live sibling node,
+  // not the node that happens to be booting right now. Only nodes still
+  // heartbeating count as "online" here — a crashed node's row is flipped
+  // to offline by `sweepStaleNodes()` once its heartbeat goes stale. Jobs
+  // claimed before `nodeId` tracking existed have no owner on record and
+  // are treated as orphaned, matching the old (pre-fix) behavior.
+  const onlineNodeNames = new Set((await mainDb.listNodes({ status: 'online' })).map((n) => n.name));
+
   let tenantsScanned = 0;
   let failedRunningJobs = 0;
   let requeuedJobs = 0;
@@ -58,6 +80,10 @@ export async function reconcileOrphanedCrawlJobs(): Promise<{
 
       const runningJobs = await tenantDb.listCrawlJobs(tenantId, { status: 'running' });
       for (const job of runningJobs) {
+        // Owned by a node that's still alive elsewhere — not orphaned,
+        // leave it alone so its real result can persist when it finishes.
+        if (job.nodeId && onlineNodeNames.has(job.nodeId)) continue;
+
         const endedAt = new Date();
         const finalized = await tenantDb.finalizeCrawlJob(String(job._id), tenantId, {
           status: 'failed',


### PR DESCRIPTION
## Problem

`reconcileOrphanedCrawlJobs()` runs once at every pod's bootstrap and, until this fix, blindly marked **all** `running` crawl jobs across **all** tenants as `failed` — with no check on which node actually claimed the job.

This deployment is multi-pod (confirmed via distinct pod names in `cluster.node-registry` logs, restarting every ~5-10s in observed windows). That means any pod booting would falsely fail jobs genuinely, successfully running on **other** healthy pods. The crawl would finish correctly (confirmed via `pagesProcessed`/`errorsCount` in the 'Crawl job ended' log), but `finalizeCrawlJob`'s `WHERE status = 'running'` guard would then no-op silently (already flipped to `failed` by the reconciler), leaving the UI stuck showing 'Running' with 0/0/0 stats forever.

Reproduced with two independent real job traces (jobId `6a57461b2e6b9d51aec25875` and `6a57480e662ee18b4dfc2848`) showing `Crawl job finalize skipped: job was no longer running` immediately before a correct 'Crawl job ended' log.

This is a **separate bug from #191** (Promise.try polyfill) — same user-visible symptom (stuck/failed jobs), different root cause, still active regardless of #191.

## Fix

- Add `ICrawlJob.nodeId`, stamped by `claimCrawlJob` (Mongo + SQLite) with the claiming node's identity (`getThisNodeIdentity()`).
- Extract node-identity resolution into `lib/core/nodeIdentity.ts` so the database layer can read it without a database -> cluster -> database import cycle (`cluster/nodeRegistry.ts` imports `@/lib/database` for heartbeats).
- `reconcileOrphanedCrawlJobs()` now cross-checks each running job's `nodeId` against the set of currently-online nodes (node registry heartbeats, `listNodes({status:'online'})`) and only fails jobs whose owning node is **not** online. Jobs claimed before this fix (no `nodeId` on record) keep the old orphan-cleanup behavior.
- SQLite gets the new `nodeId` column via the existing `ensureTableColumn` migration helper (same pattern as `cancelRequestedAt`).

## Testing

- `npx tsc --noEmit` passes clean.
- Existing crawler test suites (`crawler-e2e.test.ts`, `crawler-routes.test.ts`) could not be run in this local environment due to a pre-existing, unrelated `better-sqlite3` native binding mismatch (Node 26 ABI) — not caused by this change.