### PR TITLE
Hide stringified-undefined tool details left in already-stored sessions

### DIFF
--- a/src/__tests__/unit/agent-tracing.test.ts
+++ b/src/__tests__/unit/agent-tracing.test.ts
@@ -261,6 +261,62 @@ describe('AgentTracingService.getSessionDetail', () => {
     expect(result!.events[0].type).toBe('llm_call');
   });
 
+  it('hides tool details that are a stringified `undefined` spread into a record', async () => {
+    // What agent-sdk < 0.9.5 persisted for an absent payload: sanitizeTracePayload
+    // returned the literal string "undefined", and ingest spread it into
+    // {0:'u',1:'n',…}. Those rows are already in the database, so the read path
+    // has to hide them — the UI rendered them as a 9-key object of letters.
+    db.findAgentTracingSessionById.mockResolvedValue(makeSession());
+    db.listAgentTracingEvents.mockResolvedValue([
+      {
+        sessionId: SESSION_ID,
+        tenantId: TENANT_ID,
+        sequence: 1,
+        type: 'tool_call',
+        timestamp: new Date(),
+        toolName: 'list_todos',
+        // `{...'undefined'}`, written out because TS will not spread a string.
+        metadata: {
+          toolDetails: Object.fromEntries(Array.from('undefined', (c, i) => [i, c])),
+          finishReason: 'stop',
+        },
+      },
+    ]);
+
+    const result = await AgentTracingService.getSessionDetail(TENANT_DB, PROJECT_ID, SESSION_ID);
+    // The mapper's return type is a summary|detail union; this suite asserts on
+    // the detail shape.
+    const event = result!.events[0] as Record<string, unknown>;
+
+    // Neither the folded field nor the raw metadata bag (its own UI tab) may
+    // carry the wreckage.
+    expect(event.toolDetails).not.toHaveProperty('0');
+    expect(event.metadata).not.toHaveProperty('toolDetails');
+    // Unrelated metadata survives — this strips one bad value, not the bag.
+    expect(event.metadata).toMatchObject({ finishReason: 'stop' });
+  });
+
+  it('keeps genuine tool details untouched', async () => {
+    db.findAgentTracingSessionById.mockResolvedValue(makeSession());
+    db.listAgentTracingEvents.mockResolvedValue([
+      {
+        sessionId: SESSION_ID,
+        tenantId: TENANT_ID,
+        sequence: 1,
+        type: 'tool_call',
+        timestamp: new Date(),
+        metadata: { toolDetails: { name: 'list_todos', description: 'List todos' } },
+      },
+    ]);
+
+    const result = await AgentTracingService.getSessionDetail(TENANT_DB, PROJECT_ID, SESSION_ID);
+
+    expect((result!.events[0] as Record<string, unknown>).toolDetails).toMatchObject({
+      name: 'list_todos',
+      description: 'List todos',
+    });
+  });
+
   it('calls db with correct sessionId and projectId', async () => {
     db.findAgentTracingSessionById.mockResolvedValue(makeSession());
     db.listAgentTracingEvents.mockResolvedValue([]);

--- a/src/app/dashboard/tracing/sessions/[sessionId]/page.tsx
+++ b/src/app/dashboard/tracing/sessions/[sessionId]/page.tsx
@@ -640,10 +640,25 @@ function EventTokenStats({ event }: { event: TracingEvent }) {
     );
 }
 
+/**
+ * An object that is really a string spread into a record — `{...'undefined'}`
+ * gives `{0:'u',1:'n',…}`. Sessions captured before the agent-sdk 0.9.5 fix
+ * have this persisted, and the API strips it now; this is the same guard on
+ * the render side so a stale API build cannot put the noise back on screen.
+ */
+function isSpreadStringRecord(value: Record<string, unknown>): boolean {
+    const keys = Object.keys(value);
+    if (keys.length === 0) return false;
+    return keys.every((key, index) => key === String(index))
+        && Object.values(value).every((entry) => typeof entry === 'string' && entry.length === 1);
+}
+
 function getRecord(value: unknown): Record<string, unknown> | undefined {
-    return value && typeof value === 'object' && !Array.isArray(value)
-        ? value as Record<string, unknown>
-        : undefined;
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        return undefined;
+    }
+    const record = value as Record<string, unknown>;
+    return isSpreadStringRecord(record) ? undefined : record;
 }
 
 function ToolDetailsBlock({ event }: { event: TracingEvent }) {

--- a/src/lib/services/agentTracing.ts
+++ b/src/lib/services/agentTracing.ts
@@ -326,10 +326,52 @@ const SESSION_EVENT_SUMMARY_PROJECTION = {
   'sections.tools.name': 1,
 } as const;
 
+/**
+ * True for an object that is really a string somebody spread into a record:
+ * `{...'undefined'}` produces `{0:'u',1:'n',…}`.
+ *
+ * agent-sdk's `sanitizeTracePayload` answered an absent payload with the
+ * literal string `"undefined"` until 0.9.5, and the ingest that ran before
+ * the guard landed spread it into exactly this shape — so it is already
+ * persisted on every session captured in between, and no migration can be
+ * assumed. Matched on shape rather than on the word "undefined": keys are
+ * exactly 0..n-1 and every value is a single character, which no genuine
+ * tool-details or tool-definitions record ever looks like.
+ */
+function isSpreadStringRecord(value: Record<string, unknown>): boolean {
+  const keys = Object.keys(value);
+  if (keys.length === 0) return false;
+  return keys.every((key, index) => key === String(index))
+    && Object.values(value).every((entry) => typeof entry === 'string' && entry.length === 1);
+}
+
 function toRecord(value: unknown): Record<string, unknown> | undefined {
-  return value && typeof value === 'object' && !Array.isArray(value)
-    ? value as Record<string, unknown>
-    : undefined;
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return undefined;
+  }
+  const record = value as Record<string, unknown>;
+  return isSpreadStringRecord(record) ? undefined : record;
+}
+
+/**
+ * Drop stored metadata entries that are spread-string wreckage (see
+ * `isSpreadStringRecord`). The raw metadata bag is rendered verbatim in the
+ * event detail's Metadata tab, so without this the same `{0:'u',…}` noise the
+ * Tool Details panel now hides is still on screen one tab over.
+ */
+function stripSpreadStringValues(
+  metadata: Record<string, unknown> | undefined,
+): Record<string, unknown> | undefined {
+  if (!metadata) return metadata;
+  const entries = Object.entries(metadata).filter(([, entry]) => !(
+    entry
+    && typeof entry === 'object'
+    && !Array.isArray(entry)
+    && isSpreadStringRecord(entry as Record<string, unknown>)
+  ));
+  return entries.length === Object.keys(metadata).length
+    ? metadata
+    : Object.fromEntries(entries);
 }
 
 function getSectionToolName(section: Record<string, unknown>): string | undefined {
@@ -417,7 +459,7 @@ function mapTracingEventDetail(event: IAgentTracingEvent) {
     timestamp: event.timestamp,
     status: event.status,
     actor: event.actor,
-    metadata: event.metadata,
+    metadata: stripSpreadStringValues(event.metadata),
     sections: event.sections,
     model: event.model,
     error: event.error,


### PR DESCRIPTION
## Summary
Confirmed against production data (tenant_cognipeer, post-v1.2.28): sessions captured before agent-sdk 0.9.5 have `{0:'u',1:'n',...}` wreckage persisted on `agent_iteration`/`ai_call` events' `metadata.toolDetails` — the v1.2.28 ingest guard stops new writes but does not touch what's already stored, and the UI rendered the stored shape verbatim.

- Strips it on read (shape-matched: keys exactly `0..n-1`, every value a single character — no genuine `toolDetails`/`tool_definitions` record looks like that), not via migration.
- Applied in the API mapper (`agentTracing.ts`) so both the folded `toolDetails` field and the raw Metadata tab are clean, and again as a render-side guard in the session detail page.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint` on touched files — clean
- [x] Full suite: `npx vitest run` — 3237/3237 passed (2 new: hides the wreckage / leaves genuine tool details untouched)
- [x] Verified against live production data that the corruption is real and this shape-match catches it without false positives

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R7LsJcWXZ2D9ZmhEWx1UVL