### PR TITLE
Support streamable HTTP transport for MCP clients

### DIFF
--- a/src/app/dashboard/mcp/[id]/page.tsx
+++ b/src/app/dashboard/mcp/[id]/page.tsx
@@ -12,7 +12,6 @@ import {
   Code,
   CopyButton,
   Group,
-  JsonInput,
   Loader,
   Menu,
   Modal,
@@ -54,6 +53,7 @@ import StatusBadge from '@/components/common/ui/StatusBadge';
 import McpToolArgsEditor from '@/components/mcp/McpToolArgsEditor';
 import McpToolsPanel from '@/components/mcp/McpToolsPanel';
 import RuntimeContextEditor, { parseRuntimeContextJson } from '@/components/common/RuntimeContextEditor';
+import SpecImportField, { type SpecFormat } from '@/components/common/SpecImportField';
 import type { McpServerView, McpRequestLogView } from '@/lib/services/mcp';
 
 const AUTH_LABELS: Record<string, string> = {
@@ -153,6 +153,7 @@ export default function McpDetailPage() {
       authUsername: '',
       authPassword: '',
       openApiSpec: '',
+      specFormat: 'auto' as SpecFormat,
       // remote source
       remoteUrl: '',
       remoteTransport: 'streamable-http' as string,
@@ -191,12 +192,18 @@ export default function McpDetailPage() {
         description: data.server.description || '',
         upstreamBaseUrl: data.server.upstreamBaseUrl || '',
         authType: data.server.upstreamAuth?.type || 'none',
-        authToken: '',
+        // Secrets come back masked (••••••) when present. Prefill the masked
+        // placeholder so an untouched save round-trips it and the vault keeps
+        // the stored secret — leaving these blank drops the secret on save.
+        authToken: data.server.upstreamAuth?.token || '',
         authHeaderName: data.server.upstreamAuth?.headerName || '',
-        authHeaderValue: '',
+        authHeaderValue: data.server.upstreamAuth?.headerValue || '',
         authUsername: data.server.upstreamAuth?.username || '',
-        authPassword: '',
+        authPassword: data.server.upstreamAuth?.password || '',
         openApiSpec: data.server.openApiSpec || '',
+        // Stored spec is already normalized to OpenAPI JSON; a re-import can
+        // still bring YAML/Postman, so the format hint resets to auto-detect.
+        specFormat: 'auto',
         remoteUrl: data.server.remoteConfig?.url || '',
         remoteTransport: data.server.remoteConfig?.transport || 'streamable-http',
         stdioRuntime: data.server.stdioConfig?.runtime || 'npx',
@@ -379,9 +386,11 @@ export default function McpDetailPage() {
 
       if (sourceType === 'openapi') {
         update.upstreamBaseUrl = values.upstreamBaseUrl || undefined;
-        // Update spec if changed
+        // Update spec if changed. A re-imported spec may be YAML/Postman, so
+        // pass the format hint through for server-side normalization.
         if (values.openApiSpec && values.openApiSpec !== server?.openApiSpec) {
           update.openApiSpec = values.openApiSpec;
+          update.specFormat = values.specFormat;
         }
       } else if (sourceType === 'remote') {
         if (!values.remoteUrl.trim()) throw new Error('MCP server URL is required');
@@ -1647,14 +1656,14 @@ async with sse_client(
               <FormRow cols={1}>
                 <FormField
                   label="OpenAPI specification"
-                  hint="Edit the JSON spec to update available tools."
+                  hint="Paste, upload, or re-fetch the spec from a URL to refresh the available tools. Saving re-imports the tool list."
                 >
-                  <JsonInput
+                  <SpecImportField
+                    value={form.values.openApiSpec}
+                    onChange={(val) => form.setFieldValue('openApiSpec', val)}
+                    format={form.values.specFormat}
+                    onFormatChange={(val) => form.setFieldValue('specFormat', val)}
                     minRows={10}
-                    maxRows={20}
-                    autosize
-                    formatOnBlur
-                    {...form.getInputProps('openApiSpec')}
                   />
                 </FormField>
               </FormRow>
@@ -1758,7 +1767,7 @@ async with sse_client(
 
             {form.values.authType === 'token' && (
               <FormRow cols={1}>
-                <FormField label="Bearer token" hint="Leave empty to keep the current token.">
+                <FormField label="Bearer token" hint="Keep the masked value to preserve the current token, or type a new one to replace it.">
                   <PasswordInput {...form.getInputProps('authToken')} />
                 </FormField>
               </FormRow>
@@ -1769,7 +1778,7 @@ async with sse_client(
                 <FormField label="Header name">
                   <TextInput {...form.getInputProps('authHeaderName')} />
                 </FormField>
-                <FormField label="Header value" hint="Leave empty to keep the current value.">
+                <FormField label="Header value" hint="Keep the masked value to preserve the current value, or type a new one to replace it.">
                   <PasswordInput {...form.getInputProps('authHeaderValue')} />
                 </FormField>
               </FormRow>
@@ -1780,7 +1789,7 @@ async with sse_client(
                 <FormField label="Username">
                   <TextInput {...form.getInputProps('authUsername')} />
                 </FormField>
-                <FormField label="Password" hint="Leave empty to keep the current password.">
+                <FormField label="Password" hint="Keep the masked value to preserve the current password, or type a new one to replace it.">
                   <PasswordInput {...form.getInputProps('authPassword')} />
                 </FormField>
               </FormRow>

--- a/src/server/api/plugins/client-mcp.ts
+++ b/src/server/api/plugins/client-mcp.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from 'node:crypto';
 import { Readable } from 'node:stream';
 import type { ReadableStream as NodeReadableStream } from 'node:stream/web';
-import type { FastifyPluginAsync, FastifyRequest } from 'fastify';
+import type { FastifyPluginAsync, FastifyReply, FastifyRequest } from 'fastify';
 import type {
   IMcpAuthConfig,
   IMcpExposureConfig,
@@ -256,6 +256,170 @@ async function runToolCall(
   }
 }
 
+/**
+ * Handle a single JSON-RPC message for the client MCP gateway.
+ *
+ * Shared by the `/message` endpoint (SSE transport when a `sessionId` is
+ * present, streamable-HTTP when it is not) and the POST handler on `/sse`
+ * (streamable HTTP). Modern MCP clients speak streamable HTTP first and POST
+ * their JSON-RPC to the very URL they would open an SSE stream on — so the
+ * advertised `/sse` URL must accept POST too, or those clients fail their
+ * streamable-HTTP attempt (404) before falling back to SSE.
+ */
+async function handleClientMcpMessage(request: FastifyRequest, reply: FastifyReply) {
+  const ctx = await getApiTokenContextForRequest(request);
+  const { serverKey } = request.params as { serverKey: string };
+  const query = (request.query ?? {}) as { sessionId?: string };
+  const sessionId = query.sessionId;
+  const session = sessionId ? getSseSession(sessionId) : null;
+
+  let body: {
+    id?: string | number | null;
+    jsonrpc?: string;
+    method?: string;
+    params?: Record<string, unknown>;
+  };
+  try {
+    body = readJsonBody(request);
+  } catch {
+    const errorPayload = jsonRpcError(null, -32700, 'Parse error');
+    if (session && sessionId) {
+      sendSseResponse(sessionId, errorPayload);
+      return reply.code(202).send();
+    }
+    return reply.code(400).send(errorPayload);
+  }
+
+  const { id = null, method } = body;
+  if (!method) {
+    const errorPayload = jsonRpcError(id, -32600, 'Invalid Request: method is required');
+    if (session && sessionId) {
+      sendSseResponse(sessionId, errorPayload);
+      return reply.code(400).send(errorPayload);
+    }
+    return reply.code(400).send(errorPayload);
+  }
+
+  const respond = (payload: Record<string, unknown>) => {
+    if (session && sessionId) {
+      sendSseResponse(sessionId, payload);
+      return reply.code(202).send();
+    }
+    return reply.code(200).send(payload);
+  };
+
+  // Direct (sessionless) JSON-RPC = streamable HTTP; via an SSE session
+  // the message endpoint belongs to the SSE transport.
+  const requiredProtocol = session && sessionId ? 'sse' : 'streamable-http';
+
+  if (method === 'initialize') {
+    const server = await getMcpServerByKey(ctx.tenantDbName, serverKey, ctx.projectId);
+    if (!server) {
+      return respond(jsonRpcError(id, -32001, 'MCP server not found'));
+    }
+    if (!protocolEnabled(server, requiredProtocol)) {
+      return respond(jsonRpcError(id, -32003, `${requiredProtocol} access is disabled for this MCP server`));
+    }
+    return respond(jsonRpcOk(id, {
+      capabilities: {
+        tools: { listChanged: false },
+      },
+      protocolVersion: MCP_PROTOCOL_VERSION,
+      serverInfo: SERVER_INFO,
+    }));
+  }
+
+  if (method === 'notifications/initialized') {
+    return reply.code(202).send();
+  }
+
+  if (method === 'ping') {
+    return respond(jsonRpcOk(id, {}));
+  }
+
+  if (method === 'tools/list') {
+    const server = await getMcpServerByKey(ctx.tenantDbName, serverKey, ctx.projectId);
+    if (!server) {
+      return respond(jsonRpcError(id, -32001, 'MCP server not found'));
+    }
+    if (!protocolEnabled(server, requiredProtocol)) {
+      return respond(jsonRpcError(id, -32003, `${requiredProtocol} access is disabled for this MCP server`));
+    }
+
+    return respond(jsonRpcOk(id, {
+      tools: listEnabledMcpTools(server).map((tool) => ({
+        description: tool.description,
+        inputSchema: tool.inputSchema,
+        name: tool.name,
+      })),
+    }));
+  }
+
+  if (method === 'tools/call') {
+    const toolName = typeof body.params?.name === 'string' ? body.params.name : '';
+    const args = body.params?.arguments && typeof body.params.arguments === 'object'
+      ? body.params.arguments as Record<string, unknown>
+      : {};
+
+    if (!toolName) {
+      return respond(jsonRpcError(id, -32602, 'Invalid params: "name" is required'));
+    }
+
+    const server = await getMcpServerByKey(ctx.tenantDbName, serverKey, ctx.projectId);
+    if (!server) {
+      return respond(jsonRpcError(id, -32001, 'MCP server not found'));
+    }
+    if (server.status !== 'active') {
+      return respond(jsonRpcError(id, -32002, 'MCP server is disabled'));
+    }
+    if (!protocolEnabled(server, requiredProtocol)) {
+      return respond(jsonRpcError(id, -32003, `${requiredProtocol} access is disabled for this MCP server`));
+    }
+
+    // MCP convention: request-scoped extras ride in params._meta.
+    const meta = body.params?._meta as Record<string, unknown> | undefined;
+    const outcome = await runToolCall(server, toolName, args, {
+      tenantDbName: ctx.tenantDbName,
+      tenantId: ctx.tenantId,
+      projectId: ctx.projectId,
+      transport: session && sessionId ? 'sse' : 'jsonrpc',
+      caller: {
+        tokenId: ctx.tokenRecord._id?.toString(),
+        userId: ctx.user?._id?.toString(),
+      },
+      sessionId: sessionId ?? undefined,
+      runtimeContext: buildRuntimeContextFromRequest(meta?.runtime_context, request.headers, {
+        userId: ctx.user?._id?.toString(),
+        tokenId: ctx.tokenRecord._id?.toString(),
+        source: 'mcp',
+      }),
+    });
+
+    if (outcome.ok) {
+      return respond(jsonRpcOk(id, {
+        content: [
+          {
+            text: typeof outcome.result === 'string' ? outcome.result : JSON.stringify(outcome.result),
+            type: 'text',
+          },
+        ],
+        isError: false,
+      }));
+    }
+    return respond(jsonRpcOk(id, {
+      content: [
+        {
+          text: outcome.error,
+          type: 'text',
+        },
+      ],
+      isError: true,
+    }));
+  }
+
+  return respond(jsonRpcError(id, -32601, `Method not found: ${method}`));
+}
+
 export const clientMcpApiPlugin: FastifyPluginAsync = async (app) => {
   app.post('/client/v1/mcp/:serverKey/execute', withClientApiRequestContext(async (request, reply) => {
     try {
@@ -344,159 +508,22 @@ export const clientMcpApiPlugin: FastifyPluginAsync = async (app) => {
 
   app.post('/client/v1/mcp/:serverKey/message', withClientApiRequestContext(async (request, reply) => {
     try {
-      const ctx = await getApiTokenContextForRequest(request);
-      const { serverKey } = request.params as { serverKey: string };
-      const query = (request.query ?? {}) as { sessionId?: string };
-      const sessionId = query.sessionId;
-      const session = sessionId ? getSseSession(sessionId) : null;
-
-      let body: {
-        id?: string | number | null;
-        jsonrpc?: string;
-        method?: string;
-        params?: Record<string, unknown>;
-      };
-      try {
-        body = readJsonBody(request);
-      } catch {
-        const errorPayload = jsonRpcError(null, -32700, 'Parse error');
-        if (session && sessionId) {
-          sendSseResponse(sessionId, errorPayload);
-          return reply.code(202).send();
-        }
-        return reply.code(400).send(errorPayload);
-      }
-
-      const { id = null, method } = body;
-      if (!method) {
-        const errorPayload = jsonRpcError(id, -32600, 'Invalid Request: method is required');
-        if (session && sessionId) {
-          sendSseResponse(sessionId, errorPayload);
-          return reply.code(400).send(errorPayload);
-        }
-        return reply.code(400).send(errorPayload);
-      }
-
-      const respond = (payload: Record<string, unknown>) => {
-        if (session && sessionId) {
-          sendSseResponse(sessionId, payload);
-          return reply.code(202).send();
-        }
-        return reply.code(200).send(payload);
-      };
-
-      // Direct (sessionless) JSON-RPC = streamable HTTP; via an SSE session
-      // the message endpoint belongs to the SSE transport.
-      const requiredProtocol = session && sessionId ? 'sse' : 'streamable-http';
-
-      if (method === 'initialize') {
-        const server = await getMcpServerByKey(ctx.tenantDbName, serverKey, ctx.projectId);
-        if (!server) {
-          return respond(jsonRpcError(id, -32001, 'MCP server not found'));
-        }
-        if (!protocolEnabled(server, requiredProtocol)) {
-          return respond(jsonRpcError(id, -32003, `${requiredProtocol} access is disabled for this MCP server`));
-        }
-        return respond(jsonRpcOk(id, {
-          capabilities: {
-            tools: { listChanged: false },
-          },
-          protocolVersion: MCP_PROTOCOL_VERSION,
-          serverInfo: SERVER_INFO,
-        }));
-      }
-
-      if (method === 'notifications/initialized') {
-        return reply.code(202).send();
-      }
-
-      if (method === 'ping') {
-        return respond(jsonRpcOk(id, {}));
-      }
-
-      if (method === 'tools/list') {
-        const server = await getMcpServerByKey(ctx.tenantDbName, serverKey, ctx.projectId);
-        if (!server) {
-          return respond(jsonRpcError(id, -32001, 'MCP server not found'));
-        }
-        if (!protocolEnabled(server, requiredProtocol)) {
-          return respond(jsonRpcError(id, -32003, `${requiredProtocol} access is disabled for this MCP server`));
-        }
-
-        return respond(jsonRpcOk(id, {
-          tools: listEnabledMcpTools(server).map((tool) => ({
-            description: tool.description,
-            inputSchema: tool.inputSchema,
-            name: tool.name,
-          })),
-        }));
-      }
-
-      if (method === 'tools/call') {
-        const toolName = typeof body.params?.name === 'string' ? body.params.name : '';
-        const args = body.params?.arguments && typeof body.params.arguments === 'object'
-          ? body.params.arguments as Record<string, unknown>
-          : {};
-
-        if (!toolName) {
-          return respond(jsonRpcError(id, -32602, 'Invalid params: "name" is required'));
-        }
-
-        const server = await getMcpServerByKey(ctx.tenantDbName, serverKey, ctx.projectId);
-        if (!server) {
-          return respond(jsonRpcError(id, -32001, 'MCP server not found'));
-        }
-        if (server.status !== 'active') {
-          return respond(jsonRpcError(id, -32002, 'MCP server is disabled'));
-        }
-        if (!protocolEnabled(server, requiredProtocol)) {
-          return respond(jsonRpcError(id, -32003, `${requiredProtocol} access is disabled for this MCP server`));
-        }
-
-        // MCP convention: request-scoped extras ride in params._meta.
-        const meta = body.params?._meta as Record<string, unknown> | undefined;
-        const outcome = await runToolCall(server, toolName, args, {
-          tenantDbName: ctx.tenantDbName,
-          tenantId: ctx.tenantId,
-          projectId: ctx.projectId,
-          transport: session && sessionId ? 'sse' : 'jsonrpc',
-          caller: {
-            tokenId: ctx.tokenRecord._id?.toString(),
-            userId: ctx.user?._id?.toString(),
-          },
-          sessionId: sessionId ?? undefined,
-          runtimeContext: buildRuntimeContextFromRequest(meta?.runtime_context, request.headers, {
-            userId: ctx.user?._id?.toString(),
-            tokenId: ctx.tokenRecord._id?.toString(),
-            source: 'mcp',
-          }),
-        });
-
-        if (outcome.ok) {
-          return respond(jsonRpcOk(id, {
-            content: [
-              {
-                text: typeof outcome.result === 'string' ? outcome.result : JSON.stringify(outcome.result),
-                type: 'text',
-              },
-            ],
-            isError: false,
-          }));
-        }
-        return respond(jsonRpcOk(id, {
-          content: [
-            {
-              text: outcome.error,
-              type: 'text',
-            },
-          ],
-          isError: true,
-        }));
-      }
-
-      return respond(jsonRpcError(id, -32601, `Method not found: ${method}`));
+      return await handleClientMcpMessage(request, reply);
     } catch (error) {
       logger.error('Client MCP message handler error', { error });
+      return reply.code(500).send(jsonRpcError(null, -32603, 'Internal error'));
+    }
+  }));
+
+  // Streamable HTTP transport: modern MCP clients POST JSON-RPC to the same URL
+  // they open the SSE stream on (the advertised `/sse` URL). Without this POST
+  // handler such a client's streamable-HTTP attempt 404s (falling through to
+  // the Next.js app) before it can fall back to the GET SSE transport below.
+  app.post('/client/v1/mcp/:serverKey/sse', withClientApiRequestContext(async (request, reply) => {
+    try {
+      return await handleClientMcpMessage(request, reply);
+    } catch (error) {
+      logger.error('Client MCP streamable-http handler error', { error });
       return reply.code(500).send(jsonRpcError(null, -32603, 'Internal error'));
     }
   }));

--- a/src/server/api/plugins/public-mcp.ts
+++ b/src/server/api/plugins/public-mcp.ts
@@ -245,6 +245,18 @@ export const publicMcpApiPlugin: FastifyPluginAsync = async (app) => {
     }
   });
 
+  // Streamable HTTP transport: accept JSON-RPC POSTs on the advertised `/sse`
+  // URL so streamable-HTTP-first MCP clients connect without a failed attempt +
+  // SSE fallback (mirrors the client gateway).
+  app.post('/public/mcp/:tenantId/:endpointSlug/sse', async (request, reply) => {
+    try {
+      return await handlePublicMessage(request, reply);
+    } catch (error) {
+      logger.error('Public MCP streamable-http error', { error });
+      return reply.code(500).send(jsonRpcError(null, -32603, 'Internal error'));
+    }
+  });
+
   app.get('/public/mcp/:tenantId/:endpointSlug/sse', async (request, reply) => {
     try {
       const { tenantId, endpointSlug } = request.params as { tenantId: string; endpointSlug: string };


### PR DESCRIPTION
## Summary

Modern MCP clients prefer streamable HTTP transport and attempt to POST JSON-RPC messages to the same URL they open SSE streams on. Without POST handlers on the `/sse` endpoints, these clients fail their streamable-HTTP attempt (404) before falling back to SSE. This change adds POST support to both the client gateway and public MCP `/sse` endpoints, enabling seamless streamable HTTP transport while maintaining backward compatibility with SSE.

Additionally, the client MCP message handler logic is refactored into a shared `handleClientMcpMessage` function to eliminate duplication between the `/message` and `/sse` endpoints.

## Changes

- **client-mcp.ts**: 
  - Extract message handling logic into `handleClientMcpMessage()` function to support both SSE and streamable HTTP transports
  - Add POST handler on `/client/v1/mcp/:serverKey/sse` endpoint for streamable HTTP transport
  - Update `/message` endpoint to use the shared handler
  - Add `FastifyReply` to imports

- **public-mcp.ts**:
  - Add POST handler on `/public/mcp/:tenantId/:endpointSlug/sse` endpoint for streamable HTTP transport (mirrors client gateway)

- **[id]/page.tsx**:
  - Replace `JsonInput` with new `SpecImportField` component for OpenAPI spec management (supports paste, upload, and URL fetch)
  - Add `specFormat` field to track spec format hint ('auto', 'openapi', 'yaml', 'postman') for server-side normalization
  - Improve secret field handling: prefill masked values so untouched saves preserve stored secrets
  - Update form hints to clarify secret field behavior and spec import workflow
  - Pass `specFormat` to server when updating OpenAPI spec

## Validation

- Existing tests pass (no new test files added, but refactoring maintains existing behavior)
- Changes are backward compatible: SSE transport continues to work as before
- Streamable HTTP clients can now connect without failed 404 attempts

## Release Notes

- MCP clients using streamable HTTP transport can now connect directly without falling back to SSE
- OpenAPI spec management improved with import field supporting multiple formats (JSON, YAML, Postman)
- Secret field handling clarified to prevent accidental deletion on form save

https://claude.ai/code/session_01YLi6Tq3NW2No31hUwghkrz