### PR TITLE
chore: prepare 1.2.20 community release

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -30,7 +30,7 @@ export default defineConfig({
       { text: 'SDK Docs', link: 'https://cognipeer.github.io/console-sdk/' },
       { text: 'Licensing', link: '/guide/licensing' },
       {
-        text: 'v0.1.0',
+        text: 'v1.2.20',
         items: [
           { text: 'Changelog', link: '/changelog' },
           { text: 'Contributing', link: '/contributing' },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cognipeer-console",
-  "version": "0.1.0",
+  "version": "1.2.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cognipeer-console",
-      "version": "0.1.0",
+      "version": "1.2.20",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@aws-sdk/client-bedrock-runtime": "^3.901.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cognipeer-console",
-  "version": "0.1.0",
+  "version": "1.2.20",
   "private": true,
   "license": "AGPL-3.0-only",
   "workspaces": [],


### PR DESCRIPTION
## Summary
- bump the community package version metadata to 1.2.20
- align the root lockfile version to 1.2.20
- update the docs nav version label to match the upcoming community release

## Validation
- verified package.json and package-lock.json versions resolve to 1.2.20
- npm run docs:build