### PR TITLE
test(support): stop the route tests from opening a real database connection

### DIFF
--- a/src/__tests__/api/support.test.ts
+++ b/src/__tests__/api/support.test.ts
@@ -5,6 +5,14 @@ vi.mock('@/lib/services/support/supportHandoff', () => ({
   isSupportEntryPointEnabled: vi.fn(),
 }));
 
+// The request wrapper binds the session's tenant DB around every handler, which
+// would otherwise open a real connection.
+vi.mock('@/lib/database', () => ({
+  getDatabase: vi.fn(async () => ({
+    runWithTenant: (_tenantDbName: string, run: () => unknown) => run(),
+  })),
+}));
+
 import {
   createSupportHandoff,
   isSupportEntryPointEnabled,


### PR DESCRIPTION
Fixes the CI failure on `main` introduced by #220.

`withApiRequestContext` binds the session's tenant DB around every handler, so
`src/__tests__/api/support.test.ts` opened a real MongoDB connection on each
request. That passed locally, where an instance happens to be running, and
timed out after five seconds on all ten cases in CI:

```
× GET /api/support/status > reports whether an entry point should be shown 5006ms
× POST /api/support/handoff > passes the session identity to the handoff service 5000ms
...
```

The test now mocks `@/lib/database` with a `runWithTenant` that simply invokes
the callback, the same shape the other Fastify plugin tests use. That keeps the
tenant-binding branch exercised instead of skipping it.

10 tests, 5006ms → 55ms, no database required.