### PR TITLE
chore: release 1.2.20 community

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cognipeer-console",
-  "version": "0.1.0",
+  "version": "1.2.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cognipeer-console",
-      "version": "0.1.0",
+      "version": "1.2.20",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@aws-sdk/client-bedrock-runtime": "^3.901.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cognipeer-console",
-  "version": "0.1.0",
+  "version": "1.2.20",
   "private": true,
   "license": "AGPL-3.0-only",
   "workspaces": [],


### PR DESCRIPTION
## Summary
- bump community package version to 1.2.20
- align package-lock root version metadata
- prepare release tag v1.2.20-community

## Validation
- verified package.json and package-lock.json versions resolve to 1.2.20
- confirmed updated JSON files have no editor diagnostics