### PR TITLE
feat(support): hand signed-in users into Cognipeer Support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,6 +38,21 @@ PROVIDER_ENCRYPTION_SECRET=                        # (required) Independent encr
 # BOOTSTRAP_ADMIN_PASSWORD=
 # BOOTSTRAP_ADMIN_NAME=Administrator
 
+# ---- Deployment ----------------------------------------------
+# saas | onprem. Defaults to 'onprem' when DB_PROVIDER=sqlite, otherwise 'saas'.
+# Set it explicitly when the inferred value is wrong (e.g. on-prem on MongoDB).
+# DEPLOYMENT_MODE=
+
+# ---- Cognipeer Support ---------------------------------------
+# Help & Support entry points stay hidden until SUPPORT_BASE_URL is set.
+# SUPPORT_HANDOFF_SECRET must be at least 32 characters and must equal CRM's
+# SUPPORT_HANDOFF_SECRET_CONSOLE. It is server-only — never use NEXT_PUBLIC_.
+# On-prem: when SUPPORT_BASE_URL is set but the CRM values are not, Console
+# sends the user to the Support login page instead of failing.
+# SUPPORT_BASE_URL=https://support.cognipeer.com
+# SUPPORT_CRM_API_URL=
+# SUPPORT_HANDOFF_SECRET=
+
 # ---- License -------------------------------------------------
 # Free license is built in and allows 2 projects. Paid offline licenses are
 # signed outside the app with the private key and verified here with the public key.

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -4,6 +4,7 @@ import { redirect } from 'next/navigation';
 import DashboardLayout from '@/components/layout/DashboardLayout';
 import { getDatabase } from '@/lib/database';
 import { normalizeServicePermissions } from '@/lib/security/rbac';
+import { isSupportReachable } from '@/lib/services/support/supportHandoff';
 
 interface DashboardRouteLayoutProps {
   children: ReactNode;
@@ -53,6 +54,7 @@ export default async function DashboardRouteLayout({ children }: DashboardRouteL
 
   return (
     <DashboardLayout
+      supportEnabled={isSupportReachable()}
       user={{
         name: email ? email.split('@')[0] : 'Account',
         email,

--- a/src/components/layout/DashboardLayout.tsx
+++ b/src/components/layout/DashboardLayout.tsx
@@ -27,7 +27,8 @@ import ServiceSubNav, {
 } from './launcher/ServiceSubNav';
 import { useLauncherState } from './launcher/useLauncherState';
 import { LauncherProvider } from './launcher/LauncherContext';
-import { useTranslations } from '@/lib/i18n';
+import { openSupport } from '@/lib/support/openSupport';
+import { useLocale, useTranslations } from '@/lib/i18n';
 import classes from './launcher/LauncherShell.module.css';
 import { DocsDrawerProvider } from '@/components/docs/DocsDrawerContext';
 import { DEFAULT_SDK_DOC, resolveSdkDoc, type SdkDocId } from '@/lib/docs/sdkDocs';
@@ -49,6 +50,7 @@ const SETTINGS_NAV_ORDER: string[] = [
 
 interface DashboardLayoutProps {
   children: ReactNode;
+  supportEnabled?: boolean;
   user?: {
     name: string;
     email: string;
@@ -58,7 +60,7 @@ interface DashboardLayoutProps {
   };
 }
 
-export default function DashboardLayout({ children, user }: DashboardLayoutProps) {
+export default function DashboardLayout({ children, supportEnabled = false, user }: DashboardLayoutProps) {
   const router = useRouter();
   const pathname = usePathname() ?? '';
   const [docsOpened, docsControls] = useDisclosure(false);
@@ -66,6 +68,7 @@ export default function DashboardLayout({ children, user }: DashboardLayoutProps
   const [launcherOpen, setLauncherOpen] = useState(false);
   const [mobileNavOpen, setMobileNavOpen] = useState(false);
   const t = useTranslations('layout');
+  const locale = useLocale();
   const tNotifications = useTranslations('notifications');
   const tNavigation = useTranslations('navigation');
 
@@ -96,6 +99,17 @@ export default function DashboardLayout({ children, user }: DashboardLayoutProps
       });
     }
   }, [router, tNotifications]);
+
+  const handleSupportClick = useCallback(async () => {
+    const opened = await openSupport(locale === 'tr' ? 'tr' : 'en');
+    if (!opened) {
+      notifications.show({
+        title: tNotifications('supportErrorTitle'),
+        message: tNotifications('supportErrorMessage'),
+        color: 'red',
+      });
+    }
+  }, [locale, tNotifications]);
 
   const defaultUser = user || {
     name: t('defaultUser.name'),
@@ -294,9 +308,11 @@ export default function DashboardLayout({ children, user }: DashboardLayoutProps
             <TopbarV2
               user={defaultUser}
               isTenantAdmin={isTenantAdmin}
+              supportEnabled={supportEnabled}
               onSearchClick={openCommandPalette}
               onLauncherClick={() => setLauncherOpen(true)}
               onDocsClick={() => openDocs(DEFAULT_SDK_DOC)}
+              onSupportClick={handleSupportClick}
               onLogout={handleLogout}
               onNavigate={handleNavigate}
               onMobileNavClick={() => setMobileNavOpen(true)}

--- a/src/components/layout/launcher/TopbarV2.tsx
+++ b/src/components/layout/launcher/TopbarV2.tsx
@@ -16,6 +16,7 @@ import {
   IconBook,
   IconCertificate,
   IconChevronDown,
+  IconLifebuoy,
   IconLogout,
   IconMenu2,
   IconMoon,
@@ -34,9 +35,11 @@ interface TopbarV2Props {
     licenseType: string;
   };
   isTenantAdmin: boolean;
+  supportEnabled?: boolean;
   onSearchClick: () => void;
   onLauncherClick: () => void;
   onDocsClick: () => void;
+  onSupportClick?: () => void;
   onLogout: () => void;
   onNavigate: (href: string) => void;
   onMobileNavClick: () => void;
@@ -46,9 +49,11 @@ interface TopbarV2Props {
 export default function TopbarV2({
   user,
   isTenantAdmin,
+  supportEnabled = false,
   onSearchClick,
   onLauncherClick,
   onDocsClick,
+  onSupportClick,
   onLogout,
   onNavigate,
   onMobileNavClick,
@@ -186,6 +191,11 @@ export default function TopbarV2({
               onClick={() => onNavigate('/dashboard/license')}
             >
               {tAccount('license')}
+            </Menu.Item>
+          ) : null}
+          {supportEnabled && onSupportClick ? (
+            <Menu.Item leftSection={<IconLifebuoy size={14} />} onClick={onSupportClick}>
+              {tAccount('support')}
             </Menu.Item>
           ) : null}
           <Menu.Divider />

--- a/src/config/policies.json
+++ b/src/config/policies.json
@@ -287,6 +287,14 @@
         "/api/client/v1/realtime",
         "/api/client/v1/realtime/*"
       ]
+    },
+    "SUPPORT": {
+      "name": "Cognipeer Support",
+      "description": "Hand the signed-in user over to Cognipeer Support with a single-use CRM code",
+      "endpoints": [
+        "/api/support/status",
+        "/api/support/handoff"
+      ]
     }
   },
   "licenses": {

--- a/src/lib/core/config.ts
+++ b/src/lib/core/config.ts
@@ -37,6 +37,12 @@ class EnvConfigSource implements ConfigSource {
 export interface AppConfig {
   nodeEnv: string;
 
+  deployment: {
+    /** saas = Cognipeer-hosted, onprem = customer-hosted. */
+    mode: 'saas' | 'onprem';
+    isOnPrem: boolean;
+  };
+
   license: {
     offlinePublicKey: string;
     offlinePublicKeyPath: string;
@@ -85,6 +91,19 @@ export interface AppConfig {
     bootstrapAdminEmail: string;
     bootstrapAdminPassword: string;
     bootstrapAdminName: string;
+  };
+
+  /**
+   * Cognipeer Support handoff. Console never sends the secret to the browser:
+   * it exchanges it server-to-server for a single-use CRM code.
+   */
+  support: {
+    /** Public Support app URL. Every Support entry point stays hidden while this is empty. */
+    baseUrl: string;
+    /** CRM API that issues handoff codes. */
+    crmApiUrl: string;
+    /** Must equal CRM's SUPPORT_HANDOFF_SECRET_CONSOLE. */
+    handoffSecret: string;
   };
 
   smtp: {
@@ -291,9 +310,22 @@ function oneOf<T extends string>(
 
 function buildConfig(source: ConfigSource): AppConfig {
   const nodeEnv = str(source, 'NODE_ENV', 'development');
+  const databaseProvider = oneOf(source, 'DB_PROVIDER', ['mongodb', 'sqlite'], 'sqlite');
+  // SQLite is the self-hosted default, so it decides the mode unless an operator says otherwise.
+  const deploymentMode = oneOf(
+    source,
+    'DEPLOYMENT_MODE',
+    ['saas', 'onprem'],
+    databaseProvider === 'sqlite' ? 'onprem' : 'saas',
+  );
 
   return {
     nodeEnv,
+
+    deployment: {
+      mode: deploymentMode,
+      isOnPrem: deploymentMode === 'onprem',
+    },
 
     license: {
       offlinePublicKey: str(source, 'OFFLINE_LICENSE_PUBLIC_KEY', ''),
@@ -308,7 +340,7 @@ function buildConfig(source: ConfigSource): AppConfig {
     },
 
     database: {
-      provider: oneOf(source, 'DB_PROVIDER', ['mongodb', 'sqlite'], 'sqlite'),
+      provider: databaseProvider,
       uri: str(source, 'MONGODB_URI', ''),
       mainDbName: str(source, 'MAIN_DB_NAME', 'console_main'),
       dataDir: str(source, 'SQLITE_DATA_DIR', './data'),
@@ -331,6 +363,12 @@ function buildConfig(source: ConfigSource): AppConfig {
       bootstrapAdminEmail: str(source, 'BOOTSTRAP_ADMIN_EMAIL', ''),
       bootstrapAdminPassword: str(source, 'BOOTSTRAP_ADMIN_PASSWORD', ''),
       bootstrapAdminName: str(source, 'BOOTSTRAP_ADMIN_NAME', 'Administrator'),
+    },
+
+    support: {
+      baseUrl: str(source, 'SUPPORT_BASE_URL', '').replace(/\/$/, ''),
+      crmApiUrl: str(source, 'SUPPORT_CRM_API_URL', '').replace(/\/$/, ''),
+      handoffSecret: str(source, 'SUPPORT_HANDOFF_SECRET', ''),
     },
 
     smtp: {

--- a/src/lib/i18n/messages/en.ts
+++ b/src/lib/i18n/messages/en.ts
@@ -111,6 +111,8 @@ export const en = {
     logoutSuccessMessage: 'You have been logged out successfully',
     logoutErrorTitle: 'Error',
     logoutErrorMessage: 'Failed to logout',
+    supportErrorTitle: 'Support unavailable',
+    supportErrorMessage: 'Support could not be opened. Please try again shortly.',
     loginFailedTitle: 'Login Failed',
     invalidCredentials: 'Invalid credentials',
     loginSuccess: 'Login successful!',
@@ -127,6 +129,7 @@ export const en = {
     menuLabel: 'Account',
     settings: 'Settings',
     license: 'License',
+    support: 'Help & Support',
     logout: 'Logout',
   },
   breadcrumbs: {

--- a/src/lib/i18n/messages/tr.ts
+++ b/src/lib/i18n/messages/tr.ts
@@ -58,6 +58,15 @@ export const tr: typeof en = {
       maxOutputTokens: 'Maksimum çıktı token sayısı bağlam penceresini aşamaz.',
     },
   },
+  account: {
+    ...en.account,
+    support: 'Yardım ve Destek',
+  },
+  notifications: {
+    ...en.notifications,
+    supportErrorTitle: 'Destek açılamadı',
+    supportErrorMessage: 'Destek şu anda açılamadı. Lütfen kısa süre sonra tekrar deneyin.',
+  },
   navigation: {
     ...en.navigation,
     evaluations: 'Değerlendirme',

--- a/src/lib/services/support/supportHandoff.ts
+++ b/src/lib/services/support/supportHandoff.ts
@@ -1,0 +1,163 @@
+/**
+ * Cognipeer Support handoff.
+ *
+ * Console exchanges its integration secret for a single-use CRM code
+ * server-to-server; the browser only ever receives the resulting Support URL.
+ * Mirrors the Studio and Pulse integrations so one CRM contract serves all
+ * products.
+ */
+import { getConfig } from '@/lib/core/config';
+import { createLogger } from '@/lib/core/logger';
+import { getDatabase } from '@/lib/database';
+
+const logger = createLogger('support-handoff');
+
+const CRM_TIMEOUT_MS = 10_000;
+
+export type SupportLocale = 'tr' | 'en';
+
+export type SupportHandoffResult =
+  | { ok: true; url: string; diagnosticsUnavailable?: true }
+  | { ok: false; status: number; message: string };
+
+export type SupportHandoffInput = {
+  tenantId: string;
+  userId: string;
+  userEmail: string;
+  locale: SupportLocale;
+  summary?: string;
+  diagnostics?: Record<string, unknown>;
+};
+
+/** True when a handoff code can actually be issued, which needs all three values. */
+export function isSupportConfigured() {
+  const { support } = getConfig();
+  return Boolean(support.baseUrl && support.crmApiUrl && support.handoffSecret);
+}
+
+/** True when Support is reachable at all, even if handoffs cannot be issued. */
+export function isSupportReachable() {
+  return Boolean(getConfig().support.baseUrl);
+}
+
+/**
+ * On-prem deployments often point at Support without holding CRM credentials.
+ * Sending the user to the Support login beats failing the action outright.
+ */
+function loginFallback(locale: SupportLocale): SupportHandoffResult | null {
+  const { support, deployment } = getConfig();
+  if (!deployment.isOnPrem || !support.baseUrl) return null;
+
+  const url = new URL(`/${locale}/login`, support.baseUrl);
+  url.searchParams.set('diagnostics', 'unavailable');
+  return { ok: true, url: url.toString(), diagnosticsUnavailable: true };
+}
+
+async function postToCrm(path: string, payload: unknown) {
+  const { support } = getConfig();
+  const response = await fetch(`${support.crmApiUrl}${path}`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${support.handoffSecret}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(payload),
+    signal: AbortSignal.timeout(CRM_TIMEOUT_MS),
+  });
+  const body = (await response.json().catch(() => ({}))) as Record<string, unknown>;
+  return { ok: response.ok, status: response.status, body };
+}
+
+async function createDiagnosticDraft(
+  input: SupportHandoffInput,
+  tenantId: string,
+): Promise<string | null> {
+  const draft = await postToCrm('/api/internal-support/v1/diagnostic-drafts', {
+    issuer: 'console',
+    requesterEmail: input.userEmail,
+    externalInstallationId: tenantId,
+    summary: input.summary?.trim().slice(0, 500) || 'Console application error',
+    diagnostics: input.diagnostics,
+  });
+
+  if (!draft.ok || typeof draft.body.id !== 'string') {
+    logger.warn('CRM rejected the Support diagnostic draft', { statusCode: draft.status });
+    return null;
+  }
+  return draft.body.id;
+}
+
+export async function createSupportHandoff(
+  input: SupportHandoffInput,
+): Promise<SupportHandoffResult> {
+  const { support } = getConfig();
+
+  if (!support.baseUrl) {
+    return { ok: false, status: 503, message: 'Support integration is not configured.' };
+  }
+  if (!support.crmApiUrl || !support.handoffSecret) {
+    return (
+      loginFallback(input.locale)
+      ?? { ok: false, status: 503, message: 'Support integration is not configured.' }
+    );
+  }
+
+  // The CRM identifies the customer by tenant, and requires its display name.
+  const db = await getDatabase();
+  const tenant = await db.findTenantById(input.tenantId);
+  if (!tenant) {
+    return { ok: false, status: 403, message: 'Support access denied.' };
+  }
+
+  const email = input.userEmail.trim().toLowerCase();
+  if (!email) {
+    return { ok: false, status: 403, message: 'Support access denied.' };
+  }
+
+  try {
+    let diagnosticDraftId: string | undefined;
+    if (input.diagnostics) {
+      const draftId = await createDiagnosticDraft(input, input.tenantId);
+      if (!draftId) {
+        return (
+          loginFallback(input.locale)
+          ?? { ok: false, status: 502, message: 'Error details could not be prepared for Support.' }
+        );
+      }
+      diagnosticDraftId = draftId;
+    }
+
+    const handoff = await postToCrm('/api/internal-support/v1/handoffs', {
+      issuer: 'console',
+      email,
+      externalInstallationId: input.tenantId,
+      diagnosticDraftId,
+      context: {
+        workspaceName: tenant.companyName,
+        organizationId: tenant.slug || null,
+        userId: input.userId,
+        userName: email,
+      },
+    });
+
+    if (!handoff.ok || typeof handoff.body.code !== 'string') {
+      logger.warn('CRM rejected the Support handoff', { statusCode: handoff.status });
+      return handoff.status === 404 || handoff.status === 403
+        ? { ok: false, status: 403, message: 'Support access denied.' }
+        : { ok: false, status: 502, message: 'Support access could not be created.' };
+    }
+
+    const callbackUrl = new URL('/api/auth/handoff', support.baseUrl);
+    callbackUrl.searchParams.set('code', handoff.body.code);
+    callbackUrl.searchParams.set('locale', input.locale);
+    return { ok: true, url: callbackUrl.toString() };
+  } catch (error) {
+    logger.warn('Support handoff request failed', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return (
+      loginFallback(input.locale)
+      ?? { ok: false, status: 502, message: 'Support service is unavailable.' }
+    );
+  }
+}

--- a/src/lib/support/openSupport.ts
+++ b/src/lib/support/openSupport.ts
@@ -1,0 +1,28 @@
+'use client';
+
+import { apiRequest } from '@/lib/api/client';
+
+type HandoffResponse = { url: string; diagnosticsUnavailable?: boolean };
+
+/**
+ * Opens Support in a new tab. The tab is opened before the request so the
+ * browser attributes it to the click and does not block it as a popup.
+ */
+export async function openSupport(locale: 'tr' | 'en' = 'tr'): Promise<boolean> {
+  const supportWindow = window.open('about:blank', '_blank');
+  if (!supportWindow) return false;
+  supportWindow.opener = null;
+
+  try {
+    const response = await apiRequest<HandoffResponse>('/api/support/handoff', {
+      method: 'POST',
+      body: JSON.stringify({ locale }),
+    });
+    supportWindow.location.replace(response.url);
+    return true;
+  } catch (error) {
+    supportWindow.close();
+    console.error('Support handoff failed', error);
+    return false;
+  }
+}

--- a/src/server/api/plugin.ts
+++ b/src/server/api/plugin.ts
@@ -79,6 +79,7 @@ import { quotaApiPlugin } from './plugins/quota';
 import { ragApiPlugin } from './plugins/rag';
 import { rerankerApiPlugin } from './plugins/reranker';
 import { specsApiPlugin } from './plugins/specs';
+import { supportApiPlugin } from './plugins/support';
 import { tokensApiPlugin } from './plugins/tokens';
 import { toolsApiPlugin } from './plugins/tools';
 import { tracingApiPlugin } from './plugins/tracing';
@@ -435,6 +436,7 @@ export const fastifyApiPlugin: FastifyPluginAsync = async (app) => {
   await app.register(ragApiPlugin);
   await app.register(rerankerApiPlugin);
   await app.register(specsApiPlugin);
+  await app.register(supportApiPlugin);
   await app.register(tokensApiPlugin);
   await app.register(toolsApiPlugin);
   await app.register(tracingApiPlugin);

--- a/src/server/api/plugins/support.ts
+++ b/src/server/api/plugins/support.ts
@@ -1,0 +1,75 @@
+import type { FastifyPluginAsync } from 'fastify';
+import { createLogger } from '@/lib/core/logger';
+import {
+  createSupportHandoff,
+  isSupportConfigured,
+  type SupportLocale,
+} from '@/lib/services/support/supportHandoff';
+import { readJsonBody, requireSessionContext, withApiRequestContext } from '../fastify-utils';
+
+const logger = createLogger('api:support');
+
+type HandoffBody = {
+  locale?: unknown;
+  summary?: unknown;
+  diagnostics?: unknown;
+};
+
+function parseLocale(value: unknown): SupportLocale {
+  return value === 'en' ? 'en' : 'tr';
+}
+
+export const supportApiPlugin: FastifyPluginAsync = async (app) => {
+  app.get('/support/status', withApiRequestContext(async (request, reply) => {
+    try {
+      requireSessionContext(request);
+      return reply.code(200).send({ enabled: isSupportConfigured() });
+    } catch {
+      return reply.code(401).send({ error: 'Unauthorized' });
+    }
+  }));
+
+  app.post('/support/handoff', withApiRequestContext(async (request, reply) => {
+    let session;
+    try {
+      session = requireSessionContext(request);
+    } catch {
+      return reply.code(401).send({ error: 'Unauthorized' });
+    }
+
+    const body = readJsonBody<HandoffBody>(request);
+    if (body.locale !== undefined && body.locale !== 'tr' && body.locale !== 'en') {
+      return reply.code(400).send({ error: 'Invalid Support locale' });
+    }
+    if (
+      body.diagnostics !== undefined
+      && (typeof body.diagnostics !== 'object' || body.diagnostics === null || Array.isArray(body.diagnostics))
+    ) {
+      return reply.code(400).send({ error: 'Invalid Support diagnostics' });
+    }
+
+    try {
+      const result = await createSupportHandoff({
+        tenantId: session.tenantId,
+        userId: session.userId,
+        userEmail: session.userEmail ?? '',
+        locale: parseLocale(body.locale),
+        summary: typeof body.summary === 'string' ? body.summary : undefined,
+        diagnostics: body.diagnostics as Record<string, unknown> | undefined,
+      });
+
+      if (!result.ok) {
+        return reply.code(result.status).send({ error: result.message });
+      }
+
+      reply.header('Cache-Control', 'no-store');
+      return reply.code(200).send({
+        url: result.url,
+        ...(result.diagnosticsUnavailable ? { diagnosticsUnavailable: true } : {}),
+      });
+    } catch (error) {
+      logger.error('Support handoff error', { error });
+      return reply.code(500).send({ error: 'Internal server error' });
+    }
+  }));
+};


### PR DESCRIPTION
## Problem

Console had no route into Cognipeer Support. Studio and Pulse both hand a signed-in user across; Console users fell back to email.

## Change

- `createSupportHandoff()` exchanges the Console secret for a single-use CRM code server-to-server. The browser only ever receives the resulting Support URL, never the secret.
- Native Fastify endpoints: `GET /support/status` and `POST /support/handoff`, both session-guarded and mapped in `policies.json`.
- "Help & Support" in the account menu, with TR/EN copy. The tab is opened before the request so the browser does not treat it as a popup.
- New `deployment.mode` config (`saas` | `onprem`), inferred from `DB_PROVIDER` unless `DEPLOYMENT_MODE` overrides it. Console had no explicit mode before, unlike Studio (`MODE`) and Pulse (`PULSE_DEPLOYMENT_MODE`).

## On-prem behaviour

On-prem deployments often know the Support URL but hold no CRM credentials. Rather than failing the action, they are sent to the Support login with `diagnostics=unavailable`, matching Studio and Pulse.

The menu is therefore gated on `isSupportReachable()` (`SUPPORT_BASE_URL` present) rather than full handoff config — gating on the latter would have hidden the entry point in exactly the deployments the fallback exists for.

## Depends on

Cognipeer/kogniser-crm#119 registers `console` as a Support product. Until it merges and `SUPPORT_HANDOFF_SECRET_CONSOLE` is set, CRM returns 401 for Console handoffs.

## Validation

- `npx tsc --noEmit`
- `npx eslint` over the touched files
- `npx vitest run` (2765 passed)
- Verified config resolution for both the fully-configured and on-prem partial-config cases