### PR TITLE
docs: add release runbook

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -98,6 +98,7 @@ export default defineConfig({
             { text: 'Deployment', link: '/guide/deployment' },
             { text: 'Cluster', link: '/guide/cluster' },
             { text: 'Monitoring', link: '/guide/monitoring' },
+            { text: 'Releasing', link: '/guide/releasing' },
             { text: 'Smoke Testing', link: '/guide/smoke-testing' },
             { text: 'E2E & Load Testing', link: '/guide/e2e-testing' },
           ],

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -102,4 +102,8 @@ npm run test
 npm run docs:build
 ```
 
+## Release Process
+
+For the public release-order runbook, see [Releasing](/guide/releasing).
+
 If you are changing licensing, community policies, or release-process documents, update the root repo files and the mirrored pages under `docs/guide/` in the same pull request.

--- a/docs/guide/releasing.md
+++ b/docs/guide/releasing.md
@@ -1,0 +1,68 @@
+# Releasing
+
+This runbook defines the intended release order for the community and enterprise SaaS editions.
+
+## Public-Safe Scope
+
+This page is safe to keep in the public community repository because it documents release order and public workflow behavior only.
+
+It does not include:
+
+- secrets, tokens, or registry credentials
+- internal deployment environments
+- private repository automation details
+- customer-specific rollout procedures
+
+Private operational steps should stay in the private enterprise repository or internal ops documentation.
+
+## Core Rule
+
+Release the community edition first.
+
+The enterprise SaaS build is layered on top of a released community tag. If the community change is not merged and tagged yet, enterprise SaaS will not pick it up.
+
+## Community Release
+
+The community build is tag-driven.
+
+- Merge the intended community changes to `main`.
+- Run the normal validation set for the release candidate.
+- Create and push a tag in the format `vX.Y.Z-community`.
+- The community build workflow publishes from that tag.
+
+Current trigger: `.github/workflows/build-community.yml` listens only for `vX.Y.Z-community` tags.
+
+## Enterprise SaaS Release
+
+The enterprise SaaS build is also tag-driven, but it does not build from an unreleased community branch.
+
+- Make sure the required community release tag already exists.
+- Confirm enterprise compatibility metadata still matches the intended community release line.
+- Create and push the SaaS tag from the private enterprise release flow.
+
+The public contract to remember is simple: enterprise SaaS must follow a released community tag, not an open PR or an unmerged branch.
+
+## What To Avoid
+
+- Do not treat a release branch or PR as the release itself.
+- Do not assume enterprise SaaS will include community changes that only exist in a branch.
+- Do not cut the SaaS release first when it depends on community changes that are not tagged yet.
+
+## Minimal Checklist
+
+1. Merge community changes.
+2. Validate community release candidate.
+3. Push `vX.Y.Z-community`.
+4. Confirm enterprise compatibility against that community release.
+5. Run the private SaaS release flow.
+
+## Validation Reminder
+
+Keep docs verification in the release loop:
+
+```bash
+npm run lint
+npm run build
+npm run test
+npm run docs:build
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -78,6 +78,7 @@ docker run -p 3000:3000 --env-file .env.local cognipeer-console
 - [Guide](/guide/getting-started): setup, architecture, deployment, providers, and feature walkthroughs.
 - [Core Modules](/guide/core-overview): config, request context, cache, resilience, runtime pool, health, lifecycle, and CORS.
 - [API Reference](/api/overview): gateway endpoints for chat, embeddings, agents, tools, tracing, vector, Knowledge Engine, files, and health.
+- [Releasing](/guide/releasing): the required release order for community and enterprise SaaS, plus the tag-driven runbook.
 - [Using the SDK](/guide/sdk-integration): where Console stops, where the SDK starts, and how teams should split responsibility.
 - [Licensing](/guide/licensing): AGPL community terms, commercial options, and redistribution guidance.
 - [Security](/guide/security): secret handling, hardening defaults, and vulnerability disclosure workflow.


### PR DESCRIPTION
## Summary
- add a public-safe release runbook for community-first releases
- document that enterprise SaaS follows a released community tag
- link the runbook from the docs home, sidebar, and contributing guide

## Validation
- npm run docs:build