### PR TITLE
docs(observability): fix repo links to console-observability

### DIFF
--- a/docs/guide/observability/manual.md
+++ b/docs/guide/observability/manual.md
@@ -297,7 +297,7 @@ idempotent. For long-running runs there is a streaming trio
 field, every event type, the section kinds, the identifier rules and the two
 delivery shapes. An implementation in a new language is a mapping onto that and
 nothing else — and is very welcome as a contribution to the
-[open-source repository](https://github.com/Cognipeer/cognipeer-observability).
+[open-source repository](https://github.com/Cognipeer/console-observability).
 
 ## Flushing
 

--- a/docs/guide/observability/overview.md
+++ b/docs/guide/observability/overview.md
@@ -5,7 +5,7 @@ call, tool call and retrieval, with tokens, latency and cost. This section is
 about getting an agent you did **not** build on Console to send that data.
 
 The integrations live in a separate open-source package,
-[`cognipeer-observability`](https://github.com/Cognipeer/cognipeer-observability),
+[`cognipeer-observability`](https://github.com/Cognipeer/console-observability),
 published as `@cognipeer/observability` (npm) and `cognipeer-observability`
 (PyPI). Nothing about it is Console-specific beyond the endpoint it posts to,
 and it is MIT licensed so customers can read and fork it.

--- a/docs/guide/observability/troubleshooting.md
+++ b/docs/guide/observability/troubleshooting.md
@@ -178,6 +178,6 @@ easier path.
 ## Getting help
 
 Open an issue at
-[Cognipeer/cognipeer-observability](https://github.com/Cognipeer/cognipeer-observability/issues)
+[Cognipeer/console-observability](https://github.com/Cognipeer/console-observability/issues)
 with the debug output, your framework and its version, and the SDK version. The
 package is MIT licensed, so a patch is welcome too.


### PR DESCRIPTION
The observability SDK's GitHub repo was created as `Cognipeer/console-observability`, but three docs pages still linked to the old (nonexistent) `Cognipeer/cognipeer-observability` repo. Updates the links in:

- `docs/guide/observability/overview.md`
- `docs/guide/observability/manual.md`
- `docs/guide/observability/troubleshooting.md`

No content changes beyond the URLs.