### PR TITLE
fix: normalize OpenAI-compatible inference errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,7 @@
         "dayjs": "^1.11.18",
         "fast-uri": "^3.1.2",
         "fastify": "^5.8.5",
+        "gpt-tokenizer": "^3.4.0",
         "handlebars": "^4.7.8",
         "iconv-lite": "^0.6.3",
         "ioredis": "^5.9.3",
@@ -12987,67 +12988,6 @@
         "url": "https://opencollective.com/node-fetch"
       }
     },
-    "node_modules/gcp-metadata": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-5.3.0.tgz",
-      "integrity": "sha512-FNTkdNEnBdlqF2oatizolQqNANMrcqJt6AAYt99B3y1aLLC8Hc5IOBb+ZnnzllodEEf6xMBp6wRcBbc16fa65w==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "gaxios": "^5.0.0",
-        "json-bigint": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/gcp-metadata/node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
-    "node_modules/gcp-metadata/node_modules/gaxios": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-5.1.3.tgz",
-      "integrity": "sha512-95hVgBRgEIRQQQHIbnxBXeHbW4TqFk4ZDJW7wmVtvYar72FdhRIo1UGOLS2eRAKCPEdPBWu+M7+A33D9CdX9rA==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "extend": "^3.0.2",
-        "https-proxy-agent": "^5.0.0",
-        "is-stream": "^2.0.0",
-        "node-fetch": "^2.6.9"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/gcp-metadata/node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/generator-function": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
@@ -13270,6 +13210,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/gpt-tokenizer": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/gpt-tokenizer/-/gpt-tokenizer-3.4.0.tgz",
+      "integrity": "sha512-wxFLnhIXTDjYebd9A9pGl3e31ZpSypbpIJSOswbgop5jLte/AsZVDvjlbEuVFlsqZixVKqbcoNmRlFDf6pz/UQ==",
+      "license": "MIT"
     },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
@@ -16651,23 +16597,6 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=20.19.0"
-      }
-    },
-    "node_modules/mongodb-memory-server-core/node_modules/gcp-metadata": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-7.0.1.tgz",
-      "integrity": "sha512-UcO3kefx6dCcZkgcTGgVOTFb7b1LlQ02hY1omMjjrrBzkajRMCFgYOjs7J71WqnuG1k2b+9ppGL7FsOfhZMQKQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "gaxios": "^7.0.0",
-        "google-logging-utils": "^1.0.0",
-        "json-bigint": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/mongodb-memory-server-core/node_modules/mongodb": {

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "dayjs": "^1.11.18",
     "fast-uri": "^3.1.2",
     "fastify": "^5.8.5",
+    "gpt-tokenizer": "^3.4.0",
     "handlebars": "^4.7.8",
     "iconv-lite": "^0.6.3",
     "ioredis": "^5.9.3",

--- a/src/__tests__/api/chat-completions.test.ts
+++ b/src/__tests__/api/chat-completions.test.ts
@@ -139,7 +139,7 @@ describe('POST /api/client/v1/chat/completions', () => {
       expect(res.status).toBe(400);
     });
 
-    it('returns 500 when handleChatCompletion throws because messages is missing', async () => {
+    it('returns 400 when handleChatCompletion rejects missing messages', async () => {
       // The route delegates messages validation to the service, not at the route level.
       // When messages is omitted & the service throws, the route returns 500.
       (handleChatCompletion as ReturnType<typeof vi.fn>).mockRejectedValue(
@@ -147,7 +147,7 @@ describe('POST /api/client/v1/chat/completions', () => {
       );
       const req = buildChatRequest({ model: 'gpt-4o' });
       const res = await POST(req);
-      expect(res.status).toBe(500);
+      expect(res.status).toBe(400);
     });
   });
 
@@ -199,7 +199,7 @@ describe('POST /api/client/v1/chat/completions', () => {
   });
 
   describe('service error propagation', () => {
-    it('returns 500 when inference service throws an unexpected error', async () => {
+    it('returns 404 when the requested model is not found', async () => {
       (requireApiToken as ReturnType<typeof vi.fn>).mockResolvedValue(MOCK_TOKEN_CONTEXT);
       (getModelByKey as ReturnType<typeof vi.fn>).mockResolvedValue(MOCK_MODEL);
       (handleChatCompletion as ReturnType<typeof vi.fn>).mockRejectedValue(
@@ -211,7 +211,7 @@ describe('POST /api/client/v1/chat/completions', () => {
         messages: [{ role: 'user', content: 'Hello' }],
       });
       const res = await POST(req);
-      expect(res.status).toBe(500);
+      expect(res.status).toBe(404);
     });
   });
 });

--- a/src/__tests__/api/client-chat-completions.test.ts
+++ b/src/__tests__/api/client-chat-completions.test.ts
@@ -28,9 +28,17 @@ vi.mock('@/lib/services/models/inferenceService', () => {
       this.findings = findings;
     }
   }
+  class OutputTokenLimitError extends Error {
+    limit?: number;
+    constructor(limit?: number) {
+      super(`The model reached its output token limit (${limit} tokens).`);
+      this.limit = limit;
+    }
+  }
   return {
     handleChatCompletion: vi.fn(),
     GuardrailBlockError,
+    OutputTokenLimitError,
   };
 });
 
@@ -55,7 +63,7 @@ import { handleChatCompletion } from '@/lib/services/models/inferenceService';
 import * as inferenceServiceMod from '@/lib/services/models/inferenceService';
 // GuardrailBlockError is not in the real module types but IS in the mock
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const { GuardrailBlockError } = inferenceServiceMod as any;
+const { GuardrailBlockError, OutputTokenLimitError } = inferenceServiceMod as any;
 import { checkPerRequestLimits, checkRateLimit, checkBudget } from '@/lib/quota/quotaGuard';
 import { getModelByKey } from '@/lib/services/models/modelService';
 
@@ -135,7 +143,6 @@ describe('POST /api/client/v1/chat/completions', () => {
 
   it('returns 400 when model is not a string', async () => {
     const res = await POST(makeReq({ model: 42, messages: [] }));
-    const json = await res.json();
 
     expect(res.status).toBe(400);
   });
@@ -256,6 +263,23 @@ describe('POST /api/client/v1/chat/completions', () => {
     expect(json.error.guardrail_key).toBe('pii-guard');
     expect(json.error.action).toBe('block');
     expect(json.error.findings).toHaveLength(1);
+  });
+
+  it('returns 422 with an actionable output token limit error', async () => {
+    (handleChatCompletion as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new OutputTokenLimitError(512),
+    );
+
+    const res = await POST(makeReq(VALID_BODY));
+    const json = await res.json();
+
+    expect(res.status).toBe(422);
+    expect(json.error).toMatchObject({
+      type: 'output_token_limit_exceeded',
+      code: 'output_token_limit_exceeded',
+      param: 'max_completion_tokens',
+    });
+    expect(json.error.message).toContain('512 tokens');
   });
 
   it('returns 500 on inference service error', async () => {

--- a/src/__tests__/api/client-inference-fastify.test.ts
+++ b/src/__tests__/api/client-inference-fastify.test.ts
@@ -1,0 +1,156 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/services/apiTokenAuth', () => {
+  class ApiTokenAuthError extends Error {
+    status: number;
+
+    constructor(message: string, status = 401) {
+      super(message);
+      this.name = 'ApiTokenAuthError';
+      this.status = status;
+    }
+  }
+
+  return {
+    ApiTokenAuthError,
+    requireApiTokenFromHeader: vi.fn(),
+  };
+});
+
+vi.mock('@/lib/database', () => ({
+  getDatabase: vi.fn(),
+}));
+
+vi.mock('@/lib/security/rbac', () => ({
+  getPermissionServiceForPath: vi.fn(),
+  authorizeServiceRequest: vi.fn(),
+}));
+
+vi.mock('@/lib/core/lifecycle', () => ({
+  isShuttingDown: vi.fn().mockReturnValue(false),
+}));
+
+vi.mock('@/lib/services/models/inferenceService', () => {
+  class GuardrailBlockError extends Error {
+    guardrailKey = '';
+    action = '';
+    findings: unknown[] = [];
+  }
+
+  return {
+    GuardrailBlockError,
+    handleChatCompletion: vi.fn(),
+    handleEmbeddingRequest: vi.fn(),
+  };
+});
+
+vi.mock('@/lib/services/models/modelService', () => ({
+  getModelByKey: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock('@/lib/services/models/usageLogger', () => ({
+  calculateCost: vi.fn().mockReturnValue({ currency: 'USD', totalCost: 0 }),
+  logModelUsage: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('@/lib/quota/quotaGuard', () => ({
+  checkBudget: vi.fn().mockResolvedValue({ allowed: true }),
+  checkPerRequestLimits: vi.fn().mockResolvedValue({ allowed: true }),
+  checkRateLimit: vi.fn().mockResolvedValue({ allowed: true }),
+}));
+
+import { requireApiTokenFromHeader } from '@/lib/services/apiTokenAuth';
+import { getDatabase } from '@/lib/database';
+import { authorizeServiceRequest, getPermissionServiceForPath } from '@/lib/security/rbac';
+import { handleChatCompletion } from '@/lib/services/models/inferenceService';
+import { OutputTokenLimitError } from '@/lib/services/models/openaiErrors';
+import { clientInferenceApiPlugin } from '@/server/api/plugins/client-inference';
+import { createFastifyApiTestApp, parseJsonBody } from '../helpers/fastify-api';
+
+const AUTH_CTX = {
+  token: 'tok_abc',
+  tokenRecord: { _id: 'tok-1', userId: 'user-1' },
+  tenant: { licenseType: 'STARTER' },
+  tenantId: 'tenant-1',
+  tenantSlug: 'acme',
+  tenantDbName: 'tenant_acme',
+  projectId: 'proj-1',
+  user: { _id: 'user-1', role: 'owner', tenantId: 'tenant-1' },
+};
+
+function mockFn(fn: unknown): ReturnType<typeof vi.fn> {
+  return fn as ReturnType<typeof vi.fn>;
+}
+
+describe('Fastify client inference errors', () => {
+  let app: Awaited<ReturnType<typeof createFastifyApiTestApp>>;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mockFn(requireApiTokenFromHeader).mockResolvedValue(AUTH_CTX);
+    mockFn(getDatabase).mockResolvedValue({
+      runWithTenant: <T>(_tenantDbName: string, operation: () => T) => operation(),
+    });
+    mockFn(getPermissionServiceForPath).mockReturnValue('models');
+    mockFn(authorizeServiceRequest).mockReturnValue({ allowed: true });
+    app = await createFastifyApiTestApp(clientInferenceApiPlugin);
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  async function postChat() {
+    return app.inject({
+      method: 'POST',
+      url: '/api/client/v1/chat/completions',
+      headers: { authorization: 'Bearer tok_abc' },
+      payload: {
+        model: 'test-model',
+        messages: [{ role: 'user', content: 'Hello' }],
+      },
+    });
+  }
+
+  it('returns a structured 422 for output token exhaustion', async () => {
+    mockFn(handleChatCompletion).mockRejectedValue(new OutputTokenLimitError(512));
+
+    const response = await postChat();
+    const body = parseJsonBody<{ error: Record<string, unknown> }>(response.body);
+
+    expect(response.statusCode).toBe(422);
+    expect(body.error).toMatchObject({
+      type: 'output_token_limit_exceeded',
+      code: 'output_token_limit_exceeded',
+      param: 'max_completion_tokens',
+    });
+  });
+
+  it('returns a structured 404 for a missing model', async () => {
+    mockFn(handleChatCompletion).mockRejectedValue(new Error('Model not found: test-model'));
+
+    const response = await postChat();
+    const body = parseJsonBody<{ error: Record<string, unknown> }>(response.body);
+
+    expect(response.statusCode).toBe(404);
+    expect(body.error).toMatchObject({
+      type: 'not_found_error',
+      code: 'model_not_found',
+      param: 'model',
+    });
+  });
+
+  it('keeps unexpected failures as structured 500 errors', async () => {
+    mockFn(handleChatCompletion).mockRejectedValue(new Error('Unexpected provider response'));
+
+    const response = await postChat();
+    const body = parseJsonBody<{ error: Record<string, unknown> }>(response.body);
+
+    expect(response.statusCode).toBe(500);
+    expect(body.error).toMatchObject({
+      message: 'Unexpected provider response',
+      type: 'server_error',
+      code: 'inference_error',
+    });
+  });
+});

--- a/src/__tests__/api/embeddings.test.ts
+++ b/src/__tests__/api/embeddings.test.ts
@@ -197,7 +197,7 @@ describe('POST /api/client/v1/embeddings', () => {
   });
 
   describe('service error propagation', () => {
-    it('returns 500 when embedding service throws an unexpected error', async () => {
+    it('returns 404 when the requested embedding model is not found', async () => {
       (requireApiToken as ReturnType<typeof vi.fn>).mockResolvedValue(MOCK_TOKEN_CONTEXT);
       (getModelByKey as ReturnType<typeof vi.fn>).mockResolvedValue(null);
       (handleEmbeddingRequest as ReturnType<typeof vi.fn>).mockRejectedValue(
@@ -209,7 +209,7 @@ describe('POST /api/client/v1/embeddings', () => {
         input: 'test',
       });
       const res = await POST(req);
-      expect(res.status).toBe(500);
+      expect(res.status).toBe(404);
     });
   });
 });

--- a/src/__tests__/unit/inference-service.test.ts
+++ b/src/__tests__/unit/inference-service.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { handleChatCompletion, handleEmbeddingRequest } from '@/lib/services/models/inferenceService';
+import {
+  handleChatCompletion,
+  handleEmbeddingRequest,
+  OutputTokenLimitError,
+} from '@/lib/services/models/inferenceService';
 
 // ---- mocks ----
 vi.mock('@/lib/services/models/modelService', () => ({
@@ -31,7 +35,11 @@ import { getModelByKey } from '@/lib/services/models/modelService';
 import { buildModelRuntime } from '@/lib/services/models/runtimeService';
 import { isSemanticCacheEnabled, lookupCache, storeInCache } from '@/lib/services/models/semanticCacheService';
 import { logModelUsage } from '@/lib/services/models/usageLogger';
-import { toOpenAIChatResponse, summarizeUsage } from '@/lib/services/models/openaiAdapter';
+import {
+  toOpenAIChatResponse,
+  toOpenAIStreamChunk,
+  summarizeUsage,
+} from '@/lib/services/models/openaiAdapter';
 
 // ---- helpers ----
 const makeLlmModel = (overrides = {}) => ({
@@ -322,6 +330,166 @@ describe('handleChatCompletion', () => {
     expect(result.stream).toBeInstanceOf(ReadableStream);
   });
 
+  it('emits requested stream usage as a final usage-only chunk', async () => {
+    (getModelByKey as ReturnType<typeof vi.fn>).mockResolvedValue(makeLlmModel());
+    const asyncIterator = (async function* () {
+      yield { content: 'Hello' };
+    })();
+    (buildModelRuntime as ReturnType<typeof vi.fn>).mockResolvedValue({
+      runtime: {
+        createChatModel: vi.fn().mockResolvedValue({
+          invoke: vi.fn(),
+          stream: vi.fn().mockResolvedValue(asyncIterator),
+        }),
+      },
+    });
+    (toOpenAIStreamChunk as ReturnType<typeof vi.fn>).mockReturnValue({
+      id: 'chatcmpl-1',
+      object: 'chat.completion.chunk',
+      choices: [{ index: 0, delta: { content: 'Hello' }, finish_reason: 'stop' }],
+      usage: {
+        prompt_tokens: 5,
+        completion_tokens: 2,
+        cached_tokens: 0,
+        total_tokens: 7,
+      },
+    });
+
+    const result = await handleChatCompletion({
+      ...BASE_PARAMS,
+      body: {
+        messages: [],
+        stream_options: { include_usage: true },
+      },
+      stream: true,
+    });
+    const body = await new Response(result.stream).text();
+    const chunks = body
+      .split('\n')
+      .filter((line) => line.startsWith('data: {'))
+      .map((line) => JSON.parse(line.slice(6)));
+
+    expect(chunks[0].usage).toBeUndefined();
+    expect(chunks.at(-1)).toMatchObject({
+      choices: [],
+      usage: { prompt_tokens: 5, completion_tokens: 2, total_tokens: 7 },
+    });
+  });
+
+  it('emits an explanatory SSE error when output budget ends without an answer', async () => {
+    (getModelByKey as ReturnType<typeof vi.fn>).mockResolvedValue(
+      makeLlmModel({ settings: { maxTokens: 512 } }),
+    );
+    const asyncIterator = (async function* () {
+      yield { content: '', response_metadata: { finish_reason: 'length' } };
+    })();
+    (buildModelRuntime as ReturnType<typeof vi.fn>).mockResolvedValue({
+      runtime: {
+        createChatModel: vi.fn().mockResolvedValue({
+          invoke: vi.fn(),
+          stream: vi.fn().mockResolvedValue(asyncIterator),
+        }),
+      },
+    });
+    (toOpenAIStreamChunk as ReturnType<typeof vi.fn>).mockReturnValue({
+      id: 'chatcmpl-limit',
+      object: 'chat.completion.chunk',
+      choices: [{ index: 0, delta: { content: '' }, finish_reason: 'length' }],
+      usage: {
+        prompt_tokens: 100,
+        completion_tokens: 512,
+        cached_tokens: 0,
+        total_tokens: 612,
+      },
+    });
+
+    const result = await handleChatCompletion({
+      ...BASE_PARAMS,
+      body: { messages: [], stream_options: { include_usage: true } },
+      stream: true,
+    });
+    const streamBody = await new Response(result.stream).text();
+    const errorLine = streamBody
+      .split('\n')
+      .find((line) => line.startsWith('data: {') && line.includes('"error"'));
+    const payload = JSON.parse(errorLine!.slice(6));
+
+    expect(payload.error).toMatchObject({
+      type: 'output_token_limit_exceeded',
+      code: 'output_token_limit_exceeded',
+      param: 'max_completion_tokens',
+    });
+    expect(payload.error.message).toContain('512 tokens');
+    expect(streamBody).not.toContain('"finish_reason":"length"');
+    expect(streamBody).not.toContain('data: [DONE]');
+  });
+
+  it('emits a normalized SSE error when a provider stream fails', async () => {
+    (getModelByKey as ReturnType<typeof vi.fn>).mockResolvedValue(makeLlmModel());
+    const providerError = Object.assign(new Error('Provider rate limit reached'), {
+      status: 429,
+      code: 'rate_limit_exceeded',
+    });
+    const asyncIterator = (async function* () {
+      yield { content: 'Partial' };
+      throw providerError;
+    })();
+    (buildModelRuntime as ReturnType<typeof vi.fn>).mockResolvedValue({
+      runtime: {
+        createChatModel: vi.fn().mockResolvedValue({
+          invoke: vi.fn(),
+          stream: vi.fn().mockResolvedValue(asyncIterator),
+        }),
+      },
+    });
+    (toOpenAIStreamChunk as ReturnType<typeof vi.fn>).mockReturnValueOnce({
+      id: 'chatcmpl-rate-limit',
+      object: 'chat.completion.chunk',
+      choices: [{ index: 0, delta: { content: 'Partial' }, finish_reason: null }],
+    });
+
+    const result = await handleChatCompletion({
+      ...BASE_PARAMS,
+      body: { messages: [] },
+      stream: true,
+    });
+    const streamBody = await new Response(result.stream).text();
+    const errorLine = streamBody
+      .split('\n')
+      .find((line) => line.startsWith('data: {') && line.includes('"error"'));
+    const payload = JSON.parse(errorLine!.slice(6));
+
+    expect(payload.error).toMatchObject({
+      message: 'Provider rate limit reached',
+      type: 'rate_limit_error',
+      code: 'rate_limit_exceeded',
+    });
+    expect(payload.request_id).toBe(result.requestId);
+    expect(streamBody).not.toContain('data: [DONE]');
+  });
+
+  it('throws an output token limit error for an empty non-streaming length result', async () => {
+    (getModelByKey as ReturnType<typeof vi.fn>).mockResolvedValue(
+      makeLlmModel({ settings: { maxTokens: 512 } }),
+    );
+    (buildModelRuntime as ReturnType<typeof vi.fn>).mockResolvedValue({
+      runtime: makeChatRuntime({
+        content: '',
+        tool_calls: [],
+        response_metadata: { finish_reason: 'length' },
+      }),
+    });
+
+    await expect(handleChatCompletion({
+      ...BASE_PARAMS,
+      body: { messages: [] },
+    })).rejects.toMatchObject({
+      name: 'OutputTokenLimitError',
+      limit: 512,
+      message: expect.stringContaining('Reasoning models'),
+    } satisfies Partial<OutputTokenLimitError>);
+  });
+
   it('throws when streaming is requested but runtime does not support it', async () => {
     (getModelByKey as ReturnType<typeof vi.fn>).mockResolvedValue(makeLlmModel());
 
@@ -380,6 +548,144 @@ describe('handleChatCompletion', () => {
       expect.any(Array),
       expect.objectContaining({ stop: ['DONE'] }),
     );
+  });
+
+  it('forwards parallel tool options and normalizes strict nested schemas', async () => {
+    (getModelByKey as ReturnType<typeof vi.fn>).mockResolvedValue(makeLlmModel());
+    const chatModel = {
+      invoke: vi.fn().mockResolvedValue({ content: '', tool_calls: [] }),
+    };
+    const createChatModel = vi.fn().mockResolvedValue(chatModel);
+    (buildModelRuntime as ReturnType<typeof vi.fn>).mockResolvedValue({
+      runtime: { createChatModel },
+    });
+
+    await handleChatCompletion({
+      ...BASE_PARAMS,
+      body: {
+        messages: [],
+        strict: true,
+        parallel_tool_calls: true,
+        tools: [{
+          type: 'function',
+          function: {
+            name: 'lookup',
+            parameters: {
+              type: 'object',
+              properties: {
+                filters: {
+                  type: 'array',
+                  items: {
+                    type: 'object',
+                    properties: { key: { type: 'string' } },
+                  },
+                },
+              },
+            },
+          },
+        }],
+      },
+    });
+
+    expect(chatModel.invoke).toHaveBeenCalledWith(
+      expect.any(Array),
+      expect.objectContaining({
+        strict: true,
+        parallel_tool_calls: true,
+        tools: [expect.objectContaining({
+          function: expect.objectContaining({
+            strict: true,
+            parameters: expect.objectContaining({
+              additionalProperties: false,
+              properties: {
+                filters: expect.objectContaining({
+                  items: expect.objectContaining({
+                    additionalProperties: false,
+                  }),
+                }),
+              },
+            }),
+          }),
+        })],
+      }),
+    );
+  });
+
+  it('disables provider streaming only for streamed tool calls', async () => {
+    (getModelByKey as ReturnType<typeof vi.fn>).mockResolvedValue(makeLlmModel());
+    const createChatModel = vi.fn().mockResolvedValue({
+      invoke: vi.fn().mockResolvedValue({
+        content: '',
+        tool_calls: [{
+          id: 'call_lookup',
+          name: 'lookup',
+          args: {},
+          type: 'tool_call',
+        }],
+        response_metadata: { finish_reason: 'tool_calls' },
+      }),
+      stream: vi.fn().mockResolvedValue((async function* () {
+        yield { content: '' };
+      })()),
+    });
+    (buildModelRuntime as ReturnType<typeof vi.fn>).mockResolvedValue({
+      runtime: { createChatModel },
+    });
+
+    await handleChatCompletion({
+      ...BASE_PARAMS,
+      body: {
+        messages: [],
+        tools: [{
+          type: 'function',
+          function: { name: 'lookup', parameters: { type: 'object' } },
+        }],
+      },
+      stream: true,
+    });
+
+    expect(createChatModel).toHaveBeenCalledWith(
+      expect.objectContaining({
+        options: { streaming: true, disableStreaming: true },
+      }),
+    );
+  });
+
+  it('emits an explanatory SSE error for an empty eager tool result', async () => {
+    (getModelByKey as ReturnType<typeof vi.fn>).mockResolvedValue(
+      makeLlmModel({ settings: { maxTokens: 512 } }),
+    );
+    const stream = vi.fn();
+    (buildModelRuntime as ReturnType<typeof vi.fn>).mockResolvedValue({
+      runtime: {
+        createChatModel: vi.fn().mockResolvedValue({
+          invoke: vi.fn().mockResolvedValue({
+            content: '',
+            tool_calls: [],
+            response_metadata: { finish_reason: 'length' },
+          }),
+          stream,
+        }),
+      },
+    });
+
+    const result = await handleChatCompletion({
+      ...BASE_PARAMS,
+      body: {
+        messages: [],
+        tools: [{
+          type: 'function',
+          function: { name: 'lookup', parameters: { type: 'object' } },
+        }],
+      },
+      stream: true,
+    });
+    const streamBody = await new Response(result.stream).text();
+
+    expect(streamBody).toContain('"code":"output_token_limit_exceeded"');
+    expect(streamBody).toContain('512 tokens');
+    expect(streamBody).not.toContain('"finish_reason":"length"');
+    expect(stream).not.toHaveBeenCalled();
   });
 });
 

--- a/src/__tests__/unit/openai-adapter.test.ts
+++ b/src/__tests__/unit/openai-adapter.test.ts
@@ -119,6 +119,40 @@ describe('toOpenAIChatResponse', () => {
     expect(result.usage.total_tokens).toBe(15);
   });
 
+  it('preserves GPT-5 reasoning usage from LangChain metadata', () => {
+    const msg = new AIMessage({
+      content: '',
+      response_metadata: {
+        usage: {
+          prompt_tokens: 932,
+          completion_tokens: 512,
+          total_tokens: 1444,
+          prompt_tokens_details: { cached_tokens: 0 },
+          completion_tokens_details: { reasoning_tokens: 512 },
+        },
+        finish_reason: 'length',
+      },
+      usage_metadata: {
+        input_tokens: 932,
+        output_tokens: 512,
+        total_tokens: 1444,
+        input_token_details: { cache_read: 0 },
+        output_token_details: { reasoning: 512 },
+      },
+    });
+
+    const result = toOpenAIChatResponse(msg, baseOptions);
+
+    expect(result.usage).toMatchObject({
+      prompt_tokens: 932,
+      completion_tokens: 512,
+      total_tokens: 1444,
+      prompt_tokens_details: { cached_tokens: 0 },
+      completion_tokens_details: { reasoning_tokens: 512 },
+    });
+    expect(result.choices[0].finish_reason).toBe('length');
+  });
+
   it('sets usage counts to 0 when no token metadata', () => {
     const msg = makeAIMessage('ok');
     const result = toOpenAIChatResponse(msg, baseOptions);
@@ -192,6 +226,130 @@ describe('toOpenAIStreamChunk', () => {
     expect(result.usage).toBeUndefined();
   });
 
+  it('uses stable completion metadata supplied by the stream owner', () => {
+    const options = {
+      model: 'gpt-5',
+      stream: true,
+      completionId: 'chatcmpl_stable',
+      created: 1234567890,
+    };
+
+    const first = toOpenAIStreamChunk(
+      new AIMessageChunk({ content: 'one' }),
+      options,
+    );
+    const second = toOpenAIStreamChunk(
+      new AIMessageChunk({ content: 'two' }),
+      options,
+    );
+
+    expect(first.id).toBe('chatcmpl_stable');
+    expect(second.id).toBe(first.id);
+    expect(first.created).toBe(1234567890);
+    expect(second.created).toBe(first.created);
+  });
+
+  it('preserves incremental tool call arguments and index', () => {
+    const first = toOpenAIStreamChunk(
+      new AIMessageChunk({
+        content: '',
+        tool_call_chunks: [{
+          id: 'call_weather',
+          name: 'get_weather',
+          args: '{"city":',
+          index: 0,
+          type: 'tool_call_chunk',
+        }],
+      }),
+      { model: 'gpt-5' },
+    );
+    const second = toOpenAIStreamChunk(
+      new AIMessageChunk({
+        content: '',
+        tool_call_chunks: [{
+          args: '"Ankara"}',
+          index: 0,
+          type: 'tool_call_chunk',
+        }],
+      }),
+      { model: 'gpt-5' },
+    );
+
+    expect(first.choices[0].delta.tool_calls).toEqual([{
+      index: 0,
+      id: 'call_weather',
+      type: 'function',
+      function: {
+        name: 'get_weather',
+        arguments: '{"city":',
+      },
+    }]);
+    expect(second.choices[0].delta.tool_calls).toEqual([{
+      index: 0,
+      function: { arguments: '"Ankara"}' },
+    }]);
+  });
+
+  it('prefers raw OpenAI tool deltas over parsed tool calls', () => {
+    const chunk = new AIMessageChunk({
+      content: '',
+      additional_kwargs: {
+        tool_calls: [{
+          index: 0,
+          id: 'call_weather',
+          type: 'function',
+          function: {
+            name: 'get_weather',
+            arguments: '{"city":"Ankara"}',
+          },
+        }],
+      },
+      tool_calls: [{
+        id: 'call_weather',
+        name: 'get_weather',
+        args: {},
+        type: 'tool_call',
+      }],
+    });
+
+    const result = toOpenAIStreamChunk(chunk, { model: 'gpt-5' });
+
+    expect(result.choices[0].delta.tool_calls).toEqual([{
+      index: 0,
+      id: 'call_weather',
+      type: 'function',
+      function: {
+        name: 'get_weather',
+        arguments: '{"city":"Ankara"}',
+      },
+    }]);
+  });
+
+  it('includes reasoning token details in the final usage chunk', () => {
+    const chunk = new AIMessageChunk({
+      content: '',
+      response_metadata: {
+        usage: {
+          prompt_tokens: 932,
+          completion_tokens: 512,
+          total_tokens: 1444,
+          completion_tokens_details: { reasoning_tokens: 512 },
+        },
+        finish_reason: 'length',
+      },
+    });
+
+    const result = toOpenAIStreamChunk(chunk, { model: 'gpt-5' });
+
+    expect(result.usage).toMatchObject({
+      prompt_tokens: 932,
+      completion_tokens: 512,
+      total_tokens: 1444,
+      completion_tokens_details: { reasoning_tokens: 512 },
+    });
+    expect(result.choices[0].finish_reason).toBe('length');
+  });
+
   it('surfaces reasoning_content from additional_kwargs in the delta', () => {
     const chunk = new AIMessageChunk({
       content: '',
@@ -253,6 +411,28 @@ describe('summarizeUsage', () => {
     const msg = makeAIMessage('x', { promptTokens: 7, completionTokens: 3 });
     const usage = summarizeUsage(msg);
     expect(usage.totalTokens).toBe(10);
+  });
+
+  it('reads normalized LangChain usage_metadata', () => {
+    const msg = new AIMessage({
+      content: '',
+      usage_metadata: {
+        input_tokens: 932,
+        output_tokens: 512,
+        total_tokens: 1444,
+        input_token_details: { cache_read: 12 },
+        output_token_details: { reasoning: 512 },
+      },
+    });
+
+    expect(summarizeUsage(msg)).toMatchObject({
+      inputTokens: 932,
+      outputTokens: 512,
+      cachedInputTokens: 12,
+      totalTokens: 1444,
+      promptTokensDetails: { cache_read: 12, cached_tokens: 12 },
+      completionTokensDetails: { reasoning: 512, reasoning_tokens: 512 },
+    });
   });
 });
 

--- a/src/__tests__/unit/openai-errors.test.ts
+++ b/src/__tests__/unit/openai-errors.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from 'vitest';
+import {
+  normalizeInferenceError,
+  OutputTokenLimitError,
+} from '@/lib/services/models/openaiErrors';
+
+describe('normalizeInferenceError', () => {
+  it('normalizes output token exhaustion', () => {
+    expect(normalizeInferenceError(new OutputTokenLimitError(512))).toEqual({
+      status: 422,
+      error: {
+        message: expect.stringContaining('512 tokens'),
+        type: 'output_token_limit_exceeded',
+        param: 'max_completion_tokens',
+        code: 'output_token_limit_exceeded',
+      },
+    });
+  });
+
+  it('reads nested provider context-length details', () => {
+    const error = {
+      response: {
+        status: 400,
+        data: {
+          error: {
+            message: 'Maximum context length is 8192 tokens',
+            code: 'context_length_exceeded',
+            param: 'messages',
+          },
+        },
+      },
+    };
+
+    expect(normalizeInferenceError(error)).toEqual({
+      status: 400,
+      error: {
+        message: 'Maximum context length is 8192 tokens',
+        type: 'invalid_request_error',
+        param: 'messages',
+        code: 'context_length_exceeded',
+      },
+    });
+  });
+
+  it('normalizes provider quota errors', () => {
+    const error = Object.assign(new Error('You exceeded your current quota'), {
+      status: 429,
+      code: 'insufficient_quota',
+    });
+
+    expect(normalizeInferenceError(error)).toMatchObject({
+      status: 429,
+      error: {
+        type: 'rate_limit_error',
+        code: 'insufficient_quota',
+      },
+    });
+  });
+
+  it('does not expose provider credentials in authentication errors', () => {
+    const error = Object.assign(new Error('Unauthorized for Bearer sk-secretvalue123'), {
+      status: 401,
+    });
+
+    expect(normalizeInferenceError(error)).toEqual({
+      status: 401,
+      error: {
+        message: 'Model provider authentication failed. Verify the configured provider credentials.',
+        type: 'authentication_error',
+        code: 'invalid_api_key',
+      },
+    });
+  });
+
+  it('redacts provider-specific secrets from returned messages', () => {
+    const error = new Error(
+      'Request failed with api_key=AIza1234567890abcdefghijklmnop and session_token:abc123secret',
+    );
+
+    const result = normalizeInferenceError(error);
+
+    expect(result.error.message).not.toContain('AIza1234567890abcdefghijklmnop');
+    expect(result.error.message).not.toContain('abc123secret');
+    expect(result.error.message).toContain('[REDACTED]');
+  });
+
+  it('reads provider error details nested in arrays', () => {
+    const error = {
+      response: {
+        status: 400,
+        data: {
+          errors: [{
+            message: 'Prompt exceeds the context window',
+            code: 'context_length_exceeded',
+          }],
+        },
+      },
+    };
+
+    expect(normalizeInferenceError(error)).toMatchObject({
+      status: 400,
+      error: {
+        message: 'Prompt exceeds the context window',
+        type: 'invalid_request_error',
+        code: 'context_length_exceeded',
+      },
+    });
+  });
+
+  it('distinguishes provider timeout and availability failures', () => {
+    expect(normalizeInferenceError(new Error('Request timed out after 30s'))).toMatchObject({
+      status: 504,
+      error: { type: 'server_error', code: 'provider_timeout' },
+    });
+    expect(normalizeInferenceError(new Error('APIConnectionError: ECONNREFUSED'))).toMatchObject({
+      status: 503,
+      error: { type: 'server_error', code: 'provider_unavailable' },
+    });
+  });
+
+  it('maps invalid input and missing models to client errors', () => {
+    expect(normalizeInferenceError(new Error('`messages` array is required'))).toMatchObject({
+      status: 400,
+      error: { type: 'invalid_request_error', code: 'invalid_request' },
+    });
+    expect(normalizeInferenceError(new Error('Model not found: missing-model'))).toMatchObject({
+      status: 404,
+      error: { type: 'not_found_error', code: 'model_not_found', param: 'model' },
+    });
+  });
+
+  it('keeps unknown errors structured', () => {
+    expect(normalizeInferenceError(new Error('Unexpected provider response'))).toEqual({
+      status: 500,
+      error: {
+        message: 'Unexpected provider response',
+        type: 'server_error',
+        code: 'inference_error',
+      },
+    });
+  });
+});

--- a/src/app/dashboard/models/[id]/edit/page.tsx
+++ b/src/app/dashboard/models/[id]/edit/page.tsx
@@ -77,7 +77,7 @@ interface ModelDetailDto {
     supportsStructuredOutputs?: boolean;
   };
   pricing: ModelPricing;
-  settings: Record<string, string>;
+  settings: Record<string, string | number | boolean | null>;
   semanticCache?: SemanticCacheConfig;
   inputGuardrailKey?: string;
   outputGuardrailKey?: string;
@@ -112,7 +112,7 @@ interface FormValues {
     outputTokenPer1M: number;
     cachedTokenPer1M: number;
   };
-  settings: Record<string, string>;
+  settings: Record<string, string | number | boolean | null>;
   isMultimodal: boolean;
   supportsToolCalls: boolean;
   contextWindow: number | '';
@@ -252,10 +252,7 @@ export default function EditModelPage() {
       const nextModel: ModelDetailDto = modelData.model;
       setModel(nextModel);
 
-      const settings = Object.entries(nextModel.settings || {}).reduce<Record<string, string>>((acc, [key, value]) => {
-        acc[key] = typeof value === 'string' ? value : JSON.stringify(value);
-        return acc;
-      }, {});
+      const settings = { ...nextModel.settings };
 
       const cache = nextModel.semanticCache;
 
@@ -621,7 +618,7 @@ export default function EditModelPage() {
             </Paper>
 
             <Grid>
-              <Grid.Col span={{ base: 12, md: 6 }}>
+              <Grid.Col span={{ base: 12, md: 4 }}>
                 <NumberInput
                   label={tWizard('fields.contextWindow.label')}
                   description={tWizard('fields.contextWindow.description')}
@@ -631,7 +628,7 @@ export default function EditModelPage() {
                   {...form.getInputProps('contextWindow')}
                 />
               </Grid.Col>
-              <Grid.Col span={{ base: 12, md: 6 }}>
+              <Grid.Col span={{ base: 12, md: 4 }}>
                 <NumberInput
                   label={tWizard('fields.maxOutputTokens.label')}
                   description={tWizard('fields.maxOutputTokens.description')}
@@ -639,6 +636,16 @@ export default function EditModelPage() {
                   step={1024}
                   thousandSeparator=","
                   {...form.getInputProps('maxOutputTokens')}
+                />
+              </Grid.Col>
+              <Grid.Col span={{ base: 12, md: 4 }}>
+                <NumberInput
+                  label={tWizard('fields.runtimeMaxTokens.label')}
+                  description={tWizard('fields.runtimeMaxTokens.description')}
+                  min={1}
+                  step={1024}
+                  thousandSeparator=","
+                  {...form.getInputProps('settings.maxTokens')}
                 />
               </Grid.Col>
             </Grid>

--- a/src/lib/i18n/messages/en.ts
+++ b/src/lib/i18n/messages/en.ts
@@ -1174,6 +1174,10 @@ export const en = {
         description: 'Maximum generated tokens; must not exceed the context window.',
         placeholder: 'e.g. 16384',
       },
+      runtimeMaxTokens: {
+        label: 'Default max tokens',
+        description: 'Runtime output limit used when the request does not provide one.',
+      },
     },
     review: {
       title: 'Review configuration',

--- a/src/lib/i18n/messages/tr.ts
+++ b/src/lib/i18n/messages/tr.ts
@@ -39,6 +39,10 @@ export const tr: typeof en = {
           'Üretilebilecek maksimum token sayısı; bağlam penceresini aşmamalıdır.',
         placeholder: 'ör. 16384',
       },
+      runtimeMaxTokens: {
+        label: 'Varsayılan maksimum token',
+        description: 'İstekte belirtilmediğinde kullanılan çalışma zamanı çıktı sınırı.',
+      },
     },
     review: {
       ...en.modelWizard.review,

--- a/src/lib/providers/contracts/modelContracts.ts
+++ b/src/lib/providers/contracts/modelContracts.ts
@@ -183,6 +183,7 @@ export const OpenAiModelProviderContract: ProviderContract<ModelProviderRuntime,
           maxTokens: overrides.maxTokens,
           reasoning: overrides.reasoning,
           streaming: config.options?.streaming ?? false,
+          disableStreaming: config.options?.disableStreaming ?? false,
         });
       },
       createEmbeddingModel: (config) =>
@@ -329,6 +330,7 @@ export const OpenAiCompatibleModelProviderContract: ProviderContract<ModelProvid
           maxTokens: overrides.maxTokens,
           reasoning: overrides.reasoning,
           streaming: config.options?.streaming ?? false,
+          disableStreaming: config.options?.disableStreaming ?? false,
         });
       },
       createEmbeddingModel: (config) =>
@@ -414,6 +416,7 @@ export const TogetherModelProviderContract: ProviderContract<ModelProviderRuntim
           temperature: overrides.temperature,
           maxTokens: overrides.maxTokens,
           streaming: config.options?.streaming ?? false,
+          disableStreaming: config.options?.disableStreaming ?? false,
         });
       },
       createEmbeddingModel: (config) =>

--- a/src/lib/providers/domains/model.ts
+++ b/src/lib/providers/domains/model.ts
@@ -6,6 +6,7 @@ export type ModelRuntimeCategory = ModelCategory;
 
 export interface ModelRuntimeOptions {
   streaming?: boolean;
+  disableStreaming?: boolean;
 }
 
 export interface ModelRuntimeConfig {

--- a/src/lib/services/models/inferenceService.ts
+++ b/src/lib/services/models/inferenceService.ts
@@ -2,7 +2,7 @@ import crypto from 'crypto';
 import { createLogger } from '@/lib/core/logger';
 import { withResilience } from '@/lib/core/resilience';
 import { fireAndForget } from '@/lib/core/asyncTask';
-import type { AIMessage, AIMessageChunk } from '@langchain/core/messages';
+import { AIMessageChunk, type AIMessage } from '@langchain/core/messages';
 
 const logger = createLogger('inference');
 import { IModel } from '@/lib/database';
@@ -23,6 +23,12 @@ import {
   toOpenAIStreamChunk,
   summarizeUsage,
 } from './openaiAdapter';
+import {
+  normalizeInferenceError,
+  OutputTokenLimitError,
+} from './openaiErrors';
+
+export { OutputTokenLimitError } from './openaiErrors';
 
 import { logModelUsage, TokenUsage } from './usageLogger';
 import {
@@ -301,6 +307,13 @@ function buildOverrides(body: Record<string, unknown>) {
   if (body.stop !== undefined) overrides.stop = body.stop;
   if (body.tools !== undefined) overrides.tools = body.tools;
   if (body.tool_choice !== undefined) overrides.tool_choice = body.tool_choice;
+  if (body.parallel_tool_calls !== undefined) {
+    overrides.parallel_tool_calls = body.parallel_tool_calls;
+  }
+  if (body.strict !== undefined) overrides.strict = body.strict;
+  if (body.stream_options !== undefined) {
+    overrides.stream_options = body.stream_options;
+  }
   if (body.response_format !== undefined)
     overrides.response_format = body.response_format;
   if (body.modality !== undefined) overrides.modality = body.modality;
@@ -363,12 +376,73 @@ function buildChatModelSettings(
   return settings;
 }
 
+function normalizeStrictJsonSchema(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(normalizeStrictJsonSchema);
+  }
+
+  if (!value || typeof value !== 'object') {
+    return value;
+  }
+
+  const schema = Object.fromEntries(
+    Object.entries(value as Record<string, unknown>).map(([key, nestedValue]) => [
+      key,
+      normalizeStrictJsonSchema(nestedValue),
+    ]),
+  );
+
+  if (schema.type === 'object' || schema.properties) {
+    schema.additionalProperties = false;
+  }
+
+  return schema;
+}
+
+function normalizeTools(tools: unknown, strictOverride: unknown): unknown {
+  if (!Array.isArray(tools)) {
+    return tools;
+  }
+
+  return tools.map((tool) => {
+    if (!tool || typeof tool !== 'object') {
+      return tool;
+    }
+
+    const normalizedTool = { ...(tool as Record<string, unknown>) };
+    if (!normalizedTool.function || typeof normalizedTool.function !== 'object') {
+      return normalizedTool;
+    }
+
+    const fn = { ...(normalizedTool.function as Record<string, unknown>) };
+    const strict = typeof strictOverride === 'boolean' ? strictOverride : fn.strict;
+    if (strict === true) {
+      fn.strict = true;
+      if (fn.parameters !== undefined) {
+        fn.parameters = normalizeStrictJsonSchema(fn.parameters);
+      }
+    }
+
+    normalizedTool.function = fn;
+    return normalizedTool;
+  });
+}
+
 function buildChatCallOptions(overrides: Record<string, unknown>) {
   const options: Record<string, unknown> = {};
 
   if (overrides.stop !== undefined) options.stop = overrides.stop;
-  if (overrides.tools !== undefined) options.tools = overrides.tools;
+  if (overrides.tools !== undefined) {
+    options.tools = normalizeTools(overrides.tools, overrides.strict);
+  }
   if (overrides.tool_choice !== undefined) options.tool_choice = overrides.tool_choice;
+  if (overrides.parallel_tool_calls !== undefined) {
+    options.parallel_tool_calls = overrides.parallel_tool_calls;
+  }
+  if (overrides.strict !== undefined) options.strict = overrides.strict;
+  if (overrides.stream_options !== undefined) {
+    options.stream_options = overrides.stream_options;
+  }
   if (overrides.response_format !== undefined) {
     options.response_format = overrides.response_format;
   }
@@ -383,6 +457,22 @@ function buildChatCallOptions(overrides: Record<string, unknown>) {
   }
 
   return options;
+}
+
+function resolveOutputTokenLimit(
+  overrides: Record<string, unknown>,
+  modelSettings: Record<string, unknown>,
+): number | undefined {
+  const candidates = [
+    overrides.max_completion_tokens,
+    overrides.max_tokens,
+    modelSettings.maxCompletionTokens,
+    modelSettings.maxTokens,
+  ];
+
+  return candidates.find(
+    (value): value is number => typeof value === 'number' && Number.isFinite(value),
+  );
 }
 
 function ensureLlmModel(model: IModel) {
@@ -739,29 +829,68 @@ export async function handleChatCompletion(params: {
   const overrides = buildOverrides(body);
   const modelSettings = buildChatModelSettings(model.settings, overrides);
   const callOptions = buildChatCallOptions(overrides);
+  const outputTokenLimit = resolveOutputTokenLimit(overrides, modelSettings);
+  const disableProviderStreaming = Boolean(
+    stream && Array.isArray(overrides.tools) && overrides.tools.length > 0,
+  );
+  const includeStreamUsage =
+    asRecord(overrides.stream_options).include_usage === true;
+
+  if (disableProviderStreaming) {
+    delete callOptions.stream_options;
+  }
 
   const chatModel = ensureChatRunnable(await runtime.createChatModel({
     modelId: model.modelId,
     category: model.category,
     modelSettings,
-    options: { streaming: Boolean(stream) },
+    options: {
+      streaming: Boolean(stream),
+      disableStreaming: disableProviderStreaming,
+    },
   }));
 
   if (stream) {
-    if (typeof chatModel.stream !== 'function') {
+    if (!disableProviderStreaming && typeof chatModel.stream !== 'function') {
       throw new Error('Model provider does not support streaming responses');
     }
 
-    const asyncIterator = await withResilience(
-      () => chatModel.stream!(messages, callOptions) as Promise<AsyncIterable<AIMessageChunk>>,
-      { key: `chat-stream:${model.providerKey}` },
-    );
+    let asyncIterator: AsyncIterable<AIMessageChunk>;
+    if (disableProviderStreaming) {
+      const eagerMessage = await withResilience(
+        () => chatModel.invoke(messages, callOptions),
+        { key: `chat:${model.providerKey}` },
+      );
+      asyncIterator = (async function* () {
+        yield new AIMessageChunk({
+          content: eagerMessage.content,
+          additional_kwargs: eagerMessage.additional_kwargs,
+          response_metadata: eagerMessage.response_metadata,
+          id: eagerMessage.id,
+          name: eagerMessage.name,
+          usage_metadata: eagerMessage.usage_metadata,
+          tool_calls: eagerMessage.tool_calls,
+          invalid_tool_calls: eagerMessage.invalid_tool_calls,
+        });
+      })();
+    } else {
+      asyncIterator = await withResilience(
+        () => chatModel.stream!(messages, callOptions) as Promise<AsyncIterable<AIMessageChunk>>,
+        { key: `chat-stream:${model.providerKey}` },
+      );
+    }
     const startedAt = Date.now();
+    const completionId = `chatcmpl_${crypto.randomUUID()}`;
+    const completionCreated = Math.floor(Date.now() / 1000);
 
     const readable = new ReadableStream<Uint8Array>({
       async start(controller) {
         let aggregatedChunk: AIMessageChunk | null = null;
         let lastUsage: TokenUsage | undefined;
+        let finalUsagePayload: Record<string, unknown> | undefined;
+        let terminalFinishReason: string | undefined;
+        let hasFinalOutput = false;
+        let outputLimitError: OutputTokenLimitError | null = null;
         const toolCalls: ToolCallPayload[] = [];
 
         try {
@@ -780,7 +909,23 @@ export async function handleChatCompletion(params: {
             const payload = toOpenAIStreamChunk(chunk, {
               model: model.modelId,
               stream: true,
+              completionId,
+              created: completionCreated,
             });
+            const choice = payload.choices[0];
+            if (typeof choice?.finish_reason === 'string') {
+              terminalFinishReason = choice.finish_reason;
+            }
+            const delta = choice?.delta as Record<string, unknown> | undefined;
+            if (
+              guardrailContentToText(delta?.content).trim()
+              || (Array.isArray(delta?.tool_calls) && delta.tool_calls.length > 0)
+            ) {
+              hasFinalOutput = true;
+            }
+            if (terminalFinishReason === 'length' && !hasFinalOutput) {
+              outputLimitError = new OutputTokenLimitError(outputTokenLimit);
+            }
 
             if (payload.usage) {
               lastUsage = {
@@ -789,14 +934,45 @@ export async function handleChatCompletion(params: {
                 cachedInputTokens: payload.usage.cached_tokens,
                 totalTokens: payload.usage.total_tokens,
               };
+              if (includeStreamUsage) {
+                finalUsagePayload = payload.usage;
+                payload.usage = undefined;
+              }
             }
 
+            if (!outputLimitError) {
+              controller.enqueue(
+                encoder.encode(`data: ${JSON.stringify(payload)}\n\n`),
+              );
+            }
+          }
+
+          if (outputLimitError) {
+            const normalizedError = normalizeInferenceError(outputLimitError);
             controller.enqueue(
-              encoder.encode(`data: ${JSON.stringify(payload)}\n\n`),
+              encoder.encode(`data: ${JSON.stringify({
+                error: normalizedError.error,
+                request_id: requestId,
+              })}\n\n`),
             );
           }
 
-          controller.enqueue(encoder.encode('data: [DONE]\n\n'));
+          if (!outputLimitError && includeStreamUsage && finalUsagePayload) {
+            controller.enqueue(
+              encoder.encode(`data: ${JSON.stringify({
+                id: completionId,
+                object: 'chat.completion.chunk',
+                created: completionCreated,
+                model: model.modelId,
+                choices: [],
+                usage: finalUsagePayload,
+              })}\n\n`),
+            );
+          }
+
+          if (!outputLimitError) {
+            controller.enqueue(encoder.encode('data: [DONE]\n\n'));
+          }
           controller.close();
 
           const latencyMs = Date.now() - startedAt;
@@ -815,7 +991,7 @@ export async function handleChatCompletion(params: {
             logModelUsage(tenantDbName, model, {
               requestId,
               route: 'chat.completions',
-              status: 'success',
+              status: outputLimitError ? 'error' : 'success',
               providerRequest: sanitizeForLogging({
                 model: modelKey,
                 messages: body.messages,
@@ -823,6 +999,7 @@ export async function handleChatCompletion(params: {
                 stream: true,
               }),
               providerResponse: sanitizeForLogging(providerResponse),
+              errorMessage: outputLimitError?.message,
               latencyMs,
               usage,
             }),
@@ -852,7 +1029,8 @@ export async function handleChatCompletion(params: {
           }
         } catch (error: unknown) {
           const latencyMs = Date.now() - startedAt;
-          const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+          const normalizedError = normalizeInferenceError(error);
+          const errorMessage = normalizedError.error.message;
           fireAndForget('log-stream-error', () =>
             logModelUsage(tenantDbName, model, {
               requestId,
@@ -871,7 +1049,13 @@ export async function handleChatCompletion(params: {
             }),
           );
 
-          controller.error(error);
+          controller.enqueue(
+            encoder.encode(`data: ${JSON.stringify({
+              error: normalizedError.error,
+              request_id: requestId,
+            })}\n\n`),
+          );
+          controller.close();
         }
       },
     });
@@ -889,6 +1073,14 @@ export async function handleChatCompletion(params: {
     model: model.modelId,
     stream: false,
   });
+
+  if (
+    aiMessage.response_metadata?.finish_reason === 'length'
+    && !guardrailContentToText(aiMessage.content).trim()
+    && getToolCallCount(aiMessage) === 0
+  ) {
+    throw new OutputTokenLimitError(outputTokenLimit);
+  }
 
   const usage = summarizeUsage(aiMessage) as TokenUsage;
   const toolCallCount = getToolCallCount(aiMessage);

--- a/src/lib/services/models/openaiAdapter.ts
+++ b/src/lib/services/models/openaiAdapter.ts
@@ -56,9 +56,21 @@ interface OpenAIToolCall {
   };
 }
 
+interface OpenAIStreamToolCall {
+  index: number;
+  id?: string;
+  type?: 'function';
+  function: {
+    name?: string;
+    arguments: string;
+  };
+}
+
 export interface ChatTransformOptions {
   model: string;
   stream?: boolean;
+  completionId?: string;
+  created?: number;
 }
 
 function normalizeContent(
@@ -165,21 +177,25 @@ export function toLangChainMessages(messages: OpenAIMessage[]): BaseMessage[] {
 
 function extractUsage(message: AIMessage | AIMessageChunk): UsageMetrics {
   const metadata = message.response_metadata || {};
-  const usageSource =
-    metadata.tokenUsage ||
-    metadata.token_usage ||
-    metadata.usage_metadata ||
-    {};
-  const usage =
-    typeof usageSource === 'object' && usageSource !== null
-      ? (usageSource as Record<string, unknown>)
-      : {};
+  const messageUsage = (message as { usage_metadata?: unknown }).usage_metadata;
+  const usageSources = [
+    metadata.tokenUsage,
+    metadata.token_usage,
+    metadata.usage,
+    metadata.usage_metadata,
+    messageUsage,
+  ].filter(
+    (source): source is Record<string, unknown> =>
+      typeof source === 'object' && source !== null && !Array.isArray(source),
+  );
 
   const coalesceNumber = (keys: string[]): number | undefined => {
-    for (const key of keys) {
-      const value = usage[key];
-      if (typeof value === 'number') {
-        return value;
+    for (const usage of usageSources) {
+      for (const key of keys) {
+        const value = usage[key];
+        if (typeof value === 'number') {
+          return value;
+        }
       }
     }
     return undefined;
@@ -188,17 +204,19 @@ function extractUsage(message: AIMessage | AIMessageChunk): UsageMetrics {
   const coalesceDetails = (
     keys: string[],
   ): Record<string, number> | undefined => {
-    for (const key of keys) {
-      const value = usage[key];
-      if (value && typeof value === 'object' && !Array.isArray(value)) {
-        const entries = Object.entries(value as Record<string, unknown>)
-          .filter(([, detailValue]) => typeof detailValue === 'number')
-          .map(([detailKey, detailValue]) => [
-            detailKey,
-            detailValue as number,
-          ]);
-        if (entries.length) {
-          return Object.fromEntries(entries);
+    for (const usage of usageSources) {
+      for (const key of keys) {
+        const value = usage[key];
+        if (value && typeof value === 'object' && !Array.isArray(value)) {
+          const entries = Object.entries(value as Record<string, unknown>)
+            .filter(([, detailValue]) => typeof detailValue === 'number')
+            .map(([detailKey, detailValue]) => [
+              detailKey,
+              detailValue as number,
+            ]);
+          if (entries.length) {
+            return Object.fromEntries(entries);
+          }
         }
       }
     }
@@ -235,6 +253,7 @@ function extractUsage(message: AIMessage | AIMessageChunk): UsageMetrics {
     'prompt_tokens_details',
     'promptTokensDetail',
     'prompt_tokens_detail',
+    'input_token_details',
   ]);
 
   const completionTokensDetails = coalesceDetails([
@@ -242,15 +261,35 @@ function extractUsage(message: AIMessage | AIMessageChunk): UsageMetrics {
     'completion_tokens_details',
     'completionTokensDetail',
     'completion_tokens_detail',
+    'output_token_details',
   ]);
+
+  const normalizedPromptTokensDetails = promptTokensDetails
+    ? {
+        ...promptTokensDetails,
+        ...(promptTokensDetails.cache_read !== undefined
+          ? { cached_tokens: promptTokensDetails.cache_read }
+          : {}),
+      }
+    : undefined;
+  const normalizedCompletionTokensDetails = completionTokensDetails
+    ? {
+        ...completionTokensDetails,
+        ...(completionTokensDetails.reasoning !== undefined
+          ? { reasoning_tokens: completionTokensDetails.reasoning }
+          : {}),
+      }
+    : undefined;
+
+  const nestedCachedTokens = normalizedPromptTokensDetails?.cached_tokens;
 
   return {
     inputTokens,
     outputTokens,
-    cachedInputTokens,
+    cachedInputTokens: cachedInputTokens ?? nestedCachedTokens,
     totalTokens,
-    promptTokensDetails,
-    completionTokensDetails,
+    promptTokensDetails: normalizedPromptTokensDetails,
+    completionTokensDetails: normalizedCompletionTokensDetails,
   };
 }
 
@@ -393,16 +432,26 @@ export function toOpenAIStreamChunk(
     delta.reasoning = reasoning;
   }
 
-  const chunkWithTools = chunk as AIMessageChunk & { tool_calls?: unknown };
-  const normalizedToolCalls = normalizeToolCalls(chunkWithTools.tool_calls);
+  const chunkWithTools = chunk as AIMessageChunk & {
+    tool_calls?: unknown;
+    tool_call_chunks?: unknown;
+  };
+  const additional =
+    chunk.additional_kwargs && typeof chunk.additional_kwargs === 'object'
+      ? chunk.additional_kwargs as Record<string, unknown>
+      : {};
+  const normalizedToolCalls =
+    normalizeRawStreamToolCalls(additional.tool_calls)
+    ?? normalizeToolCallChunks(chunkWithTools.tool_call_chunks)
+    ?? normalizeToolCalls(chunkWithTools.tool_calls);
   if (normalizedToolCalls) {
     delta.tool_calls = normalizedToolCalls;
   }
 
   return {
-    id: `chatcmpl_${crypto.randomUUID()}`,
+    id: options.completionId || `chatcmpl_${crypto.randomUUID()}`,
     object: 'chat.completion.chunk',
-    created: Math.floor(Date.now() / 1000),
+    created: options.created ?? Math.floor(Date.now() / 1000),
     model: options.model,
     choices: [
       {
@@ -411,12 +460,18 @@ export function toOpenAIStreamChunk(
         finish_reason: chunk.response_metadata?.finish_reason || null,
       },
     ],
-    usage: usage.totalTokens
+    usage: usage.totalTokens !== undefined
       ? {
           prompt_tokens: usage.inputTokens ?? 0,
           completion_tokens: usage.outputTokens ?? 0,
           cached_tokens: usage.cachedInputTokens ?? 0,
           total_tokens: usage.totalTokens,
+          ...(usage.promptTokensDetails
+            ? { prompt_tokens_details: usage.promptTokensDetails }
+            : {}),
+          ...(usage.completionTokensDetails
+            ? { completion_tokens_details: usage.completionTokensDetails }
+            : {}),
         }
       : undefined,
   };
@@ -492,6 +547,77 @@ function normalizeToolCalls(
       function: {
         name: nameCandidate,
         arguments: argsString,
+      },
+    };
+  });
+}
+
+function normalizeToolCallChunks(
+  rawToolCallChunks: unknown,
+): OpenAIStreamToolCall[] | undefined {
+  if (!Array.isArray(rawToolCallChunks) || rawToolCallChunks.length === 0) {
+    return undefined;
+  }
+
+  return rawToolCallChunks.map((entry, position) => {
+    const chunk = entry && typeof entry === 'object'
+      ? entry as Record<string, unknown>
+      : {};
+    const id = typeof chunk.id === 'string' && chunk.id.length > 0
+      ? chunk.id
+      : undefined;
+    const name = typeof chunk.name === 'string' && chunk.name.length > 0
+      ? chunk.name
+      : undefined;
+    const index = typeof chunk.index === 'number' ? chunk.index : position;
+    const argumentsChunk = typeof chunk.args === 'string'
+      ? chunk.args
+      : serializeArguments(chunk.args);
+
+    return {
+      index,
+      ...(id ? { id, type: 'function' as const } : {}),
+      function: {
+        ...(name ? { name } : {}),
+        arguments: argumentsChunk,
+      },
+    };
+  });
+}
+
+function normalizeRawStreamToolCalls(
+  rawToolCalls: unknown,
+): OpenAIStreamToolCall[] | undefined {
+  if (!Array.isArray(rawToolCalls) || rawToolCalls.length === 0) {
+    return undefined;
+  }
+
+  return rawToolCalls.map((entry, position) => {
+    const call = entry && typeof entry === 'object'
+      ? entry as Record<string, unknown>
+      : {};
+    const fn = call.function && typeof call.function === 'object'
+      ? call.function as Record<string, unknown>
+      : {};
+    const id = typeof call.id === 'string' && call.id.length > 0
+      ? call.id
+      : undefined;
+    const name = typeof fn.name === 'string' && fn.name.length > 0
+      ? fn.name
+      : undefined;
+    const index = typeof call.index === 'number' ? call.index : position;
+    const argumentsChunk = typeof fn.arguments === 'string'
+      ? fn.arguments
+      : fn.arguments === undefined
+        ? ''
+        : serializeArguments(fn.arguments);
+
+    return {
+      index,
+      ...(id ? { id, type: 'function' as const } : {}),
+      function: {
+        ...(name ? { name } : {}),
+        arguments: argumentsChunk,
       },
     };
   });

--- a/src/lib/services/models/openaiErrors.ts
+++ b/src/lib/services/models/openaiErrors.ts
@@ -1,0 +1,200 @@
+export type OpenAIErrorBody = {
+  message: string;
+  type: string;
+  param?: string | null;
+  code?: string | null;
+};
+
+export type NormalizedOpenAIError = {
+  status: number;
+  error: OpenAIErrorBody;
+};
+
+export class OutputTokenLimitError extends Error {
+  readonly limit?: number;
+
+  constructor(limit?: number) {
+    const limitDescription = limit ? ` (${limit} tokens)` : '';
+    super(
+      `The model reached its output token limit${limitDescription} before producing a final answer or tool call. `
+      + 'Reasoning models may consume this budget internally. Increase max_completion_tokens or configure a higher model default.',
+    );
+    this.name = 'OutputTokenLimitError';
+    this.limit = limit;
+  }
+}
+
+type ErrorRecord = Record<string, unknown>;
+
+function asRecord(value: unknown): ErrorRecord | null {
+  return value !== null && typeof value === 'object' ? value as ErrorRecord : null;
+}
+
+function collectErrorRecords(error: unknown): ErrorRecord[] {
+  const records: ErrorRecord[] = [];
+  const queue: unknown[] = [error];
+  const seen = new Set<unknown>();
+
+  while (queue.length > 0 && records.length < 16) {
+    const value = queue.shift();
+    if (!value || seen.has(value)) continue;
+    seen.add(value);
+
+    const record = asRecord(value);
+    if (!record) continue;
+    records.push(record);
+    queue.push(
+      record.cause,
+      record.error,
+      record.errors,
+      record.response,
+      record.body,
+      record.data,
+      record.details,
+    );
+    for (const nested of Object.values(record)) {
+      if (Array.isArray(nested)) queue.push(...nested);
+    }
+  }
+
+  return records;
+}
+
+function firstString(records: ErrorRecord[], keys: string[]): string | undefined {
+  for (const record of records) {
+    for (const key of keys) {
+      if (typeof record[key] === 'string' && record[key]) {
+        return record[key];
+      }
+    }
+  }
+  return undefined;
+}
+
+function firstStatus(records: ErrorRecord[]): number | undefined {
+  for (const record of records) {
+    for (const key of ['status', 'statusCode', 'status_code']) {
+      const value = record[key];
+      if (typeof value === 'number' && value >= 400 && value <= 599) return value;
+    }
+  }
+  return undefined;
+}
+
+function safeMessage(message: string): string {
+  return message
+    .replace(/Bearer\s+[A-Za-z0-9._~+/=-]+/gi, 'Bearer [REDACTED]')
+    .replace(/\bsk-[A-Za-z0-9_-]{8,}\b/g, '[REDACTED]')
+    .replace(/\bAIza[A-Za-z0-9_-]{20,}\b/g, '[REDACTED]')
+    .replace(
+      /\b(api[_-]?key|access[_-]?key|authorization|credential|secret|session[_-]?token|token)\b\s*[:=]\s*["']?[^\s,"'}]+/gi,
+      '$1=[REDACTED]',
+    )
+    .slice(0, 2000);
+}
+
+function normalized(
+  status: number,
+  message: string,
+  type: string,
+  code?: string | null,
+  param?: string | null,
+): NormalizedOpenAIError {
+  return {
+    status,
+    error: {
+      message: safeMessage(message),
+      type,
+      ...(param !== undefined ? { param } : {}),
+      ...(code !== undefined ? { code } : {}),
+    },
+  };
+}
+
+export function normalizeInferenceError(error: unknown): NormalizedOpenAIError {
+  if (error instanceof OutputTokenLimitError) {
+    return normalized(
+      422,
+      error.message,
+      'output_token_limit_exceeded',
+      'output_token_limit_exceeded',
+      'max_completion_tokens',
+    );
+  }
+
+  const records = collectErrorRecords(error);
+  const rawMessage = error instanceof Error
+    ? error.message
+    : firstString(records, ['message']) || 'Inference request failed';
+  const message = safeMessage(rawMessage);
+  const status = firstStatus(records);
+  const providerCode = firstString(records, ['code']);
+  const providerType = firstString(records, ['type']);
+  const providerParam = firstString(records, ['param']);
+  const signal = [
+    error instanceof Error ? error.name : '',
+    message,
+    providerCode,
+    providerType,
+  ].filter(Boolean).join(' ').toLowerCase();
+
+  if (/output.{0,20}token.{0,20}limit/.test(signal)) {
+    return normalized(422, message, 'output_token_limit_exceeded', 'output_token_limit_exceeded', 'max_completion_tokens');
+  }
+
+  if (/context.{0,20}(length|window)|maximum context|too many tokens|prompt.{0,20}too long/.test(signal)) {
+    return normalized(400, message, 'invalid_request_error', providerCode || 'context_length_exceeded', providerParam || 'messages');
+  }
+
+  if (/content[_ ]filter|content policy|policy violation|safety.{0,20}filter/.test(signal)) {
+    return normalized(400, message, 'invalid_request_error', providerCode || 'content_policy_violation', providerParam);
+  }
+
+  if (status === 401 || /authentication|unauthorized|invalid.{0,20}api.?key/.test(signal)) {
+    return normalized(401, 'Model provider authentication failed. Verify the configured provider credentials.', 'authentication_error', providerCode || 'invalid_api_key');
+  }
+
+  if (status === 403 || /permission denied|forbidden/.test(signal)) {
+    return normalized(403, message, 'permission_error', providerCode || 'permission_denied');
+  }
+
+  if (status === 429 || /rate.?limit|too many requests|insufficient_quota|quota exceeded/.test(signal)) {
+    const code = /insufficient_quota|quota exceeded/.test(signal)
+      ? 'insufficient_quota'
+      : providerCode || 'rate_limit_exceeded';
+    return normalized(429, message, 'rate_limit_error', code, providerParam);
+  }
+
+  if (status === 408 || status === 504 || /timeout|timed out|aborterror/.test(signal)) {
+    return normalized(status === 408 ? 408 : 504, message, 'server_error', providerCode || 'provider_timeout');
+  }
+
+  if (/apiconnectionerror|econn|enotfound|fetch failed|connection (error|refused|reset)|circuit breaker/.test(signal)) {
+    return normalized(503, message, 'server_error', providerCode || 'provider_unavailable');
+  }
+
+  if (status === 404 || /model.{0,40}not found|notfounderror/.test(signal)) {
+    return normalized(404, message, 'not_found_error', providerCode || 'model_not_found', providerParam || 'model');
+  }
+
+  if (
+    status === 400
+    || /invalid_request|badrequest|is required|must be|unsupported|does not support|json schema|tool.{0,20}(invalid|schema)/.test(signal)
+  ) {
+    return normalized(400, message, 'invalid_request_error', providerCode || 'invalid_request', providerParam);
+  }
+
+  if (status === 409) {
+    return normalized(409, message, 'conflict_error', providerCode || 'conflict', providerParam);
+  }
+
+  if (status === 422) {
+    return normalized(422, message, 'unprocessable_entity_error', providerCode || 'unprocessable_entity', providerParam);
+  }
+
+  if (status && status >= 500) {
+    return normalized(status, message, 'server_error', providerCode || 'provider_error');
+  }
+
+  return normalized(500, message, 'server_error', providerCode || 'inference_error');
+}

--- a/src/server/api/plugins/client-inference.ts
+++ b/src/server/api/plugins/client-inference.ts
@@ -9,6 +9,7 @@ import {
   handleChatCompletion,
   handleEmbeddingRequest,
 } from '@/lib/services/models/inferenceService';
+import { normalizeInferenceError } from '@/lib/services/models/openaiErrors';
 import { getModelByKey } from '@/lib/services/models/modelService';
 import {
   calculateCost,
@@ -293,12 +294,14 @@ export const clientInferenceApiPlugin: FastifyPluginAsync = async (app) => {
         });
       }
 
+      const normalizedError = normalizeInferenceError(error);
+
       try {
         const model = modelKey
           ? await getModelByKey(auth.tenantDbName, modelKey, auth.projectId)
           : null;
         if (model) {
-          const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+          const errorMessage = normalizedError.error.message;
           await logModelUsage(auth.tenantDbName, model, {
             errorMessage,
             latencyMs: Date.now() - startedAt,
@@ -316,12 +319,7 @@ export const clientInferenceApiPlugin: FastifyPluginAsync = async (app) => {
         logger.error('Failed to log client chat completion error', { error: logError });
       }
 
-      return reply.code(500).send({
-        error: {
-          message: error instanceof Error ? error.message : 'Inference error',
-          type: 'server_error',
-        },
-      });
+      return reply.code(normalizedError.status).send({ error: normalizedError.error });
     }
   }));
 
@@ -450,13 +448,14 @@ export const clientInferenceApiPlugin: FastifyPluginAsync = async (app) => {
       });
     } catch (error) {
       logger.error('Client embeddings error', { error });
+      const normalizedError = normalizeInferenceError(error);
 
       try {
         const model = modelKey
           ? await getModelByKey(auth.tenantDbName, modelKey, auth.projectId)
           : null;
         if (model) {
-          const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+          const errorMessage = normalizedError.error.message;
           await logModelUsage(auth.tenantDbName, model, {
             errorMessage,
             latencyMs: Date.now() - startedAt,
@@ -474,12 +473,7 @@ export const clientInferenceApiPlugin: FastifyPluginAsync = async (app) => {
         logger.error('Failed to log client embedding error', { error: logError });
       }
 
-      return reply.code(500).send({
-        error: {
-          message: error instanceof Error ? error.message : 'Inference error',
-          type: 'server_error',
-        },
-      });
+      return reply.code(normalizedError.status).send({ error: normalizedError.error });
     }
   }));
 };

--- a/src/server/api/routes/client/v1/chat/completions/route.ts
+++ b/src/server/api/routes/client/v1/chat/completions/route.ts
@@ -2,7 +2,11 @@ import { NextResponse, type NextRequest } from '@/server/api/http';
 import crypto from 'crypto';
 import type { LicenseType } from '@/lib/license/license-manager';
 import { requireApiToken, ApiTokenAuthError } from '@/lib/services/apiTokenAuth';
-import { handleChatCompletion, GuardrailBlockError } from '@/lib/services/models/inferenceService';
+import {
+  GuardrailBlockError,
+  handleChatCompletion,
+} from '@/lib/services/models/inferenceService';
+import { normalizeInferenceError } from '@/lib/services/models/openaiErrors';
 import { getModelByKey } from '@/lib/services/models/modelService';
 import { calculateCost, logModelUsage } from '@/lib/services/models/usageLogger';
 import { checkBudget, checkPerRequestLimits, checkRateLimit } from '@/lib/quota/quotaGuard';
@@ -250,10 +254,12 @@ const _POST = async (request: NextRequest) => {
       );
     }
 
+    const normalizedError = normalizeInferenceError(error);
+
     try {
       const model = await getModelByKey(auth.tenantDbName, modelKey, auth.projectId);
       if (model) {
-        const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+        const errorMessage = normalizedError.error.message;
         await logModelUsage(auth.tenantDbName, model, {
           requestId: typeof body?.request_id === 'string' ? body.request_id : crypto.randomUUID(),
           route: 'chat.completions',
@@ -269,8 +275,10 @@ const _POST = async (request: NextRequest) => {
       logger.error('Failed to log chat completion error', { error: logError });
     }
 
-    const errorMessage = error instanceof Error ? error.message : 'Inference error';
-    return NextResponse.json({ error: { message: errorMessage, type: 'server_error' } }, { status: 500 });
+    return NextResponse.json(
+      { error: normalizedError.error },
+      { status: normalizedError.status },
+    );
   }
 };
 

--- a/src/server/api/routes/client/v1/embeddings/route.ts
+++ b/src/server/api/routes/client/v1/embeddings/route.ts
@@ -3,6 +3,7 @@ import crypto from 'crypto';
 import type { LicenseType } from '@/lib/license/license-manager';
 import { requireApiToken, ApiTokenAuthError } from '@/lib/services/apiTokenAuth';
 import { handleEmbeddingRequest } from '@/lib/services/models/inferenceService';
+import { normalizeInferenceError } from '@/lib/services/models/openaiErrors';
 import { getModelByKey } from '@/lib/services/models/modelService';
 import { calculateCost, logModelUsage } from '@/lib/services/models/usageLogger';
 import { checkBudget, checkPerRequestLimits, checkRateLimit } from '@/lib/quota/quotaGuard';
@@ -181,11 +182,12 @@ const _POST = async (request: NextRequest) => {
     return NextResponse.json({ ...result.response, request_id: result.requestId }, { status: 200 });
   } catch (error: unknown) {
     logger.error('Embedding error', { error });
+    const normalizedError = normalizeInferenceError(error);
 
     try {
       const model = await getModelByKey(auth.tenantDbName, modelKey, auth.projectId);
       if (model) {
-        const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+        const errorMessage = normalizedError.error.message;
         await logModelUsage(auth.tenantDbName, model, {
           requestId: typeof body?.request_id === 'string' ? body.request_id : crypto.randomUUID(),
           route: 'embeddings',
@@ -201,8 +203,10 @@ const _POST = async (request: NextRequest) => {
       logger.error('Failed to log embedding error', { error: logError });
     }
 
-    const errorMessage = error instanceof Error ? error.message : 'Inference error';
-    return NextResponse.json({ error: { message: errorMessage, type: 'server_error' } }, { status: 500 });
+    return NextResponse.json(
+      { error: normalizedError.error },
+      { status: normalizedError.status },
+    );
   }
 };
 


### PR DESCRIPTION
## Summary
- centralize OpenAI-compatible inference error normalization across chat and embeddings routes
- improve streaming and non-streaming error handling, model discovery compatibility, and strict schema/tool support coverage
- add the missing `gpt-tokenizer` runtime dependency required by `@cognipeer/to-markdown`

## Validation
- `npm test`
- `npx tsc --noEmit --pretty false`
- `npm run build`
- targeted file/OCR tests and Fastify inference route regression tests
