### PR TITLE
fix(models): normalize vision inputs and redact image data

### DIFF
--- a/src/__tests__/api/client-inference-fastify.test.ts
+++ b/src/__tests__/api/client-inference-fastify.test.ts
@@ -153,4 +153,20 @@ describe('Fastify client inference errors', () => {
       code: 'inference_error',
     });
   });
+
+  it('returns a structured 400 for malformed multimodal content', async () => {
+    mockFn(handleChatCompletion).mockRejectedValue(
+      new Error('`messages[0].content[1].image_url` must be a non-empty string or an object with a non-empty `url` string'),
+    );
+
+    const response = await postChat();
+    const body = parseJsonBody<{ error: Record<string, unknown> }>(response.body);
+
+    expect(response.statusCode).toBe(400);
+    expect(body.error).toMatchObject({
+      type: 'invalid_request_error',
+      code: 'invalid_request',
+    });
+    expect(body.error.message).toContain('messages[0].content[1].image_url');
+  });
 });

--- a/src/__tests__/unit/inference-service.test.ts
+++ b/src/__tests__/unit/inference-service.test.ts
@@ -24,12 +24,15 @@ vi.mock('@/lib/services/models/usageLogger', () => ({
   logModelUsage: vi.fn().mockResolvedValue(undefined),
 }));
 
-vi.mock('@/lib/services/models/openaiAdapter', () => ({
-  toLangChainMessages: vi.fn().mockReturnValue([{ role: 'user', content: 'hello' }]),
-  toOpenAIChatResponse: vi.fn().mockReturnValue({ id: 'chatcmpl-1', choices: [] }),
-  toOpenAIStreamChunk: vi.fn().mockReturnValue({ id: 'chatcmpl-1', choices: [] }),
-  summarizeUsage: vi.fn().mockReturnValue({ inputTokens: 10, outputTokens: 20, totalTokens: 30 }),
-}));
+vi.mock('@/lib/services/models/openaiAdapter', async (importOriginal) => {
+  const original = await importOriginal<typeof import('@/lib/services/models/openaiAdapter')>();
+  return {
+    ...original,
+    toOpenAIChatResponse: vi.fn().mockReturnValue({ id: 'chatcmpl-1', choices: [] }),
+    toOpenAIStreamChunk: vi.fn().mockReturnValue({ id: 'chatcmpl-1', choices: [] }),
+    summarizeUsage: vi.fn().mockReturnValue({ inputTokens: 10, outputTokens: 20, totalTokens: 30 }),
+  };
+});
 
 import { getModelByKey } from '@/lib/services/models/modelService';
 import { buildModelRuntime } from '@/lib/services/models/runtimeService';
@@ -195,6 +198,36 @@ describe('handleChatCompletion', () => {
         cacheHit: false,
       }),
     );
+  });
+
+  it('passes canonical OpenAI vision content to the provider runnable', async () => {
+    (getModelByKey as ReturnType<typeof vi.fn>).mockResolvedValue(makeLlmModel());
+    const chatModel = {
+      invoke: vi.fn().mockResolvedValue({ content: 'A small image', tool_calls: [] }),
+    };
+    (buildModelRuntime as ReturnType<typeof vi.fn>).mockResolvedValue({
+      runtime: { createChatModel: vi.fn().mockResolvedValue(chatModel) },
+    });
+    const imageUrl = 'data:image/png;base64,iVBORw0KGgo=';
+
+    await handleChatCompletion({
+      ...BASE_PARAMS,
+      body: {
+        messages: [{
+          role: 'user',
+          content: [
+            { type: 'text', text: 'Describe this image' },
+            { type: 'image_url', image_url: imageUrl },
+          ],
+        }],
+      },
+    });
+
+    const messages = chatModel.invoke.mock.calls[0][0];
+    expect(messages[0].content).toEqual([
+      { type: 'text', text: 'Describe this image' },
+      { type: 'image_url', image_url: { url: imageUrl } },
+    ]);
   });
 
   it('uses provided request_id in response', async () => {

--- a/src/__tests__/unit/log-redaction.test.ts
+++ b/src/__tests__/unit/log-redaction.test.ts
@@ -47,6 +47,21 @@ describe('redactLogPayload — value scrubbing', () => {
     redactLogPayload(input, { secretValues: [secret] });
     expect(input.a.b).toBe(secret);
   });
+
+  it('redacts base64 data URLs from nested persisted payloads', () => {
+    const encodedImage = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAAB';
+    const out = redactLogPayload({
+      messages: [{
+        content: [{
+          type: 'image_url',
+          image_url: { url: `data:image/png;base64,${encodedImage}` },
+        }],
+      }],
+    });
+
+    expect(JSON.stringify(out)).not.toContain(encodedImage);
+    expect(JSON.stringify(out)).toContain('data:[REDACTED];base64,[REDACTED]');
+  });
 });
 
 describe('redactLogPayload — sensitive key scrubbing', () => {
@@ -115,6 +130,16 @@ describe('redactLogString', () => {
     const out = redactLogString(huge, []) as string;
     expect(out.length).toBeLessThan(huge.length);
     expect(out.endsWith('…[truncated]')).toBe(true);
+  });
+
+  it('redacts embedded base64 data URLs without supplied secrets', () => {
+    const encodedImage = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAAB';
+    const out = redactLogString(
+      `Invalid image data:image/png;base64,${encodedImage}`,
+    );
+
+    expect(out).not.toContain(encodedImage);
+    expect(out).toContain('data:[REDACTED];base64,[REDACTED]');
   });
 });
 

--- a/src/__tests__/unit/model-provider-contracts.test.ts
+++ b/src/__tests__/unit/model-provider-contracts.test.ts
@@ -21,6 +21,7 @@ import {
   afterAll,
   afterEach,
 } from 'vitest';
+import { http, HttpResponse } from 'msw';
 import { mswServer } from '../helpers/msw.server';
 
 // ── AWS SDK mock (Bedrock) ───────────────────────────────────────────────────
@@ -81,6 +82,7 @@ import {
   AzureModelProviderContract,
 } from '@/lib/providers/contracts/modelContracts';
 import type { ModelProviderRuntime } from '@/lib/providers/domains/model';
+import { toLangChainMessages } from '@/lib/services/models/openaiAdapter';
 
 // ── Helper ───────────────────────────────────────────────────────────────────
 
@@ -154,6 +156,52 @@ describe('openai-compatible provider', () => {
     const model = runtime
       .createChatModel!({ modelId: 'mistral-large', category: 'llm' });
     assertChatModel(model);
+  });
+
+  it('preserves canonical vision content in the provider HTTP payload', async () => {
+    let capturedBody: Record<string, unknown> | undefined;
+    mswServer.use(
+      http.post('https://api.custom.com/v1/chat/completions', async ({ request }) => {
+        capturedBody = await request.json() as Record<string, unknown>;
+        return HttpResponse.json({
+          id: 'chatcmpl-vision',
+          object: 'chat.completion',
+          created: 1,
+          model: 'vision-model',
+          choices: [{
+            index: 0,
+            message: { role: 'assistant', content: 'A test image' },
+            finish_reason: 'stop',
+          }],
+          usage: { prompt_tokens: 10, completion_tokens: 3, total_tokens: 13 },
+        });
+      }),
+    );
+    const model = runtime.createChatModel!({
+      modelId: 'vision-model',
+      category: 'llm',
+    }) as { invoke: (messages: unknown[]) => Promise<unknown> };
+    const imageUrl = 'data:image/png;base64,iVBORw0KGgo=';
+    const messages = toLangChainMessages([{
+      role: 'user',
+      content: [
+        { type: 'text', text: 'Describe this image' },
+        { type: 'image_url', image_url: imageUrl },
+      ],
+    }]);
+
+    await model.invoke(messages);
+
+    expect(capturedBody).toMatchObject({
+      model: 'vision-model',
+      messages: [{
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Describe this image' },
+          { type: 'image_url', image_url: { url: imageUrl } },
+        ],
+      }],
+    });
   });
 
   it('createEmbeddingModel returns LangChain-compatible object', () => {
@@ -402,6 +450,18 @@ describe('azure provider', () => {
     const model = runtime
       .createChatModel!({ modelId: 'gpt-4o', category: 'llm' });
     assertChatModel(model);
+  });
+
+  it('forwards provider streaming controls for eager tool calls', () => {
+    const model = runtime.createChatModel!({
+      modelId: 'o3-mini',
+      category: 'llm',
+      modelSettings: { maxCompletionTokens: 1024 },
+      options: { streaming: true, disableStreaming: true },
+    }) as unknown as Record<string, unknown>;
+
+    expect(model.disableStreaming).toBe(true);
+    expect(model.streaming).toBe(false);
   });
 
   it('createEmbeddingModel returns LangChain-compatible object', () => {

--- a/src/__tests__/unit/openai-adapter.test.ts
+++ b/src/__tests__/unit/openai-adapter.test.ts
@@ -74,6 +74,103 @@ describe('toLangChainMessages', () => {
     ]);
     expect(msgs[0].constructor.name).toBe('HumanMessage');
   });
+
+  it('wraps string image URLs in the OpenAI-compatible object shape', () => {
+    const imageUrl = 'data:image/png;base64,iVBORw0KGgo=';
+    const msgs = toLangChainMessages([
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Describe this image' },
+          { type: 'image_url', image_url: imageUrl },
+        ] as never,
+      },
+    ]);
+
+    expect(msgs[0].content).toEqual([
+      { type: 'text', text: 'Describe this image' },
+      { type: 'image_url', image_url: { url: imageUrl } },
+    ]);
+  });
+
+  it('preserves the detail option on object image URLs', () => {
+    const imageUrl = 'https://example.com/image.png';
+    const msgs = toLangChainMessages([
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'image_url',
+            image_url: { url: imageUrl, detail: 'high' },
+          },
+        ] as never,
+      },
+    ]);
+
+    expect(msgs[0].content).toEqual([
+      {
+        type: 'image_url',
+        image_url: { url: imageUrl, detail: 'high' },
+      },
+    ]);
+  });
+
+  it('normalizes multiple HTTP and data URL images without changing their order', () => {
+    const firstUrl = 'https://cdn.example.com/first.png';
+    const secondUrl = 'data:image/jpeg;base64,/9j/4AAQSkZJRg==';
+    const msgs = toLangChainMessages([
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Compare these images' },
+          { type: 'image_url', image_url: firstUrl },
+          { type: 'image_url', image_url: { url: secondUrl, detail: 'low' } },
+        ] as never,
+      },
+    ]);
+
+    expect(msgs[0].content).toEqual([
+      { type: 'text', text: 'Compare these images' },
+      { type: 'image_url', image_url: { url: firstUrl } },
+      { type: 'image_url', image_url: { url: secondUrl, detail: 'low' } },
+    ]);
+  });
+
+  it('rejects malformed image URLs before calling a provider', () => {
+    expect(() => toLangChainMessages([
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Describe this image' },
+          { type: 'image_url', image_url: { detail: 'high' } },
+        ] as never,
+      },
+    ])).toThrow('`messages[0].content[1].image_url` must be');
+  });
+
+  it.each([
+    '',
+    '   ',
+    { url: '' },
+    { url: '   ' },
+  ])('rejects an empty image URL: %j', (imageUrl) => {
+    expect(() => toLangChainMessages([{
+      role: 'user',
+      content: [{ type: 'image_url', image_url: imageUrl }] as never,
+    }])).toThrow('`messages[0].content[0].image_url` must be');
+  });
+
+  it('preserves unknown content parts for forward compatibility', () => {
+    const inputAudio = {
+      type: 'input_audio',
+      input_audio: { data: 'UklGRg==', format: 'wav' },
+    };
+    const msgs = toLangChainMessages([
+      { role: 'user', content: [inputAudio] as never },
+    ]);
+
+    expect(msgs[0].content).toEqual([inputAudio]);
+  });
 });
 
 // ── toOpenAIChatResponse ──────────────────────────────────────────────────────

--- a/src/__tests__/unit/openai-errors.test.ts
+++ b/src/__tests__/unit/openai-errors.test.ts
@@ -84,6 +84,25 @@ describe('normalizeInferenceError', () => {
     expect(result.error.message).toContain('[REDACTED]');
   });
 
+  it('redacts base64 image data from provider validation errors', () => {
+    const imagePayload = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAAB';
+    const error = Object.assign(
+      new Error(
+        `image_url Input should be a valid dictionary input_value='data:image/png;base64,${imagePayload}'`,
+      ),
+      { status: 400 },
+    );
+
+    const result = normalizeInferenceError(error);
+
+    expect(result).toMatchObject({
+      status: 400,
+      error: { type: 'invalid_request_error', code: 'invalid_request' },
+    });
+    expect(result.error.message).not.toContain(imagePayload);
+    expect(result.error.message).toContain('data:[REDACTED];base64,[REDACTED]');
+  });
+
   it('reads provider error details nested in arrays', () => {
     const error = {
       response: {

--- a/src/__tests__/unit/usage-logger.test.ts
+++ b/src/__tests__/unit/usage-logger.test.ts
@@ -245,4 +245,28 @@ describe('logModelUsage', () => {
     const payload = db.createModelUsageLog.mock.calls[0][0];
     expect(payload.totalTokens).toBe(150);
   });
+
+  it('redacts multimodal data URLs before persisting usage logs', async () => {
+    const encodedImage = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAAB';
+    await logModelUsage('tenant_acme', MOCK_MODEL, {
+      requestId: 'req-007',
+      route: '/api/chat',
+      status: 'error',
+      providerRequest: {
+        messages: [{
+          content: [{
+            type: 'image_url',
+            image_url: { url: `data:image/png;base64,${encodedImage}` },
+          }],
+        }],
+      },
+      providerResponse: { error: `Rejected data:image/png;base64,${encodedImage}` },
+      errorMessage: `Rejected data:image/png;base64,${encodedImage}`,
+      usage: {},
+    });
+
+    const payload = db.createModelUsageLog.mock.calls[0][0];
+    expect(JSON.stringify(payload)).not.toContain(encodedImage);
+    expect(JSON.stringify(payload)).toContain('data:[REDACTED];base64,[REDACTED]');
+  });
 });

--- a/src/lib/providers/contracts/modelContracts.ts
+++ b/src/lib/providers/contracts/modelContracts.ts
@@ -711,7 +711,9 @@ export const AzureModelProviderContract: ProviderContract<ModelProviderRuntime, 
           azureOpenAIApiVersion: apiVersion,
           temperature: overrides.temperature,
           maxTokens: overrides.maxTokens,
+          maxCompletionTokens: overrides.maxCompletionTokens,
           streaming: config.options?.streaming ?? false,
+          disableStreaming: config.options?.disableStreaming ?? false,
         });
       },
       createEmbeddingModel: (config) =>

--- a/src/lib/services/logRedaction.ts
+++ b/src/lib/services/logRedaction.ts
@@ -38,6 +38,8 @@ export const DEFAULT_MAX_STRING_CHARS = 8 * 1024;
 const MIN_SECRET_LENGTH = 6;
 const MAX_DEPTH = 8;
 const TRUNCATION_PREVIEW_CHARS = 2048;
+const DATA_URL_PATTERN = /data:[a-z0-9.+-]+\/[a-z0-9.+-]+(?:;(?!base64(?:[,;]))[^;,\s]+)*;base64,[a-z0-9+/_=-]+/gi;
+const REDACTED_DATA_URL = 'data:[REDACTED];base64,[REDACTED]';
 
 export interface RedactOptions {
   /** Outbound secret values (runtime-header values, static credentials) to mask. */
@@ -55,15 +57,19 @@ function usableSecrets(values: Iterable<string> | undefined): string[] {
   return [...out];
 }
 
+export function redactDataUrls(str: string): string {
+  return str.replace(DATA_URL_PATTERN, REDACTED_DATA_URL);
+}
+
 function scrubString(str: string, secrets: string[]): string {
-  let out = str;
+  let out = redactDataUrls(str);
   for (const secret of secrets) out = out.replaceAll(secret, LOG_SECRET_MASK);
   return out;
 }
 
 function scrubValue(value: unknown, secrets: string[], depth: number, seen: WeakSet<object>): unknown {
   if (value === null || value === undefined) return value;
-  if (typeof value === 'string') return secrets.length ? scrubString(value, secrets) : value;
+  if (typeof value === 'string') return scrubString(value, secrets);
   if (typeof value !== 'object') return value;
   // Preserve native instances — walking a Date/Buffer/Error as a plain object
   // would erase it (Object.entries is empty → {}). Matches logger.ts.
@@ -124,7 +130,7 @@ export function redactLogString(
 ): string | undefined {
   if (!str) return str;
   const secrets = usableSecrets(secretValues);
-  const scrubbed = secrets.length ? scrubString(str, secrets) : str;
+  const scrubbed = scrubString(str, secrets);
   return scrubbed.length > maxChars ? `${scrubbed.slice(0, maxChars)}…[truncated]` : scrubbed;
 }
 

--- a/src/lib/services/models/openaiAdapter.ts
+++ b/src/lib/services/models/openaiAdapter.ts
@@ -75,13 +75,14 @@ export interface ChatTransformOptions {
 
 function normalizeContent(
   content: OpenAIMessage['content'],
+  messageIndex: number,
 ): string | MessageContentPart[] {
   if (typeof content === 'string') {
     return content;
   }
 
   if (Array.isArray(content)) {
-    return content.map((item) => {
+    return content.map((item, partIndex) => {
       const record = item as Record<string, unknown>;
       const type = typeof record.type === 'string' ? record.type : undefined;
 
@@ -94,10 +95,10 @@ function normalizeContent(
 
       if (type === 'image_url') {
         const rawImage = record.image_url;
-        if (typeof rawImage === 'string') {
+        if (typeof rawImage === 'string' && rawImage.trim()) {
           return {
             type: 'image_url',
-            image_url: rawImage,
+            image_url: { url: rawImage },
           } as MessageContentPart;
         }
 
@@ -108,16 +109,27 @@ function normalizeContent(
         ) {
           const url =
             typeof (rawImage as Record<string, unknown>).url === 'string'
+              && (rawImage as Record<string, string>).url.trim()
               ? (rawImage as Record<string, unknown>).url
               : undefined;
+          const detail = (rawImage as Record<string, unknown>).detail;
 
           if (url) {
             return {
               type: 'image_url',
-              image_url: url,
+              image_url: {
+                url,
+                ...(detail === 'auto' || detail === 'low' || detail === 'high'
+                  ? { detail }
+                  : {}),
+              },
             } as MessageContentPart;
           }
         }
+
+        throw new Error(
+          `\`messages[${messageIndex}].content[${partIndex}].image_url\` must be a non-empty string or an object with a non-empty \`url\` string`,
+        );
       }
 
       return record;
@@ -128,8 +140,8 @@ function normalizeContent(
 }
 
 export function toLangChainMessages(messages: OpenAIMessage[]): BaseMessage[] {
-  return messages.map((message) => {
-    const content = normalizeContent(message.content);
+  return messages.map((message, messageIndex) => {
+    const content = normalizeContent(message.content, messageIndex);
 
     switch (message.role) {
       case 'system':

--- a/src/lib/services/models/openaiErrors.ts
+++ b/src/lib/services/models/openaiErrors.ts
@@ -1,3 +1,5 @@
+import { redactDataUrls } from '@/lib/services/logRedaction';
+
 export type OpenAIErrorBody = {
   message: string;
   type: string;
@@ -82,7 +84,7 @@ function firstStatus(records: ErrorRecord[]): number | undefined {
 }
 
 function safeMessage(message: string): string {
-  return message
+  return redactDataUrls(message)
     .replace(/Bearer\s+[A-Za-z0-9._~+/=-]+/gi, 'Bearer [REDACTED]')
     .replace(/\bsk-[A-Za-z0-9_-]{8,}\b/g, '[REDACTED]')
     .replace(/\bAIza[A-Za-z0-9_-]{20,}\b/g, '[REDACTED]')

--- a/src/lib/services/models/usageLogger.ts
+++ b/src/lib/services/models/usageLogger.ts
@@ -3,6 +3,10 @@ import {
   recordUsageEvent,
   type UsageAttribution,
 } from '@/lib/services/usage/usageEvents';
+import {
+  redactLogPayload,
+  redactLogString,
+} from '@/lib/services/logRedaction';
 
 const TOKENS_PER_MILLION = 1_000_000;
 const SECONDS_PER_THOUSAND = 1_000;
@@ -159,9 +163,9 @@ export async function logModelUsage(
     requestId: payload.requestId,
     route: payload.route,
     status: payload.status,
-    providerRequest: toRecord(payload.providerRequest),
-    providerResponse: toRecord(payload.providerResponse),
-    errorMessage: payload.errorMessage,
+    providerRequest: toRecord(redactLogPayload(payload.providerRequest)),
+    providerResponse: toRecord(redactLogPayload(payload.providerResponse)),
+    errorMessage: redactLogString(payload.errorMessage),
     latencyMs: payload.latencyMs,
     inputTokens: usage.inputTokens ?? 0,
     outputTokens: usage.outputTokens ?? 0,


### PR DESCRIPTION
## Summary

Normalize OpenAI-compatible vision message content before invoking LangChain providers, accepting both legacy string `image_url` values and canonical `{ url, detail }` objects. Malformed or empty image URLs now fail early with a structured client error.

Prevent base64 data URLs from leaking into persisted usage logs or provider error responses, and align Azure chat runtime options with reasoning-token and eager tool-call behavior.

## Changes

- Canonicalize vision content to `image_url: { url, detail? }` while preserving unknown content parts.
- Reject missing, empty, and whitespace-only image URLs before provider calls.
- Centralize base64 data URL redaction and apply it to usage payloads and normalized inference errors.
- Forward Azure `maxCompletionTokens` and `disableStreaming` runtime options.
- Add adapter, provider HTTP payload, logging, error normalization, service, and Fastify API regression coverage.

## Validation

- [x] `npm run lint` (0 errors; existing repository warnings remain)
- [x] `npm run test` (2765 passed, 4 skipped)
- [x] `npm run build`
- [ ] `npm run docs:build` (not applicable; no docs changes)
- [x] `npx tsc --noEmit`

## Release Notes

- [x] Docs updated when behavior changed (not required for wire-format compatibility fix)
- [x] Security-sensitive changes reviewed
- [x] License or policy files updated if repo-facing behavior changed (not required)