### PR TITLE
fix(tracing): stop a session's totals from being reset by its own later legs

### DIFF
--- a/src/__tests__/api/client-tracing-stream.test.ts
+++ b/src/__tests__/api/client-tracing-stream.test.ts
@@ -125,6 +125,27 @@ describe('POST /api/client/v1/tracing/sessions/stream/[sessionId]/start', () => 
     expect(mockDb.createAgentTracingSession).not.toHaveBeenCalled();
   });
 
+  it('keeps the accumulated totals when an existing session is re-started', async () => {
+    // An SDK agent opens a trace session per invoke(), so one logical run posts
+    // several starts under one sessionId. Zeroing the row here used to erase every
+    // earlier leg, leaving the session reporting only its last one.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    mockDb.findAgentTracingSessionById.mockResolvedValueOnce(mockSession as any);
+    await startPOST(
+      makeReq('POST', '/api/client/v1/tracing/sessions/stream/sess-abc/start', {}),
+      sessionParams,
+    );
+    await drainPendingTasks();
+
+    const [, update] = mockDb.updateAgentTracingSession.mock.calls[0];
+    expect(update.status).toBe('in_progress');
+    expect(update.endedAt).toBeUndefined();
+    expect(update).not.toHaveProperty('summary');
+    expect(update).not.toHaveProperty('totalInputTokens');
+    expect(update).not.toHaveProperty('totalOutputTokens');
+    expect(update).not.toHaveProperty('totalEvents');
+  });
+
   it('returns 429 when rate limit exceeded', async () => {
     const { checkRateLimit } = await import('@/lib/quota/quotaGuard');
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -234,6 +255,39 @@ describe('POST /api/client/v1/tracing/sessions/stream/[sessionId]/end', () => {
     expect(body.status).toBe('success');
     await drainPendingTasks();
     expect(mockDb.updateAgentTracingSession).toHaveBeenCalled();
+  });
+
+  it('never lets one leg’s end summary shrink the session totals', async () => {
+    // Each leg's `end` carries only that leg's numbers. Letting the payload win
+    // outright discarded whatever the run had already accumulated.
+    await endPOST(
+      makeReq('POST', '/api/client/v1/tracing/sessions/stream/sess-abc/end', {
+        status: 'success',
+        summary: { totalInputTokens: 10, totalOutputTokens: 5, totalCachedInputTokens: 0 },
+      }),
+      sessionParams,
+    );
+    await drainPendingTasks();
+
+    const [, update] = mockDb.updateAgentTracingSession.mock.calls[0];
+    expect(update.totalInputTokens).toBe(mockSession.totalInputTokens);
+    expect(update.totalOutputTokens).toBe(mockSession.totalOutputTokens);
+  });
+
+  it('adopts a leg summary larger than the session totals', async () => {
+    await endPOST(
+      makeReq('POST', '/api/client/v1/tracing/sessions/stream/sess-abc/end', {
+        status: 'success',
+        summary: { totalInputTokens: 900, totalOutputTokens: 400, totalCachedInputTokens: 300 },
+      }),
+      sessionParams,
+    );
+    await drainPendingTasks();
+
+    const [, update] = mockDb.updateAgentTracingSession.mock.calls[0];
+    expect(update.totalInputTokens).toBe(900);
+    expect(update.totalOutputTokens).toBe(400);
+    expect(update.totalCachedInputTokens).toBe(300);
   });
 
   it('ends a session with error status', async () => {

--- a/src/__tests__/integration/tracing-accumulation-parity.test.ts
+++ b/src/__tests__/integration/tracing-accumulation-parity.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Tracing session accumulation, run against BOTH providers.
+ *
+ * These cover the code the production Fastify plugin actually calls. The
+ * existing client-tracing-stream tests import the legacy `server/api/routes/**`
+ * handlers and mock the database away, so they cannot see what the provider
+ * mixins do — and the mixins are where the accounting lives.
+ *
+ * The defect being pinned: an SDK agent opens a trace session per `invoke()`, so
+ * one logical run posts several `start`/`events`/`end` cycles under a single
+ * caller-supplied sessionId. Anything that resets or overwrites the running
+ * totals on a later cycle silently discards the earlier ones.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+
+import { describeForEachProvider } from './db-parity.helper';
+
+type SessionSeed = {
+  sessionId: string;
+  projectId: string;
+  tenantId: string;
+};
+
+function seedDoc(seed: SessionSeed) {
+  return {
+    sessionId: seed.sessionId,
+    projectId: seed.projectId,
+    tenantId: seed.tenantId,
+    agentName: 'Pulse Worker Agent',
+    status: 'in_progress',
+    startedAt: new Date(),
+    errors: [],
+    modelsUsed: [],
+    toolsUsed: [],
+    eventCounts: {},
+    totalEvents: 0,
+    totalInputTokens: 0,
+    totalOutputTokens: 0,
+    totalCachedInputTokens: 0,
+    summary: {
+      totalDurationMs: 0,
+      totalInputTokens: 0,
+      totalOutputTokens: 0,
+      totalCachedInputTokens: 0,
+      eventCounts: {},
+    },
+  };
+}
+
+describeForEachProvider('Agent tracing session accumulation', (getDb) => {
+  let seed: SessionSeed;
+
+  beforeEach(async () => {
+    const unique = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const db = getDb();
+    const slug = `tracing-${unique}`;
+    const dbName = `tenant_${slug}`;
+    const tenant = await db.createTenant({
+      companyName: 'Tracing',
+      slug,
+      dbName,
+      licenseType: 'FREE',
+      ownerId: 'pending',
+    });
+    await db.switchToTenant(dbName);
+    seed = { sessionId: `sess-${unique}`, projectId: `proj-${unique}`, tenantId: String(tenant._id) };
+  });
+
+  it('adds every event to the running totals', async () => {
+    const db = getDb();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await db.createAgentTracingSession(seedDoc(seed) as any);
+
+    await db.applyAgentTracingSessionEvent(seed.sessionId, {
+      inputTokens: 60, outputTokens: 40, cachedInputTokens: 10, durationMs: 700,
+      eventType: 'ai_call', modelsUsed: ['gpt-5.4'],
+    }, seed.projectId);
+    await db.applyAgentTracingSessionEvent(seed.sessionId, {
+      inputTokens: 200, outputTokens: 100, cachedInputTokens: 0, durationMs: 500,
+      eventType: 'ai_call', modelsUsed: ['gpt-5.4'], toolsUsed: ['search'],
+    }, seed.projectId);
+
+    const session = await db.findAgentTracingSessionById(seed.sessionId, seed.projectId);
+    expect(session?.totalInputTokens).toBe(260);
+    expect(session?.totalOutputTokens).toBe(140);
+    expect(session?.totalCachedInputTokens).toBe(10);
+    expect(session?.totalEvents).toBe(2);
+    expect(session?.eventCounts).toEqual({ ai_call: 2 });
+    expect(session?.modelsUsed).toEqual(['gpt-5.4']);
+    expect(session?.toolsUsed).toEqual(['search']);
+  });
+
+  it('keeps the summary equal to the denormalized columns', async () => {
+    const db = getDb();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await db.createAgentTracingSession(seedDoc(seed) as any);
+
+    await db.applyAgentTracingSessionEvent(seed.sessionId, {
+      inputTokens: 25, outputTokens: 5, durationMs: 100, eventType: 'ai_call',
+    }, seed.projectId);
+
+    const session = await db.findAgentTracingSessionById(seed.sessionId, seed.projectId);
+    const summary = session?.summary as Record<string, unknown>;
+    expect(summary.totalInputTokens).toBe(session?.totalInputTokens);
+    expect(summary.totalOutputTokens).toBe(session?.totalOutputTokens);
+    expect(summary.totalDurationMs).toBe(100);
+    expect(summary.eventCounts).toEqual({ ai_call: 1 });
+  });
+
+  it('still accumulates when a stored total is not a number', async () => {
+    // Session fields come from unvalidated client JSON, and the batch ingest path
+    // stores `summary` verbatim. A single string in there used to make the whole
+    // event update fail, so the session stopped counting entirely.
+    const db = getDb();
+    const doc = seedDoc(seed);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (doc.summary as any).totalInputTokens = '500';
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await db.createAgentTracingSession(doc as any);
+
+    await db.applyAgentTracingSessionEvent(seed.sessionId, {
+      inputTokens: 10, eventType: 'ai_call',
+    }, seed.projectId);
+
+    const session = await db.findAgentTracingSessionById(seed.sessionId, seed.projectId);
+    expect(session?.totalInputTokens).toBe(10);
+    expect(session?.totalEvents).toBe(1);
+  });
+
+  it('normalizes event types that would otherwise read as a field path', async () => {
+    const db = getDb();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await db.createAgentTracingSession(seedDoc(seed) as any);
+
+    await db.applyAgentTracingSessionEvent(seed.sessionId, { eventType: 'ai.call' }, seed.projectId);
+
+    const session = await db.findAgentTracingSessionById(seed.sessionId, seed.projectId);
+    expect(session?.eventCounts).toEqual({ ai_call: 1 });
+  });
+
+  it('ignores a token value that is not a number rather than counting it', async () => {
+    const db = getDb();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await db.createAgentTracingSession(seedDoc(seed) as any);
+
+    await db.applyAgentTracingSessionEvent(seed.sessionId, {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      inputTokens: '100' as any,
+      eventType: 'ai_call',
+    }, seed.projectId);
+
+    const session = await db.findAgentTracingSessionById(seed.sessionId, seed.projectId);
+    expect(session?.totalInputTokens).toBe(0);
+    expect(session?.totalEvents).toBe(1);
+  });
+
+  it('survives concurrent events without losing any of them', async () => {
+    const db = getDb();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await db.createAgentTracingSession(seedDoc(seed) as any);
+
+    await Promise.all(
+      Array.from({ length: 8 }, () =>
+        db.applyAgentTracingSessionEvent(seed.sessionId, {
+          inputTokens: 10, outputTokens: 5, eventType: 'ai_call',
+        }, seed.projectId)),
+    );
+
+    const session = await db.findAgentTracingSessionById(seed.sessionId, seed.projectId);
+    expect(session?.totalEvents).toBe(8);
+    expect(session?.totalInputTokens).toBe(80);
+    expect(session?.totalOutputTokens).toBe(40);
+  });
+});

--- a/src/lib/database/mongodb/tracing.mixin.ts
+++ b/src/lib/database/mongodb/tracing.mixin.ts
@@ -6,6 +6,7 @@
 
 import { ObjectId } from 'mongodb';
 import type {
+  AgentTracingSessionEventDelta,
   IAgentTracingDashboardAggregate,
   IAgentTracingSession,
   IAgentTracingEvent,
@@ -98,7 +99,25 @@ export function TracingMixin<TBase extends Constructor<MongoDBProviderBase>>(Bas
         return;
       }
 
+      // Upserting on (projectId, sessionId) only collapses concurrent inserts if
+      // the key is unique — without this two simultaneous /start requests can
+      // still both create a document, and every aggregation counts the session
+      // twice. Best-effort: a tenant that already accumulated duplicates cannot
+      // build it, and that must not take the rest of the tracing indexes (or the
+      // request) down. Such a tenant keeps the old double-count until its
+      // duplicates are merged.
+      const uniqueSessionIndexPromise = db
+        .collection(COLLECTIONS.agentTracingSessions)
+        .createIndex({ projectId: 1, sessionId: 1 }, { name: 'uniq_project_sessionId', unique: true })
+        .catch((error) => {
+          logger.warn('Could not create unique tracing session index; duplicates present?', {
+            dbName,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        });
+
       const setupPromise = Promise.all([
+        uniqueSessionIndexPromise,
         db
           .collection(COLLECTIONS.agentTracingSessions)
           .createIndex({ sessionId: 1 }, { name: 'idx_sessionId' }),
@@ -505,9 +524,29 @@ export function TracingMixin<TBase extends Constructor<MongoDBProviderBase>>(Bas
         updatedAt: now,
       };
 
+      // Callers decide create-vs-update from a read taken earlier in the request,
+      // and the write itself runs in the background. Two starts for one sessionId
+      // arriving within that window both saw "no session" and would each insert,
+      // leaving duplicate documents that every aggregation counts twice. Upserting
+      // on the identity keys collapses that to one document.
+      //
+      // `_id` is stripped because `$setOnInsert: {_id: undefined}` stores a literal
+      // null — after which the next distinct session fails on the `_id_` index.
+      // `insertOne` generated an id instead, so the old code was immune.
+      const { _id: _ignoredId, ...insertData } = sessionData as typeof sessionData & { _id?: unknown };
+      const identity = { sessionId: sessionData.sessionId, projectId: sessionData.projectId };
       const result = await db
         .collection(COLLECTIONS.agentTracingSessions)
-        .insertOne(sessionData);
+        .findOneAndUpdate(identity, { $setOnInsert: insertData }, { upsert: true, returnDocument: 'after' });
+
+      // `$setOnInsert` is a no-op when the document already exists, which would
+      // silently discard the caller's payload — the OTLP path in particular
+      // arrives with fully merged totals. Apply them explicitly in that case.
+      const created = result?.createdAt instanceof Date
+        && result.createdAt.getTime() === sessionData.createdAt.getTime();
+      if (result && !created) {
+        await this.updateAgentTracingSession(sessionData.sessionId, insertData, sessionData.projectId);
+      }
 
       if (normalizedThreadId) {
         await this.syncAgentTracingThread(normalizedThreadId, sessionData.projectId);
@@ -515,7 +554,7 @@ export function TracingMixin<TBase extends Constructor<MongoDBProviderBase>>(Bas
 
       return {
         ...sessionData,
-        _id: result.insertedId.toString(),
+        _id: result?._id?.toString() ?? '',
       };
     }
 
@@ -642,6 +681,100 @@ export function TracingMixin<TBase extends Constructor<MongoDBProviderBase>>(Bas
       }
 
       return { sessionsDeleted, eventsDeleted };
+    }
+
+    /**
+     * Fold one event into a session's running totals atomically.
+     *
+     * The alternative — read the session, add, write the sum back — loses events:
+     * a session's events are posted concurrently, so several of them read the
+     * same baseline and the last write discards the rest. Letting the server do
+     * the addition means every event lands exactly once.
+     *
+     * This is an aggregation-pipeline update rather than plain `$inc` for two
+     * reasons. `$inc` rejects the WHOLE update if any incremented path currently
+     * holds a non-number — and session fields come from unvalidated client JSON,
+     * so one `"500"` in a batch-ingested summary would silently swallow every
+     * subsequent event. And the pipeline can read the column it just computed,
+     * which keeps `summary.*` equal to the denormalized column instead of letting
+     * the two drift apart when they did not start out equal.
+     */
+    async applyAgentTracingSessionEvent(
+      sessionId: string,
+      delta: AgentTracingSessionEventDelta,
+      projectId?: string,
+    ): Promise<void> {
+      const db = this.getTenantDb();
+      const collection = db.collection<IAgentTracingSession>(COLLECTIONS.agentTracingSessions);
+      const filter = projectId ? { sessionId, projectId } : { sessionId };
+
+      /** Current value of a field as a number, treating anything unusable as 0. */
+      const asNumber = (path: string) => ({
+        $convert: { input: `$${path}`, to: 'double', onError: 0, onNull: 0 },
+      });
+      const plus = (path: string, amount: number | undefined) => ({
+        $add: [asNumber(path), typeof amount === 'number' && Number.isFinite(amount) ? amount : 0],
+      });
+      const asObject = (path: string) => ({
+        $cond: [{ $eq: [{ $type: `$${path}` }, 'object'] }, `$${path}`, {}],
+      });
+      const asArray = (path: string) => ({
+        $cond: [{ $isArray: `$${path}` }, `$${path}`, []],
+      });
+
+      // Mongo reads `.` and `$` in a field path as structure, so an event type
+      // carrying either would land in the wrong place (or be rejected outright).
+      const eventType = delta.eventType?.replace(/[.$]/g, '_');
+      const eventCounts = eventType
+        ? {
+            $mergeObjects: [
+              asObject('eventCounts'),
+              { [eventType]: { $add: [asNumber(`eventCounts.${eventType}`), 1] } },
+            ],
+          }
+        : asObject('eventCounts');
+
+      const totals = {
+        totalEvents: plus('totalEvents', 1),
+        totalInputTokens: plus('totalInputTokens', delta.inputTokens),
+        totalOutputTokens: plus('totalOutputTokens', delta.outputTokens),
+        totalCachedInputTokens: plus('totalCachedInputTokens', delta.cachedInputTokens),
+      };
+
+      await collection.updateOne(filter, [
+        { $set: { ...totals, eventCounts } },
+        {
+          $set: {
+            updatedAt: new Date(),
+            modelsUsed: { $setUnion: [asArray('modelsUsed'), delta.modelsUsed ?? []] },
+            toolsUsed: { $setUnion: [asArray('toolsUsed'), delta.toolsUsed ?? []] },
+            // Second stage so these read the totals the first stage just wrote,
+            // keeping the summary and the columns from diverging.
+            summary: {
+              $mergeObjects: [
+                asObject('summary'),
+                {
+                  totalInputTokens: '$totalInputTokens',
+                  totalOutputTokens: '$totalOutputTokens',
+                  totalCachedInputTokens: '$totalCachedInputTokens',
+                  totalDurationMs: plus('summary.totalDurationMs', delta.durationMs),
+                  eventCounts: '$eventCounts',
+                },
+              ],
+            },
+          },
+        },
+      ]);
+
+      // The read-modify-write path this replaced went through
+      // `updateAgentTracingSession`, which refreshed the materialized thread
+      // rollup on every event. Without this the Threads screen reports zeros for
+      // the whole life of a running session.
+      const session = await collection.findOne(filter, { projection: { threadId: 1, projectId: 1 } });
+      const threadId = this.normalizeThreadId(session?.threadId);
+      if (threadId) {
+        await this.syncAgentTracingThread(threadId, session?.projectId ?? projectId);
+      }
     }
 
     async updateAgentTracingSession(

--- a/src/lib/database/provider.contract.ts
+++ b/src/lib/database/provider.contract.ts
@@ -1,5 +1,6 @@
 import type {
   AgentStatus,
+  AgentTracingSessionEventDelta,
   AlertEventStatus,
   GuardrailType,
   IAgent,
@@ -168,6 +169,11 @@ export interface DatabaseProvider {
     data: Partial<IAgentTracingSession>,
     projectId?: string,
   ): Promise<IAgentTracingSession | null>;
+  applyAgentTracingSessionEvent(
+    sessionId: string,
+    delta: AgentTracingSessionEventDelta,
+    projectId?: string,
+  ): Promise<void>;
   findAgentTracingSessionById(
     sessionId: string,
     projectId?: string,

--- a/src/lib/database/provider/contract.ts
+++ b/src/lib/database/provider/contract.ts
@@ -1,5 +1,6 @@
 import type {
   AgentStatus,
+  AgentTracingSessionEventDelta,
   AlertEventStatus,
   BrowserSessionStatus,
   BrowserStatus,
@@ -290,6 +291,11 @@ export interface DatabaseProvider extends EnterpriseDbMethods {
     data: Partial<IAgentTracingSession>,
     projectId?: string,
   ): Promise<IAgentTracingSession | null>;
+  applyAgentTracingSessionEvent(
+    sessionId: string,
+    delta: AgentTracingSessionEventDelta,
+    projectId?: string,
+  ): Promise<void>;
   findAgentTracingSessionById(
     sessionId: string,
     projectId?: string,

--- a/src/lib/database/provider/types.base.ts
+++ b/src/lib/database/provider/types.base.ts
@@ -262,6 +262,22 @@ export interface IAgentTracingSession extends IUsageAttributionFields {
   updatedAt?: Date;
 }
 
+/**
+ * One event's contribution to a session's running totals. Applied atomically by
+ * the provider so that concurrent events for the same session cannot overwrite
+ * each other's increments.
+ */
+export interface AgentTracingSessionEventDelta {
+  inputTokens?: number;
+  outputTokens?: number;
+  cachedInputTokens?: number;
+  durationMs?: number;
+  /** Event type whose per-type counter should be bumped, e.g. `ai_call`. */
+  eventType?: string;
+  modelsUsed?: string[];
+  toolsUsed?: string[];
+}
+
 export interface IAgentTracingSessionSummaryAggregate {
   sessionId: string;
   agentName?: string;

--- a/src/lib/database/sqlite/tracing.mixin.ts
+++ b/src/lib/database/sqlite/tracing.mixin.ts
@@ -3,6 +3,7 @@
  */
 
 import type {
+  AgentTracingSessionEventDelta,
   IAgentTracingDashboardAggregate,
   IAgentTracingEvent,
   IAgentTracingSession,
@@ -202,6 +203,95 @@ export function TracingMixin<TBase extends Constructor<SQLiteProviderBase>>(Base
       return { sessionsDeleted: sessionIds.length, eventsDeleted };
     }
 
+    /**
+     * Fold one event into a session's running totals in a single statement, so
+     * concurrent events for the same session add up instead of overwriting each
+     * other. Mirrors the MongoDB provider's `$inc` behaviour.
+     */
+    async applyAgentTracingSessionEvent(
+      sessionId: string,
+      delta: AgentTracingSessionEventDelta,
+      projectId?: string,
+    ): Promise<void> {
+      const db = this.getTenantDb();
+      // Coerce here rather than binding the raw value: SQLite's numeric affinity
+      // would happily add the string "100", while the MongoDB provider's
+      // arithmetic treats a non-number as 0. The two must agree.
+      const toNumber = (value: number | undefined) =>
+        typeof value === 'number' && Number.isFinite(value) ? value : 0;
+
+      const params: Record<string, unknown> = {
+        sessionId,
+        updatedAt: this.now(),
+        inputTokens: toNumber(delta.inputTokens),
+        outputTokens: toNumber(delta.outputTokens),
+        cachedInputTokens: toNumber(delta.cachedInputTokens),
+      };
+      let where = 'sessionId = @sessionId';
+      if (projectId) { where += ' AND projectId = @projectId'; params.projectId = projectId; }
+
+      const tx = db.transaction(() => {
+        db.prepare(
+          `UPDATE ${TABLES.agentTracingSessions} SET
+             updatedAt = @updatedAt,
+             totalEvents = COALESCE(totalEvents, 0) + 1,
+             totalInputTokens = COALESCE(totalInputTokens, 0) + @inputTokens,
+             totalOutputTokens = COALESCE(totalOutputTokens, 0) + @outputTokens,
+             totalCachedInputTokens = COALESCE(totalCachedInputTokens, 0) + @cachedInputTokens
+           WHERE ${where}`,
+        ).run(params);
+
+        const row = db
+          .prepare(`SELECT * FROM ${TABLES.agentTracingSessions} WHERE ${where}`)
+          .get(params) as SqliteRow | undefined;
+        if (!row) return;
+
+        const session = this.mapAgentTracingSessionRow(row);
+        const summary: Record<string, unknown> = { ...(session.summary ?? {}) };
+        summary.totalInputTokens = session.totalInputTokens ?? 0;
+        summary.totalOutputTokens = session.totalOutputTokens ?? 0;
+        summary.totalCachedInputTokens = session.totalCachedInputTokens ?? 0;
+        if (delta.durationMs) {
+          summary.totalDurationMs = (Number(summary.totalDurationMs) || 0) + delta.durationMs;
+        }
+
+        const eventCounts: Record<string, number> = { ...(session.eventCounts ?? {}) };
+        // Same key normalization the MongoDB provider applies, so the two report
+        // identical eventCounts maps for an event type containing `.` or `$`.
+        const eventType = delta.eventType?.replace(/[.$]/g, '_');
+        if (eventType) {
+          eventCounts[eventType] = (eventCounts[eventType] || 0) + 1;
+        }
+        summary.eventCounts = eventCounts;
+
+        const modelsUsed = this.normalizeStringArray([
+          ...(session.modelsUsed ?? []),
+          ...(delta.modelsUsed ?? []),
+        ]);
+        const toolsUsed = this.normalizeStringArray([
+          ...(session.toolsUsed ?? []),
+          ...(delta.toolsUsed ?? []),
+        ]);
+
+        db.prepare(
+          `UPDATE ${TABLES.agentTracingSessions} SET
+             summary = @summary,
+             eventCounts = @eventCounts,
+             modelsUsed = @modelsUsed,
+             toolsUsed = @toolsUsed
+           WHERE ${where}`,
+        ).run({
+          ...params,
+          summary: this.toJson(summary),
+          eventCounts: this.toJson(eventCounts),
+          modelsUsed: this.toJson(modelsUsed),
+          toolsUsed: this.toJson(toolsUsed),
+        });
+      });
+
+      tx();
+    }
+
     async updateAgentTracingSession(
       sessionId: string,
       data: Partial<IAgentTracingSession>,
@@ -226,8 +316,12 @@ export function TracingMixin<TBase extends Constructor<SQLiteProviderBase>>(Base
       if (data.summary !== undefined) { sets.push('summary = @summary'); params.summary = this.toJson(data.summary); }
       if (data.status !== undefined) { sets.push('status = @status'); params.status = data.status; }
       if (data.startedAt !== undefined) { sets.push('startedAt = @startedAt'); params.startedAt = data.startedAt?.toISOString() ?? null; }
-      if (data.endedAt !== undefined) { sets.push('endedAt = @endedAt'); params.endedAt = data.endedAt?.toISOString() ?? null; }
-      if (data.durationMs !== undefined) { sets.push('durationMs = @durationMs'); params.durationMs = data.durationMs; }
+      // Keyed on presence, not on `!== undefined`: reopening a session sets these
+      // to undefined deliberately to clear them. Skipping the write left a stale
+      // endedAt/durationMs on a row whose status had flipped back to in_progress,
+      // which is what MongoDB does clear.
+      if ('endedAt' in data) { sets.push('endedAt = @endedAt'); params.endedAt = data.endedAt?.toISOString() ?? null; }
+      if ('durationMs' in data) { sets.push('durationMs = @durationMs'); params.durationMs = data.durationMs ?? null; }
       if (data.errors !== undefined) { sets.push('errors = @errors'); params.errors = this.toJson(data.errors); }
       if (data.modelsUsed !== undefined) { sets.push('modelsUsed = @modelsUsed'); params.modelsUsed = this.toJson(this.normalizeStringArray(data.modelsUsed)); }
       if (data.toolsUsed !== undefined) { sets.push('toolsUsed = @toolsUsed'); params.toolsUsed = this.toJson(this.normalizeStringArray(data.toolsUsed)); }

--- a/src/server/api/plugins/client-tracing.ts
+++ b/src/server/api/plugins/client-tracing.ts
@@ -294,6 +294,42 @@ function getSummaryNumber(
   return toNumber(getSummaryRecord(summary)[key]);
 }
 
+/**
+ * Largest value a running total has reached, across the incoming payload, the
+ * session's own summary and its denormalized column. Session totals accumulate
+ * over the life of a sessionId, so a later write must never shrink them.
+ */
+function maxTotal(
+  payloadSummary: unknown,
+  sessionSummary: unknown,
+  denormalized: number | undefined,
+  key: keyof TracingSummaryPayload,
+): number {
+  const candidates = [
+    getSummaryNumber(payloadSummary, key),
+    getSummaryNumber(sessionSummary, key),
+    toNumber(denormalized),
+  ].filter((value): value is number => typeof value === 'number');
+
+  return candidates.length > 0 ? Math.max(...candidates) : 0;
+}
+
+function mergeUnique(...lists: Array<string[] | undefined>): string[] {
+  return Array.from(new Set(lists.flatMap((list) => list ?? [])));
+}
+
+/** Drops repeats so a retried `end` cannot grow the session's error list. */
+function dedupeErrors(errors: Array<Record<string, unknown>>): Array<Record<string, unknown>> {
+  const seen = new Set<string>();
+
+  return errors.filter((error) => {
+    const key = JSON.stringify(error);
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
 function getEventSections(event: TracingEventPayload): Array<Record<string, unknown>> {
   const rawSections = Array.isArray(event.sections)
     ? event.sections
@@ -912,11 +948,37 @@ export const clientTracingApiPlugin: FastifyPluginAsync = async (app) => {
         traceId: typeof payload.traceId === 'string' ? payload.traceId : undefined,
       };
 
+      // A caller may re-`/start` an id it already used: SDK agents create a trace
+      // session per `invoke()`, so one logical run (summarization legs, tool-call
+      // retries, approval/question resumes) posts several starts under one
+      // caller-supplied sessionId. Writing the zeroed skeleton over a live row on
+      // those later starts erased everything the earlier legs had accumulated, so
+      // the session only ever reported its final leg. Reopen the row instead:
+      // keep every running total and re-arm it for the incoming leg.
+      const hasAgent = Object.keys(sessionDoc.agent ?? {}).length > 0;
+      const hasConfig = Object.keys(sessionDoc.config ?? {}).length > 0;
+      const reopenDoc: Partial<IAgentTracingSession> = {
+        // A re-start body is often empty. Writing `{}` over these would drop the
+        // agent identity the reopen exists to preserve.
+        ...(hasAgent ? { agent: sessionDoc.agent } : {}),
+        ...(hasConfig ? { config: sessionDoc.config } : {}),
+        agentModel: sessionDoc.agentModel ?? existing?.agentModel,
+        agentName: sessionDoc.agentName ?? existing?.agentName,
+        agentVersion: sessionDoc.agentVersion ?? existing?.agentVersion,
+        durationMs: undefined,
+        endedAt: undefined,
+        modelsUsed: mergeUnique(existing?.modelsUsed, sessionDoc.modelsUsed),
+        status: 'in_progress',
+        ...(sessionDoc.threadId ? { threadId: sessionDoc.threadId } : {}),
+        ...(sessionDoc.traceId ? { traceId: sessionDoc.traceId } : {}),
+        ...(sessionDoc.rootSpanId ? { rootSpanId: sessionDoc.rootSpanId } : {}),
+      };
+
       fireAndForget('client-tracing-stream-start', async () => {
         const backgroundDb = await getDatabase();
         await backgroundDb.switchToTenant(ctx.tenantDbName);
         if (existing) {
-          await backgroundDb.updateAgentTracingSession(sessionId, sessionDoc, ctx.projectId);
+          await backgroundDb.updateAgentTracingSession(sessionId, reopenDoc, ctx.projectId);
         } else {
           const attribution = recordTracingSessionCreated({
             tenantDbName: ctx.tenantDbName,
@@ -1000,32 +1062,8 @@ export const clientTracingApiPlugin: FastifyPluginAsync = async (app) => {
         ?? usage?.cache_read_input_tokens
         ?? undefined;
       const newTotalEvents = (session.totalEvents || 0) + 1;
-      const newInputTokens = (session.totalInputTokens || 0) + (inputTokens || 0);
-      const newOutputTokens = (session.totalOutputTokens || 0) + (outputTokens || 0);
-      const newCachedTokens = (session.totalCachedInputTokens || 0) + (cachedInputTokens || 0);
-      const modelsUsed = new Set<string>(session.modelsUsed || []);
-      const toolsUsed = new Set<string>(session.toolsUsed || []);
-      if (event?.model) modelsUsed.add(event.model);
-      if (event?.modelName) modelsUsed.add(event.modelName);
-      if (event?.metadata?.modelName) modelsUsed.add(event.metadata.modelName);
-      for (const toolName of collectEventToolNames(event)) {
-        toolsUsed.add(toolName);
-      }
-
-      const eventCounts = { ...(session.eventCounts || {}) };
-      if (event.type) {
-        eventCounts[event.type] = (eventCounts[event.type] || 0) + 1;
-      }
-
-      const currentSummary = getSummaryRecord(session.summary);
-      const summary: Record<string, unknown> = { ...currentSummary };
-      summary.totalInputTokens = newInputTokens;
-      summary.totalOutputTokens = newOutputTokens;
-      summary.totalCachedInputTokens = newCachedTokens;
-      summary.eventCounts = eventCounts;
-      if (event.durationMs) {
-        summary.totalDurationMs = (getSummaryNumber(session.summary, 'totalDurationMs') ?? 0) + event.durationMs;
-      }
+      const models = [event?.model, event?.modelName, event?.metadata?.modelName]
+        .filter((name): name is string => typeof name === 'string' && name.length > 0);
 
       fireAndForget('client-tracing-stream-event', async () => {
         const backgroundDb = await getDatabase();
@@ -1068,15 +1106,14 @@ export const clientTracingApiPlugin: FastifyPluginAsync = async (app) => {
 
         await backgroundDb.createAgentTracingEvent(eventDoc);
 
-        await backgroundDb.updateAgentTracingSession(sessionId, {
-          eventCounts,
-          modelsUsed: Array.from(modelsUsed),
-          summary,
-          toolsUsed: Array.from(toolsUsed),
-          totalCachedInputTokens: newCachedTokens,
-          totalEvents: newTotalEvents,
-          totalInputTokens: newInputTokens,
-          totalOutputTokens: newOutputTokens,
+        await backgroundDb.applyAgentTracingSessionEvent(sessionId, {
+          cachedInputTokens,
+          durationMs: event.durationMs ?? undefined,
+          eventType: event.type ?? undefined,
+          inputTokens,
+          modelsUsed: models,
+          outputTokens,
+          toolsUsed: collectEventToolNames(event),
         }, ctx.projectId);
       });
 
@@ -1136,34 +1173,35 @@ export const clientTracingApiPlugin: FastifyPluginAsync = async (app) => {
           : (Object.keys(existingEventCounts).length > 0
             ? existingEventCounts
             : (session.eventCounts || {})),
-        totalBytesIn: getSummaryNumber(payload.summary, 'totalBytesIn')
-          ?? getSummaryNumber(session.summary, 'totalBytesIn')
-          ?? session.totalBytesIn
-          ?? 0,
-        totalBytesOut: getSummaryNumber(payload.summary, 'totalBytesOut')
-          ?? getSummaryNumber(session.summary, 'totalBytesOut')
-          ?? session.totalBytesOut
-          ?? 0,
-        totalCachedInputTokens: getSummaryNumber(payload.summary, 'totalCachedInputTokens')
-          ?? getSummaryNumber(session.summary, 'totalCachedInputTokens')
-          ?? session.totalCachedInputTokens
-          ?? 0,
-        totalDurationMs: getSummaryNumber(payload.summary, 'totalDurationMs')
-          ?? getSummaryNumber(session.summary, 'totalDurationMs')
-          ?? durationMs,
-        totalInputTokens: getSummaryNumber(payload.summary, 'totalInputTokens')
-          ?? getSummaryNumber(session.summary, 'totalInputTokens')
-          ?? session.totalInputTokens
-          ?? 0,
-        totalOutputTokens: getSummaryNumber(payload.summary, 'totalOutputTokens')
-          ?? getSummaryNumber(session.summary, 'totalOutputTokens')
-          ?? session.totalOutputTokens
-          ?? 0,
+        // `end` used to let the payload win outright. A session that spans several
+        // SDK legs sends one `end` per leg carrying only that leg's summary, so the
+        // last leg's numbers replaced the run's. Take the larger of what the session
+        // already accumulated (from `/events`) and what this leg reports: totals can
+        // only ever grow, which also makes a retried `end` idempotent.
+        totalBytesIn: maxTotal(payload.summary, session.summary, session.totalBytesIn, 'totalBytesIn'),
+        totalBytesOut: maxTotal(payload.summary, session.summary, session.totalBytesOut, 'totalBytesOut'),
+        totalCachedInputTokens: maxTotal(
+          payload.summary,
+          session.summary,
+          session.totalCachedInputTokens,
+          'totalCachedInputTokens',
+        ),
+        // Monotonic like the token totals: one `end` per leg means the payload
+        // only ever describes that leg's wall clock, so letting it win shrank a
+        // multi-leg run's duration to its last leg.
+        totalDurationMs: Math.max(
+          maxTotal(payload.summary, session.summary, undefined, 'totalDurationMs'),
+          durationMs,
+        ),
+        totalInputTokens: maxTotal(payload.summary, session.summary, session.totalInputTokens, 'totalInputTokens'),
+        totalOutputTokens: maxTotal(payload.summary, session.summary, session.totalOutputTokens, 'totalOutputTokens'),
       };
-      const mergedErrors = [
+      // A retried `end` resends the same errors. Appending blindly meant each
+      // retry grew the list, so deduplicate on the serialized entry.
+      const mergedErrors = dedupeErrors([
         ...(session.errors || []),
         ...toErrorList(payload.errors),
-      ];
+      ]);
 
       fireAndForget('client-tracing-stream-end', async () => {
         const backgroundDb = await getDatabase();

--- a/src/server/api/routes/client/v1/tracing/sessions/stream/[sessionId]/end/route.ts
+++ b/src/server/api/routes/client/v1/tracing/sessions/stream/[sessionId]/end/route.ts
@@ -67,13 +67,21 @@ const _POST = async (
         const existingSummary = session.summary || {};
         const payloadSummary = payload.summary || {};
         
+        // One `end` arrives per SDK leg, each carrying only that leg's summary, so
+        // letting the payload win outright threw away everything the run had already
+        // accumulated. Totals only ever grow — which also makes a retried `end` a no-op.
+        const maxTotal = (key: string, denormalized: unknown) => Math.max(
+            ...[payloadSummary[key], existingSummary[key], denormalized]
+                .map((value) => (typeof value === 'number' && Number.isFinite(value) ? value : 0)),
+        );
+
         const mergedSummary = {
             totalDurationMs: payloadSummary.totalDurationMs ?? existingSummary.totalDurationMs ?? durationMs,
-            totalInputTokens: payloadSummary.totalInputTokens ?? existingSummary.totalInputTokens ?? session.totalInputTokens ?? 0,
-            totalOutputTokens: payloadSummary.totalOutputTokens ?? existingSummary.totalOutputTokens ?? session.totalOutputTokens ?? 0,
-            totalCachedInputTokens: payloadSummary.totalCachedInputTokens ?? existingSummary.totalCachedInputTokens ?? session.totalCachedInputTokens ?? 0,
-            totalBytesIn: payloadSummary.totalBytesIn ?? existingSummary.totalBytesIn ?? session.totalBytesIn ?? 0,
-            totalBytesOut: payloadSummary.totalBytesOut ?? existingSummary.totalBytesOut ?? session.totalBytesOut ?? 0,
+            totalInputTokens: maxTotal('totalInputTokens', session.totalInputTokens),
+            totalOutputTokens: maxTotal('totalOutputTokens', session.totalOutputTokens),
+            totalCachedInputTokens: maxTotal('totalCachedInputTokens', session.totalCachedInputTokens),
+            totalBytesIn: maxTotal('totalBytesIn', session.totalBytesIn),
+            totalBytesOut: maxTotal('totalBytesOut', session.totalBytesOut),
             eventCounts: payloadSummary.eventCounts ?? existingSummary.eventCounts ?? session.eventCounts ?? {},
         };
 

--- a/src/server/api/routes/client/v1/tracing/sessions/stream/[sessionId]/start/route.ts
+++ b/src/server/api/routes/client/v1/tracing/sessions/stream/[sessionId]/start/route.ts
@@ -121,12 +121,31 @@ const _POST = async (
             source: 'custom' as const,
         };
 
+        // Re-starting an id that already exists must NOT reset it: SDK agents open a
+        // trace session per invoke(), so one logical run posts several starts under
+        // one caller-supplied sessionId. Writing the zeroed skeleton over a live row
+        // erased the earlier legs, leaving only the last one. Reopen instead.
+        const reopenDoc = {
+            agent: sessionDoc.agent,
+            agentModel: sessionDoc.agentModel ?? existing?.agentModel,
+            agentName: sessionDoc.agentName ?? existing?.agentName,
+            agentVersion: sessionDoc.agentVersion ?? existing?.agentVersion,
+            config: sessionDoc.config,
+            durationMs: undefined,
+            endedAt: undefined,
+            modelsUsed: Array.from(new Set([...(existing?.modelsUsed || []), ...sessionDoc.modelsUsed])),
+            status: 'in_progress',
+            ...(sessionDoc.threadId ? { threadId: sessionDoc.threadId } : {}),
+            ...(sessionDoc.traceId ? { traceId: sessionDoc.traceId } : {}),
+            ...(sessionDoc.rootSpanId ? { rootSpanId: sessionDoc.rootSpanId } : {}),
+        };
+
         // Fire-and-forget: persist session in background
         fireAndForget('tracing-stream-start', async () => {
             const bgDb = await getDatabase();
             await bgDb.switchToTenant(auth.tenantDbName);
             if (existing) {
-                await bgDb.updateAgentTracingSession(sessionId, sessionDoc, auth.projectId);
+                await bgDb.updateAgentTracingSession(sessionId, reopenDoc, auth.projectId);
             } else {
                 await bgDb.createAgentTracingSession(sessionDoc);
             }


### PR DESCRIPTION
## Problem

An SDK agent opens a trace session **per `invoke()`**, so one logical run posts several `start`/`events`/`end` cycles under a single caller-supplied `sessionId` — context summarization, tool-call retries, approval/question resumes.

`/start` wrote a zeroed skeleton over the existing row, and `/end` then let the payload win outright. A session therefore only ever reported its **final leg**.

Measured against a host's own per-model-call ledger (production data):

| run class | runs | host ledger | what tracing could show | erased |
|---|---:|---:|---:|---:|
| single-leg | 624 | 85,916,914 | 85,916,914 | **0%** |
| multi-leg | 1,681 | 598,183,204 | 91,355,330 | **84.7%** |
| total | 2,305 | 684,100,118 | 177,272,244 | **74.1%** |

Single-leg runs matching exactly is why earlier spot checks looked fine.

## Changes

- **`/start`** reopens an existing session instead of resetting it — status and agent metadata only, never the running totals.
- **`/end`** takes `max(accumulated, incoming)` per total, so totals only grow and a retried `end` is idempotent. Duration is monotonic for the same reason, and the error list deduplicates.
- **`/events`** accumulates through a new `applyAgentTracingSessionEvent` instead of a read-modify-write, which lost concurrent events. It is an aggregation-pipeline update rather than `$inc`: `$inc` rejects the *whole* update when any incremented path holds a non-number, and session fields come from unvalidated client JSON (the batch path stores `summary` verbatim). The pipeline also keeps `summary.*` equal to the denormalized columns and refreshes the thread rollup — the old path did the latter on every event.
- **Session creation** upserts on `(projectId, sessionId)`, with a best-effort unique index, so two concurrent `/start`s cannot leave duplicate documents that every aggregation counts twice.

## Testing

`src/__tests__/integration/tracing-accumulation-parity.test.ts` runs against a **real mongod and sqlite**. The existing tracing tests import the legacy `src/server/api/routes/**` copy and mock the database away, so they could not see any of this — the new test caught a double-counted `durationMs` in the SQLite provider on its first run.

Full suite: 2719 passed, `tsc --noEmit` clean.

## Note on scope

Behaviour is forward-only: sessions whose legs were already erased are not recoverable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)