### PR TITLE
fix(auth): default REGISTRATION_MODE to open, not beta

### DIFF
--- a/src/lib/core/config.ts
+++ b/src/lib/core/config.ts
@@ -326,7 +326,7 @@ function buildConfig(source: ConfigSource): AppConfig {
     },
 
     registration: {
-      mode: oneOf(source, 'REGISTRATION_MODE', ['open', 'beta', 'disabled'], 'beta'),
+      mode: oneOf(source, 'REGISTRATION_MODE', ['open', 'beta', 'disabled'], 'open'),
       bootstrapOrgName: str(source, 'BOOTSTRAP_ORG_NAME', ''),
       bootstrapAdminEmail: str(source, 'BOOTSTRAP_ADMIN_EMAIL', ''),
       bootstrapAdminPassword: str(source, 'BOOTSTRAP_ADMIN_PASSWORD', ''),


### PR DESCRIPTION
## Summary
- `REGISTRATION_MODE` defaulted to `'beta'` when unset (src/lib/core/config.ts:329). Every existing deployment — prod SaaS, on-prem, dev — leaves this env var unset, so shipping the previous default would have silently required a beta access code for all new signups.
- Changed the fallback to `'open'`, matching pre-existing behavior. `'beta'`/`'disabled'` remain available as explicit opt-ins via env.

## Why this showed up now
PR #194 merged before its `validate` CI run finished; the run completed after merge and failed 10 assertions in `auth-register.test.ts` — `register()` was short-circuiting at the new access-code gate before reaching `db.updateTenant`/`TokenManager.generateToken`/`sendEmail`/`LicenseManager.getFeaturesForLicense`, all called 0 times.

## Test plan
- [x] `src/__tests__/api/auth-register.test.ts` + `auth-register-beta.test.ts` — 21/21 passing
- [x] Full suite: `vitest run` — 186 files / 2631 tests passing, 0 failing
- [x] `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)