### PR TITLE
fix(docker): bound the build heap so the image build stops dying silently

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,20 @@ ARG E2E_BUILD=
 ENV E2E_BUILD=${E2E_BUILD}
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
-RUN npm run build \
+# Bound the build's heap explicitly. Without a ceiling, V8 sizes the old space
+# from the HOST's memory, which inside a container is the whole machine — so on
+# a 7GB CI runner it happily grows past what is actually available and the
+# kernel SIGKILLs it. That failure mode produces no error output at all: the
+# step just dies and the log comes back empty.
+#
+# The ceiling must sit BELOW the container's memory, not at it. 4096 leaves room
+# for npm, the SWC/esbuild child processes and Next's page-render workers, and
+# it makes V8 collect garbage before it reaches the limit instead of being
+# killed at it. Raising this number is usually the wrong fix; if the build runs
+# out of memory again, reduce Next's build parallelism instead — peak usage is
+# roughly workers x heap.
+ARG NODE_BUILD_HEAP_MB=4096
+RUN NODE_OPTIONS="--max-old-space-size=${NODE_BUILD_HEAP_MB}" npm run build \
   && rm -rf .next/cache
 
 # --------------------- runner stage ---------------------


### PR DESCRIPTION
The enterprise SaaS image build has failed twice at the Docker build step, both times with **no log output at all** — GitHub returns an empty log archive. That is the signature of a process being SIGKILLed rather than exiting with an error.

## Cause

The builder stage ran `npm run build` with no heap ceiling. Inside a container V8 sizes its old space from the **host's** memory, so on a ~7GB CI runner it grows past what is actually available and the kernel kills it. Nothing is written to the log on the way down.

## Fix

An explicit 4096MB ceiling, overridable through the `NODE_BUILD_HEAP_MB` build arg.

The ceiling sits deliberately **below** the container's memory rather than at it. Setting it to 8192 on a 7GB box would be worse than leaving it unset: it tells V8 it may grow to 8GB, so the kernel kills the process before V8 ever gets aggressive about collecting. 4096 leaves room for npm, the SWC/esbuild child processes and Next's page workers.

If this runs out of memory again, raising the number is usually the wrong move — Next compiles pages in worker processes, so peak usage is roughly *workers × heap*. The next lever is build parallelism, not a bigger heap.

## What was ruled out first

- **Not the npm 10 lockfile trap** (the one that killed v1.0.73-saas): `package-lock.json` is byte-identical between `v1.2.22-community` and `v1.2.23-community`, and `npm ci --dry-run` is clean.
- **Not a code error**: the merged community + enterprise tree passes `tsc --noEmit` (0 errors), `next lint` (0 errors) and `next build` locally.

## After this merges

A new community tag is needed so the SaaS build picks the fix up, followed by a COMPAT repin on the enterprise side and a fresh `-saas` tag. I will do all three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016vhAPUV6foqg5ap3x6j2K5