### PR TITLE
Add Knowledge Base as an internal MCP source

### DIFF
--- a/src/app/dashboard/mcp/page.tsx
+++ b/src/app/dashboard/mcp/page.tsx
@@ -31,6 +31,7 @@ const SOURCE_LABELS: Record<string, string> = {
   openapi: 'OpenAPI',
   remote: 'Remote MCP',
   stdio: 'Package',
+  internal: 'Internal service',
 };
 
 export default function McpServersPage() {
@@ -162,11 +163,14 @@ export default function McpServersPage() {
       key: 'source',
       label: 'Source',
       render: (s) => {
+        const internal = s.metadata?.internal as { provider?: string; instanceKey?: string } | undefined;
         const target = s.sourceType === 'remote'
           ? s.remoteConfig?.url ?? ''
           : s.sourceType === 'stdio'
             ? `${s.stdioConfig?.runtime ?? 'npx'} ${s.stdioConfig?.packageName ?? ''}`
-            : s.upstreamBaseUrl ?? '';
+            : s.sourceType === 'internal'
+              ? `${internal?.provider ?? 'internal'} · ${internal?.instanceKey ?? ''}`
+              : s.upstreamBaseUrl ?? '';
         return (
           <div className="ds-col" style={{ gap: 2, whiteSpace: 'nowrap' }}>
             <span className="ds-badge">{SOURCE_LABELS[s.sourceType] ?? 'OpenAPI'}</span>

--- a/src/components/mcp/CreateMcpModal.tsx
+++ b/src/components/mcp/CreateMcpModal.tsx
@@ -30,11 +30,27 @@ interface CreateMcpModalProps {
 }
 
 type AuthType = 'none' | 'token' | 'header' | 'basic';
-type SourceType = 'openapi' | 'remote' | 'stdio';
+type SourceType = 'openapi' | 'remote' | 'stdio' | 'internal';
 type StdioRuntime = 'npx' | 'uvx';
 type ExecutionMode = 'subprocess' | 'sandbox';
 type AccessMode = 'token' | 'public';
 type AegisMode = 'off' | 'monitor' | 'enforce';
+
+interface InternalProviderConfigField {
+  key: string;
+  label: string;
+  type: 'model' | 'text' | 'number';
+  required?: boolean;
+  modelCategory?: string;
+  hint?: string;
+}
+
+interface InternalProviderInfo {
+  id: string;
+  label: string;
+  description: string;
+  configFields: InternalProviderConfigField[];
+}
 
 interface McpCapabilities {
   stdioSubprocess: { enabled: boolean; npx: boolean; uvx: boolean };
@@ -43,7 +59,25 @@ interface McpCapabilities {
   // it is off: no license (upgradeable) vs. community build (edition).
   stdioSandbox: { available: boolean; enterpriseBuild: boolean; seamAvailable?: boolean; licenseEnterprise?: boolean };
   aegis: { hookAvailable: boolean; enterpriseBuild: boolean; seamAvailable?: boolean; licenseEnterprise?: boolean };
+  mcpHub?: { available: boolean; enterpriseBuild: boolean; licenseEnterprise?: boolean };
+  internalProviders?: InternalProviderInfo[];
 }
+
+interface InternalInstanceOption {
+  key: string;
+  label: string;
+  description?: string;
+}
+
+interface McpHubOption {
+  id: string;
+  key: string;
+  name: string;
+  serverKeys: string[];
+}
+
+const NEW_HUB_VALUE = '__new__';
+const NO_HUB_VALUE = '__none__';
 
 interface FormValues {
   name: string;
@@ -64,6 +98,12 @@ interface FormValues {
   executionMode: ExecutionMode;
   sandboxCpu: string;
   sandboxMemory: string;
+  // internal
+  internalProvider: string;
+  internalInstanceKey: string;
+  internalAnswerModelKey: string;
+  hubChoice: string;
+  newHubName: string;
   // auth
   authType: AuthType;
   authToken: string;
@@ -108,6 +148,9 @@ export default function CreateMcpModal({
   const [loading, setLoading] = useState(false);
   const [capabilities, setCapabilities] = useState<McpCapabilities | null>(null);
   const [shields, setShields] = useState<Array<{ value: string; label: string }>>([]);
+  const [ragModules, setRagModules] = useState<InternalInstanceOption[]>([]);
+  const [chatModels, setChatModels] = useState<Array<{ value: string; label: string }>>([]);
+  const [hubs, setHubs] = useState<McpHubOption[]>([]);
 
   const form = useForm<FormValues>({
     initialValues: {
@@ -126,6 +169,11 @@ export default function CreateMcpModal({
       executionMode: 'subprocess',
       sandboxCpu: '1',
       sandboxMemory: '512',
+      internalProvider: 'knowledge-base',
+      internalInstanceKey: '',
+      internalAnswerModelKey: '',
+      hubChoice: NO_HUB_VALUE,
+      newHubName: '',
       authType: 'none',
       authToken: '',
       authHeaderName: '',
@@ -150,7 +198,18 @@ export default function CreateMcpModal({
       if (values.sourceType === 'stdio' && !values.stdioPackage.trim()) {
         errors.stdioPackage = 'Package name is required';
       }
-      if (values.sourceType !== 'stdio') {
+      if (values.sourceType === 'internal') {
+        if (!values.internalInstanceKey.trim()) {
+          errors.internalInstanceKey = 'Choose which Knowledge Base to publish';
+        }
+        if (!values.internalAnswerModelKey.trim()) {
+          errors.internalAnswerModelKey = 'Choose an answer model';
+        }
+        if (values.hubChoice === NEW_HUB_VALUE && !values.newHubName.trim()) {
+          errors.newHubName = 'Name the new hub';
+        }
+      }
+      if (values.sourceType !== 'stdio' && values.sourceType !== 'internal') {
         if (values.authType === 'token' && !values.authToken.trim()) {
           errors.authToken = 'Token is required';
         }
@@ -188,8 +247,58 @@ export default function CreateMcpModal({
         })).filter((s: { value: string }) => s.value));
       })
       .catch(() => setShields([]));
+    // Knowledge Base modules — instances for the "internal" (Knowledge Base) source.
+    fetch('/api/rag/modules?status=active')
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => {
+        const list = Array.isArray(data?.modules) ? data.modules : [];
+        setRagModules(list.map((m: { key: string; name: string; description?: string }) => ({
+          key: m.key,
+          label: m.name,
+          description: m.description,
+        })));
+      })
+      .catch(() => setRagModules([]));
+    // Chat models — candidates for the Knowledge Base "answer model".
+    fetch('/api/models?category=chat')
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => {
+        const list = Array.isArray(data?.models) ? data.models : [];
+        setChatModels(list.map((m: { key: string; name: string }) => ({
+          value: m.key,
+          label: m.name,
+        })));
+      })
+      .catch(() => setChatModels([]));
+    // MCP hubs — enterprise only; degrade silently when unavailable.
+    fetch('/api/mcp/hubs')
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => {
+        const list = Array.isArray(data?.hubs) ? data.hubs : [];
+        setHubs(list.map((h: { id: string; key: string; name: string; serverKeys?: string[] }) => ({
+          id: h.id,
+          key: h.key,
+          name: h.name,
+          serverKeys: h.serverKeys ?? [],
+        })));
+      })
+      .catch(() => setHubs([]));
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [opened]);
+
+  // Default the hub picker once hubs are known: one hub → preselect it,
+  // none → offer creating one, several → leave unattached by default.
+  useEffect(() => {
+    if (!opened || form.values.sourceType !== 'internal') return;
+    if (form.values.hubChoice !== NO_HUB_VALUE) return;
+    if (hubs.length === 1) {
+      form.setFieldValue('hubChoice', hubs[0].id);
+    } else if (hubs.length === 0 && capabilities?.mcpHub?.available) {
+      form.setFieldValue('hubChoice', NEW_HUB_VALUE);
+      form.setFieldValue('newHubName', 'Knowledge Base Tools');
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [opened, hubs, capabilities, form.values.sourceType]);
 
   const v = form.values;
 
@@ -200,9 +309,9 @@ export default function CreateMcpModal({
     setLoading(true);
     try {
       const upstreamAuth: Record<string, string> = {
-        type: v.sourceType === 'stdio' ? 'none' : v.authType,
+        type: v.sourceType === 'stdio' || v.sourceType === 'internal' ? 'none' : v.authType,
       };
-      if (v.sourceType !== 'stdio') {
+      if (v.sourceType !== 'stdio' && v.sourceType !== 'internal') {
         if (v.authType === 'token') {
           upstreamAuth.token = v.authToken;
         } else if (v.authType === 'header') {
@@ -242,6 +351,12 @@ export default function CreateMcpModal({
           url: v.remoteUrl.trim(),
           transport: v.remoteTransport,
         };
+      } else if (v.sourceType === 'internal') {
+        payload.internalConfig = {
+          provider: v.internalProvider,
+          instanceKey: v.internalInstanceKey,
+          config: { answerModelKey: v.internalAnswerModelKey },
+        };
       } else {
         const env = parseEnvLines(v.stdioEnv);
         payload.stdioConfig = {
@@ -273,6 +388,41 @@ export default function CreateMcpModal({
       }
 
       const data = await res.json();
+
+      // Optional hub attach — only reachable when sourceType is 'internal'
+      // and mcpHub is licensed (see the "Add to Hub" section below).
+      if (v.sourceType === 'internal' && v.hubChoice !== NO_HUB_VALUE) {
+        try {
+          if (v.hubChoice === NEW_HUB_VALUE) {
+            await fetch('/api/mcp/hubs', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({
+                name: v.newHubName.trim(),
+                serverKeys: [data.server.key],
+              }),
+            });
+          } else {
+            const hub = hubs.find((h) => h.id === v.hubChoice);
+            if (hub) {
+              await fetch(`/api/mcp/hubs/${hub.id}`, {
+                method: 'PATCH',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                  serverKeys: [...hub.serverKeys, data.server.key],
+                }),
+              });
+            }
+          }
+        } catch {
+          notifications.show({
+            title: 'Hub attach failed',
+            message: `"${v.name}" was created, but attaching it to the hub failed. You can attach it from the MCP Hubs page.`,
+            color: 'yellow',
+          });
+        }
+      }
+
       notifications.show({
         title: 'MCP Server Created',
         message: `"${v.name}" is ready to serve requests`,
@@ -292,7 +442,7 @@ export default function CreateMcpModal({
 
   const validIdentity = Boolean(v.name.trim());
   const validAuth = (() => {
-    if (v.sourceType === 'stdio') return true;
+    if (v.sourceType === 'stdio' || v.sourceType === 'internal') return true;
     if (v.authType === 'token') return Boolean(v.authToken.trim());
     if (v.authType === 'header') return Boolean(v.authHeaderName.trim() && v.authHeaderValue.trim());
     if (v.authType === 'basic') return Boolean(v.authUsername.trim() && v.authPassword.trim());
@@ -301,8 +451,11 @@ export default function CreateMcpModal({
   const validSource = useMemo(() => {
     if (v.sourceType === 'openapi') return Boolean(v.openApiSpec.trim());
     if (v.sourceType === 'remote') return Boolean(v.remoteUrl.trim());
+    if (v.sourceType === 'internal') {
+      return Boolean(v.internalInstanceKey.trim() && v.internalAnswerModelKey.trim());
+    }
     return Boolean(v.stdioPackage.trim());
-  }, [v.sourceType, v.openApiSpec, v.remoteUrl, v.stdioPackage]);
+  }, [v.sourceType, v.openApiSpec, v.remoteUrl, v.stdioPackage, v.internalInstanceKey, v.internalAnswerModelKey]);
   const validExposure = v.protocolHttp || v.protocolSse;
 
   const checklist = [
@@ -323,7 +476,10 @@ export default function CreateMcpModal({
     openapi: 'OpenAPI spec',
     remote: 'Remote MCP',
     stdio: 'Package (stdio)',
+    internal: 'Internal service',
   };
+
+  const selectedRagModule = ragModules.find((m) => m.key === v.internalInstanceKey);
 
   const sandboxAvailable = capabilities?.stdioSandbox.available ?? false;
   const subprocessEnabled = capabilities?.stdioSubprocess.enabled ?? true;
@@ -379,6 +535,29 @@ export default function CreateMcpModal({
             />
           </>
         ) : null}
+        {v.sourceType === 'internal' ? (
+          <>
+            <SummaryKV
+              label="Knowledge Base"
+              value={selectedRagModule?.label || <span className="ds-faint">—</span>}
+            />
+            <SummaryKV
+              label="Answer model"
+              value={chatModels.find((m) => m.value === v.internalAnswerModelKey)?.label
+                || <span className="ds-faint">—</span>}
+            />
+            <SummaryKV
+              label="Hub"
+              value={
+                v.hubChoice === NO_HUB_VALUE
+                  ? 'Not attached'
+                  : v.hubChoice === NEW_HUB_VALUE
+                    ? `New: ${v.newHubName || '…'}`
+                    : hubs.find((h) => h.id === v.hubChoice)?.name || '—'
+              }
+            />
+          </>
+        ) : null}
       </SummaryGroup>
 
       <SummaryGroup title="Exposure">
@@ -397,7 +576,7 @@ export default function CreateMcpModal({
         ) : null}
       </SummaryGroup>
 
-      {v.sourceType !== 'stdio' ? (
+      {v.sourceType !== 'stdio' && v.sourceType !== 'internal' ? (
         <SummaryGroup title="Authentication">
           <SummaryKV label="Type" value={authLabel[v.authType]} />
         </SummaryGroup>
@@ -466,11 +645,85 @@ export default function CreateMcpModal({
               { value: 'openapi', label: 'OpenAPI spec' },
               { value: 'remote', label: 'Remote MCP URL' },
               { value: 'stdio', label: 'npx / uvx package' },
+              { value: 'internal', label: 'Internal service' },
             ]}
             value={v.sourceType}
             onChange={(val) => form.setFieldValue('sourceType', val as SourceType)}
           />
         </FormField>
+
+        {v.sourceType === 'internal' ? (
+          <>
+            <FormField label="Internal service" hint="More internal services will show up here over time.">
+              <ChipPicker<string>
+                options={(capabilities?.internalProviders ?? [{ id: 'knowledge-base', label: 'Knowledge Base', description: '' }])
+                  .map((p) => ({ value: p.id, label: p.label }))}
+                value={v.internalProvider}
+                onChange={(val) => form.setFieldValue('internalProvider', val)}
+              />
+            </FormField>
+
+            {v.internalProvider === 'knowledge-base' ? (
+              <>
+                <FormRow cols={1}>
+                  <FormField label="Knowledge Base" required hint="The RAG module this tool answers questions from.">
+                    {ragModules.length === 0 ? (
+                      <Alert color="yellow" icon={<IconInfoCircle size={16} />}>
+                        No Knowledge Bases yet — create one under Dashboard → Knowledge Base first.
+                      </Alert>
+                    ) : (
+                      <Select
+                        placeholder="Choose a Knowledge Base"
+                        data={ragModules.map((m) => ({ value: m.key, label: m.label }))}
+                        value={v.internalInstanceKey || null}
+                        onChange={(val) => form.setFieldValue('internalInstanceKey', val ?? '')}
+                      />
+                    )}
+                  </FormField>
+                </FormRow>
+                <FormRow cols={1}>
+                  <FormField label="Answer model" required hint="Chat model used to generate the grounded answer.">
+                    <Select
+                      placeholder="Choose a model"
+                      data={chatModels}
+                      value={v.internalAnswerModelKey || null}
+                      onChange={(val) => form.setFieldValue('internalAnswerModelKey', val ?? '')}
+                    />
+                  </FormField>
+                </FormRow>
+              </>
+            ) : null}
+
+            <FormField
+              label="Add to hub"
+              optional
+              hint={capabilities?.mcpHub?.available
+                ? 'Publish this tool under an MCP hub so it shows up alongside your other catalogued servers.'
+                : 'MCP Hubs require an active Enterprise license. This tool is still created and callable on its own endpoint.'}
+            >
+              <Select
+                disabled={!capabilities?.mcpHub?.available}
+                data={[
+                  { value: NO_HUB_VALUE, label: "Don't attach" },
+                  ...hubs.map((h) => ({ value: h.id, label: h.name })),
+                  { value: NEW_HUB_VALUE, label: '+ Create new hub' },
+                ]}
+                value={v.hubChoice}
+                onChange={(val) => form.setFieldValue('hubChoice', val ?? NO_HUB_VALUE)}
+              />
+            </FormField>
+            {v.hubChoice === NEW_HUB_VALUE ? (
+              <FormRow cols={1}>
+                <FormField label="New hub name" required>
+                  <TextInput
+                    placeholder="Knowledge Base Tools"
+                    {...form.getInputProps('newHubName')}
+                  />
+                </FormField>
+              </FormRow>
+            ) : null}
+          </>
+        ) : null}
 
         {v.sourceType === 'openapi' ? (
           <>
@@ -606,7 +859,7 @@ export default function CreateMcpModal({
         ) : null}
       </FormSection>
 
-      {v.sourceType !== 'stdio' ? (
+      {v.sourceType !== 'stdio' && v.sourceType !== 'internal' ? (
         <FormSection
           number={3}
           title="Upstream authentication"
@@ -674,7 +927,7 @@ export default function CreateMcpModal({
       ) : null}
 
       <FormSection
-        number={v.sourceType === 'stdio' ? 3 : 4}
+        number={v.sourceType === 'stdio' || v.sourceType === 'internal' ? 3 : 4}
         title="Endpoint exposure"
         description="Which protocols this server is reachable on, and how callers authenticate."
         done={validExposure}
@@ -715,7 +968,7 @@ export default function CreateMcpModal({
       </FormSection>
 
       <FormSection
-        number={v.sourceType === 'stdio' ? 4 : 5}
+        number={v.sourceType === 'stdio' || v.sourceType === 'internal' ? 4 : 5}
         title="Aegis shield"
         description="Guardrail enforcement on tool calls (evaluated by the Aegis enforcement plane)."
         done

--- a/src/components/mcp/CreateMcpModal.tsx
+++ b/src/components/mcp/CreateMcpModal.tsx
@@ -78,6 +78,10 @@ interface McpHubOption {
 
 const NEW_HUB_VALUE = '__new__';
 const NO_HUB_VALUE = '__none__';
+// Providers other than Knowledge Base aren't scoped to a per-instance
+// resource yet (one MCP server covers the whole project) — this must match
+// the instance key each such provider's `listInstances()` returns.
+const SINGLE_INSTANCE_KEY = 'project';
 
 interface FormValues {
   name: string;
@@ -199,11 +203,13 @@ export default function CreateMcpModal({
         errors.stdioPackage = 'Package name is required';
       }
       if (values.sourceType === 'internal') {
-        if (!values.internalInstanceKey.trim()) {
-          errors.internalInstanceKey = 'Choose which Knowledge Base to publish';
-        }
-        if (!values.internalAnswerModelKey.trim()) {
-          errors.internalAnswerModelKey = 'Choose an answer model';
+        if (values.internalProvider === 'knowledge-base') {
+          if (!values.internalInstanceKey.trim()) {
+            errors.internalInstanceKey = 'Choose which Knowledge Base to publish';
+          }
+          if (!values.internalAnswerModelKey.trim()) {
+            errors.internalAnswerModelKey = 'Choose an answer model';
+          }
         }
         if (values.hubChoice === NEW_HUB_VALUE && !values.newHubName.trim()) {
           errors.newHubName = 'Name the new hub';
@@ -295,10 +301,21 @@ export default function CreateMcpModal({
       form.setFieldValue('hubChoice', hubs[0].id);
     } else if (hubs.length === 0 && capabilities?.mcpHub?.available) {
       form.setFieldValue('hubChoice', NEW_HUB_VALUE);
-      form.setFieldValue('newHubName', 'Knowledge Base Tools');
+      form.setFieldValue('newHubName', 'Internal Services');
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [opened, hubs, capabilities, form.values.sourceType]);
+
+  // Providers without a per-instance picker (anything but Knowledge Base, for
+  // now) always target the same single project-scoped instance.
+  useEffect(() => {
+    if (form.values.sourceType !== 'internal') return;
+    if (form.values.internalProvider === 'knowledge-base') return;
+    if (form.values.internalInstanceKey !== SINGLE_INSTANCE_KEY) {
+      form.setFieldValue('internalInstanceKey', SINGLE_INSTANCE_KEY);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [form.values.sourceType, form.values.internalProvider]);
 
   const v = form.values;
 
@@ -355,7 +372,9 @@ export default function CreateMcpModal({
         payload.internalConfig = {
           provider: v.internalProvider,
           instanceKey: v.internalInstanceKey,
-          config: { answerModelKey: v.internalAnswerModelKey },
+          config: v.internalProvider === 'knowledge-base'
+            ? { answerModelKey: v.internalAnswerModelKey }
+            : {},
         };
       } else {
         const env = parseEnvLines(v.stdioEnv);
@@ -452,10 +471,15 @@ export default function CreateMcpModal({
     if (v.sourceType === 'openapi') return Boolean(v.openApiSpec.trim());
     if (v.sourceType === 'remote') return Boolean(v.remoteUrl.trim());
     if (v.sourceType === 'internal') {
-      return Boolean(v.internalInstanceKey.trim() && v.internalAnswerModelKey.trim());
+      return v.internalProvider === 'knowledge-base'
+        ? Boolean(v.internalInstanceKey.trim() && v.internalAnswerModelKey.trim())
+        : Boolean(v.internalInstanceKey.trim());
     }
     return Boolean(v.stdioPackage.trim());
-  }, [v.sourceType, v.openApiSpec, v.remoteUrl, v.stdioPackage, v.internalInstanceKey, v.internalAnswerModelKey]);
+  }, [
+    v.sourceType, v.openApiSpec, v.remoteUrl, v.stdioPackage,
+    v.internalProvider, v.internalInstanceKey, v.internalAnswerModelKey,
+  ]);
   const validExposure = v.protocolHttp || v.protocolSse;
 
   const checklist = [
@@ -538,14 +562,23 @@ export default function CreateMcpModal({
         {v.sourceType === 'internal' ? (
           <>
             <SummaryKV
-              label="Knowledge Base"
-              value={selectedRagModule?.label || <span className="ds-faint">—</span>}
+              label="Service"
+              value={capabilities?.internalProviders?.find((p) => p.id === v.internalProvider)?.label
+                ?? v.internalProvider}
             />
-            <SummaryKV
-              label="Answer model"
-              value={chatModels.find((m) => m.value === v.internalAnswerModelKey)?.label
-                || <span className="ds-faint">—</span>}
-            />
+            {v.internalProvider === 'knowledge-base' ? (
+              <>
+                <SummaryKV
+                  label="Knowledge Base"
+                  value={selectedRagModule?.label || <span className="ds-faint">—</span>}
+                />
+                <SummaryKV
+                  label="Answer model"
+                  value={chatModels.find((m) => m.value === v.internalAnswerModelKey)?.label
+                    || <span className="ds-faint">—</span>}
+                />
+              </>
+            ) : null}
             <SummaryKV
               label="Hub"
               value={
@@ -659,7 +692,13 @@ export default function CreateMcpModal({
                 options={(capabilities?.internalProviders ?? [{ id: 'knowledge-base', label: 'Knowledge Base', description: '' }])
                   .map((p) => ({ value: p.id, label: p.label }))}
                 value={v.internalProvider}
-                onChange={(val) => form.setFieldValue('internalProvider', val)}
+                onChange={(val) => {
+                  form.setFieldValue('internalProvider', val);
+                  // Instance picking only applies to Knowledge Base today —
+                  // reset it when switching so a stale key can't leak through.
+                  form.setFieldValue('internalInstanceKey', '');
+                  form.setFieldValue('internalAnswerModelKey', '');
+                }}
               />
             </FormField>
 
@@ -692,7 +731,12 @@ export default function CreateMcpModal({
                   </FormField>
                 </FormRow>
               </>
-            ) : null}
+            ) : (
+              <Alert color="gray" icon={<IconInfoCircle size={16} />}>
+                {capabilities?.internalProviders?.find((p) => p.id === v.internalProvider)?.description
+                  ?? 'No extra configuration needed — this publishes reporting tools for this project.'}
+              </Alert>
+            )}
 
             <FormField
               label="Add to hub"

--- a/src/lib/database/provider/types.extended.ts
+++ b/src/lib/database/provider/types.extended.ts
@@ -188,8 +188,12 @@ export interface IMcpAuthConfig {
   sealed?: string;
 }
 
-/** Where the server's tools come from. Legacy records (no field) are 'openapi'. */
-export type McpSourceType = 'openapi' | 'remote' | 'stdio';
+/**
+ * Where the server's tools come from. Legacy records (no field) are 'openapi'.
+ * 'internal' backs a console-native capability (e.g. a Knowledge Base module)
+ * instead of an external upstream — see `src/lib/services/mcp/internal/`.
+ */
+export type McpSourceType = 'openapi' | 'remote' | 'stdio' | 'internal';
 
 /** Protocols the gateway exposes for a server. */
 export type McpExposureProtocol = 'streamable-http' | 'sse';

--- a/src/lib/services/mcp/index.ts
+++ b/src/lib/services/mcp/index.ts
@@ -43,4 +43,5 @@ export type {
   McpAuditContext,
   McpServerView,
   McpRequestLogView,
+  InternalMcpConfigInput,
 } from './types';

--- a/src/lib/services/mcp/internal/agentObservabilityProvider.ts
+++ b/src/lib/services/mcp/internal/agentObservabilityProvider.ts
@@ -1,0 +1,156 @@
+/**
+ * Internal MCP provider: Agent Observability (reporting only).
+ *
+ * Read-only tools over agent tracing data for the project the MCP server
+ * belongs to — list agents, list sessions, and inspect one session. No
+ * mutation tools are exposed; this is strictly a reporting surface.
+ */
+
+import { AgentTracingService } from '@/lib/services/agentTracing';
+import type {
+  InternalMcpInstanceOption,
+  InternalMcpProvider,
+  InternalMcpProviderContext,
+} from './types';
+
+/** This provider isn't scoped to a per-instance resource (unlike a Knowledge
+ *  Base module) — one MCP server covers all agent activity in the project. */
+const INSTANCE_KEY = 'project';
+
+const TOOL_LIST_AGENTS = 'list_agents';
+const TOOL_LIST_SESSIONS = 'list_sessions';
+const TOOL_GET_SESSION_DETAIL = 'get_session_detail';
+
+const optionalString = (value: unknown): string | undefined =>
+  typeof value === 'string' && value.trim() !== '' ? value.trim() : undefined;
+
+const boundedInt = (value: unknown, fallback: number, max: number): number => {
+  const n = typeof value === 'number' ? value : Number(value);
+  if (!Number.isFinite(n) || n <= 0) return fallback;
+  return Math.min(Math.floor(n), max);
+};
+
+function requireProjectId(ctx: InternalMcpProviderContext): string {
+  if (!ctx.projectId) {
+    throw new Error('Agent Observability tools require a project-scoped MCP server');
+  }
+  return ctx.projectId;
+}
+
+export const agentObservabilityProvider: InternalMcpProvider = {
+  id: 'agent-observability',
+  label: 'Agent Observability',
+  description: 'Read-only reporting over agent tracing: list agents, list sessions, and inspect a session.',
+  configFields: [],
+
+  async listInstances(_ctx: InternalMcpProviderContext): Promise<InternalMcpInstanceOption[]> {
+    return [
+      {
+        key: INSTANCE_KEY,
+        label: 'Agent Observability',
+        description: 'Reporting tools over this project\'s agent tracing sessions.',
+      },
+    ];
+  },
+
+  async validateInstance(_ctx, instanceKey) {
+    if (instanceKey !== INSTANCE_KEY) {
+      throw new Error(`Unknown Agent Observability instance "${instanceKey}"`);
+    }
+  },
+
+  async buildTools() {
+    return {
+      tools: [
+        {
+          name: TOOL_LIST_AGENTS,
+          description:
+            'List agents that have recorded tracing sessions in this project, with session '
+            + 'counts and the most recent session status/time per agent.',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              from: { type: 'string', format: 'date-time', description: 'ISO start timestamp (inclusive).' },
+              to: { type: 'string', format: 'date-time', description: 'ISO end timestamp (inclusive).' },
+              limit: { type: 'integer', minimum: 1, maximum: 200, default: 50, description: 'Max agents to return.' },
+            },
+            additionalProperties: false,
+          },
+        },
+        {
+          name: TOOL_LIST_SESSIONS,
+          description:
+            'List recent agent tracing sessions. Supports filtering by agent name, status, and a '
+            + 'free-text search across sessionId, threadId and agent name.',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              agent: { type: 'string', description: 'Filter by exact or partial agent name.' },
+              status: { type: 'string', enum: ['success', 'error', 'running'], description: 'Filter by session status.' },
+              query: { type: 'string', description: 'Free-text search on sessionId, threadId or agent name.' },
+              from: { type: 'string', format: 'date-time', description: 'ISO start timestamp (inclusive).' },
+              to: { type: 'string', format: 'date-time', description: 'ISO end timestamp (inclusive).' },
+              limit: { type: 'integer', minimum: 1, maximum: 100, default: 20, description: 'Max sessions to return.' },
+            },
+            additionalProperties: false,
+          },
+        },
+        {
+          name: TOOL_GET_SESSION_DETAIL,
+          description:
+            'Fetch one agent tracing session by sessionId — status, timing, token usage, '
+            + 'models/tools used, and error summary (without per-event payloads).',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              sessionId: { type: 'string', description: 'The sessionId to look up.' },
+            },
+            required: ['sessionId'],
+            additionalProperties: false,
+          },
+        },
+      ],
+      suggestedName: 'Agent Observability',
+      suggestedDescription: 'Read-only reporting over this project\'s agent tracing sessions.',
+    };
+  },
+
+  async execute(ctx, _instanceKey, _config, toolName, args) {
+    const projectId = requireProjectId(ctx);
+
+    if (toolName === TOOL_LIST_AGENTS) {
+      return AgentTracingService.listRecentAgents(ctx.tenantDbName, projectId, {
+        from: optionalString(args.from),
+        to: optionalString(args.to),
+        limit: boundedInt(args.limit, 50, 200),
+      });
+    }
+
+    if (toolName === TOOL_LIST_SESSIONS) {
+      return AgentTracingService.listSessions(ctx.tenantDbName, projectId, {
+        agent: optionalString(args.agent),
+        status: optionalString(args.status),
+        query: optionalString(args.query),
+        from: optionalString(args.from),
+        to: optionalString(args.to),
+        limit: String(boundedInt(args.limit, 20, 100)),
+      });
+    }
+
+    if (toolName === TOOL_GET_SESSION_DETAIL) {
+      const sessionId = optionalString(args.sessionId);
+      if (!sessionId) {
+        throw new Error('"sessionId" is required');
+      }
+      const result = await AgentTracingService.getSessionDetail(ctx.tenantDbName, projectId, sessionId, {
+        includeEventContent: false,
+      });
+      if (!result) {
+        throw new Error(`Session ${sessionId} not found`);
+      }
+      return { session: result.session, eventCount: result.events.length };
+    }
+
+    throw new Error(`Unknown tool "${toolName}" on Agent Observability provider`);
+  },
+};

--- a/src/lib/services/mcp/internal/knowledgeBaseProvider.ts
+++ b/src/lib/services/mcp/internal/knowledgeBaseProvider.ts
@@ -1,0 +1,112 @@
+/**
+ * Internal MCP provider: Knowledge Base (RAG module).
+ *
+ * Exposes a single grounded Q&A tool ("ask") backed by `answerWithRag`, so a
+ * Knowledge Base can be published as an MCP tool without hand-writing an
+ * OpenAPI spec. One provider instance = one RAG module = one MCP tool.
+ */
+
+import { listRagModules, getRagModule } from '@/lib/services/rag/ragService';
+import { answerWithRag } from '@/lib/services/rag/ragAnswerService';
+import type {
+  InternalMcpInstanceOption,
+  InternalMcpProvider,
+  InternalMcpProviderContext,
+} from './types';
+
+const TOOL_NAME = 'ask';
+
+function askInputSchema(): Record<string, unknown> {
+  return {
+    type: 'object',
+    properties: {
+      question: {
+        type: 'string',
+        description: 'The question to answer from this knowledge base.',
+      },
+    },
+    required: ['question'],
+    additionalProperties: false,
+  };
+}
+
+export const knowledgeBaseProvider: InternalMcpProvider = {
+  id: 'knowledge-base',
+  label: 'Knowledge Base',
+  description: 'Publish a Knowledge Base as a grounded question-answering MCP tool.',
+  configFields: [
+    {
+      key: 'answerModelKey',
+      label: 'Answer model',
+      type: 'model',
+      required: true,
+      modelCategory: 'chat',
+      hint: 'The chat model used to generate the grounded answer.',
+    },
+  ],
+
+  async listInstances(ctx: InternalMcpProviderContext): Promise<InternalMcpInstanceOption[]> {
+    const modules = await listRagModules(ctx.tenantDbName, {
+      projectId: ctx.projectId,
+      status: 'active',
+    });
+    return modules.map((m) => ({
+      key: m.key,
+      label: m.name,
+      description: m.description,
+    }));
+  },
+
+  async validateInstance(ctx, instanceKey, config) {
+    const ragModule = await getRagModule(ctx.tenantDbName, instanceKey, ctx.projectId);
+    if (!ragModule) {
+      throw new Error(`Knowledge Base "${instanceKey}" not found`);
+    }
+    const answerModelKey = config.answerModelKey;
+    if (typeof answerModelKey !== 'string' || !answerModelKey.trim()) {
+      throw new Error('answerModelKey is required for the Knowledge Base provider');
+    }
+  },
+
+  async buildTools(ctx, instanceKey, _config) {
+    const ragModule = await getRagModule(ctx.tenantDbName, instanceKey, ctx.projectId);
+    const label = ragModule?.name ?? instanceKey;
+    const description = ragModule?.description
+      ? `Ask a question and get a grounded answer from the "${label}" knowledge base. ${ragModule.description}`
+      : `Ask a question and get a grounded answer from the "${label}" knowledge base.`;
+    return {
+      tools: [
+        {
+          name: TOOL_NAME,
+          description,
+          inputSchema: askInputSchema(),
+        },
+      ],
+      suggestedName: label,
+      suggestedDescription: ragModule?.description,
+    };
+  },
+
+  async execute(ctx, instanceKey, config, toolName, args) {
+    if (toolName !== TOOL_NAME) {
+      throw new Error(`Unknown tool "${toolName}" on Knowledge Base provider`);
+    }
+    const question = typeof args.question === 'string' ? args.question.trim() : '';
+    if (!question) {
+      throw new Error('"question" is required');
+    }
+    const answerModelKey = config.answerModelKey;
+    if (typeof answerModelKey !== 'string' || !answerModelKey.trim()) {
+      throw new Error('This Knowledge Base tool is missing its configured answer model');
+    }
+    const result = await answerWithRag(ctx.tenantDbName, ctx.tenantId, ctx.projectId, {
+      ragModuleKey: instanceKey,
+      question,
+      answerModelKey,
+    });
+    return {
+      answer: result.answer,
+      citations: result.citations,
+    };
+  },
+};

--- a/src/lib/services/mcp/internal/registry.ts
+++ b/src/lib/services/mcp/internal/registry.ts
@@ -1,0 +1,32 @@
+/**
+ * Internal MCP provider registry.
+ *
+ * Add a new console-native capability here to make it selectable as an
+ * "Internal Service" MCP source. Keep providers self-contained — each one
+ * owns its own instance listing, config fields, tool schema and execution.
+ */
+
+import { knowledgeBaseProvider } from './knowledgeBaseProvider';
+import type { InternalMcpProvider } from './types';
+
+export const INTERNAL_MCP_PROVIDERS: InternalMcpProvider[] = [knowledgeBaseProvider];
+
+export function getInternalMcpProvider(id: string): InternalMcpProvider | undefined {
+  return INTERNAL_MCP_PROVIDERS.find((p) => p.id === id);
+}
+
+export function requireInternalMcpProvider(id: string): InternalMcpProvider {
+  const provider = getInternalMcpProvider(id);
+  if (!provider) {
+    throw new Error(`Unknown internal MCP provider "${id}"`);
+  }
+  return provider;
+}
+
+export type {
+  InternalMcpProvider,
+  InternalMcpProviderContext,
+  InternalMcpInstanceOption,
+  InternalMcpConfigField,
+  InternalMcpBuiltTools,
+} from './types';

--- a/src/lib/services/mcp/internal/registry.ts
+++ b/src/lib/services/mcp/internal/registry.ts
@@ -7,9 +7,13 @@
  */
 
 import { knowledgeBaseProvider } from './knowledgeBaseProvider';
+import { agentObservabilityProvider } from './agentObservabilityProvider';
 import type { InternalMcpProvider } from './types';
 
-export const INTERNAL_MCP_PROVIDERS: InternalMcpProvider[] = [knowledgeBaseProvider];
+export const INTERNAL_MCP_PROVIDERS: InternalMcpProvider[] = [
+  knowledgeBaseProvider,
+  agentObservabilityProvider,
+];
 
 export function getInternalMcpProvider(id: string): InternalMcpProvider | undefined {
   return INTERNAL_MCP_PROVIDERS.find((p) => p.id === id);

--- a/src/lib/services/mcp/internal/types.ts
+++ b/src/lib/services/mcp/internal/types.ts
@@ -1,0 +1,70 @@
+/**
+ * Internal MCP provider registry — types.
+ *
+ * An "internal" MCP server (sourceType 'internal') doesn't proxy an external
+ * upstream; it wraps a console-native capability (e.g. a Knowledge Base / RAG
+ * module) and serves it as MCP tools. Each capability that wants to be
+ * exposable this way registers one provider here — see `registry.ts`.
+ */
+
+import type { IMcpTool } from '@/lib/database';
+
+export interface InternalMcpProviderContext {
+  tenantDbName: string;
+  tenantId: string;
+  projectId?: string;
+}
+
+/** One selectable instance of a provider, e.g. a single RAG module. */
+export interface InternalMcpInstanceOption {
+  key: string;
+  label: string;
+  description?: string;
+}
+
+/** Extra settings the create/edit form must collect for a provider. */
+export interface InternalMcpConfigField {
+  key: string;
+  label: string;
+  type: 'model' | 'text' | 'number';
+  required?: boolean;
+  /** For type 'model': narrows the model picker (e.g. 'chat'). */
+  modelCategory?: string;
+  hint?: string;
+}
+
+export interface InternalMcpBuiltTools {
+  tools: IMcpTool[];
+  /** Suggested server name when the user leaves the name blank. */
+  suggestedName: string;
+  suggestedDescription?: string;
+}
+
+export interface InternalMcpProvider {
+  id: string;
+  label: string;
+  description: string;
+  configFields: InternalMcpConfigField[];
+  /** List the tenant's selectable instances (e.g. RAG modules) for this provider. */
+  listInstances(ctx: InternalMcpProviderContext): Promise<InternalMcpInstanceOption[]>;
+  /** Validate an instance key + config exist/are well-formed before saving. */
+  validateInstance(
+    ctx: InternalMcpProviderContext,
+    instanceKey: string,
+    config: Record<string, unknown>,
+  ): Promise<void>;
+  /** Build the MCP tool descriptor(s) for one instance. */
+  buildTools(
+    ctx: InternalMcpProviderContext,
+    instanceKey: string,
+    config: Record<string, unknown>,
+  ): Promise<InternalMcpBuiltTools>;
+  /** Execute a tool call against one instance. */
+  execute(
+    ctx: InternalMcpProviderContext,
+    instanceKey: string,
+    config: Record<string, unknown>,
+    toolName: string,
+    args: Record<string, unknown>,
+  ): Promise<unknown>;
+}

--- a/src/lib/services/mcp/mcpService.ts
+++ b/src/lib/services/mcp/mcpService.ts
@@ -44,6 +44,7 @@ import {
 import { remoteCallTool, remoteListTools } from './remoteMcpClient';
 import { isStdioRunnerEnabled, stdioCallTool, stdioListTools } from './stdioRunner';
 import { mcpGuardrailHook, mcpSandboxRunner } from '@/enterprise/registry';
+import { requireInternalMcpProvider } from './internal/registry';
 
 const logger = createLogger('mcp-service');
 const SLUG_OPTIONS = { lower: true, strict: true, trim: true };
@@ -372,6 +373,14 @@ function validateCreateInput(input: CreateMcpServerInput): McpSourceType {
       throw new Error('Stdio subprocess execution is disabled on this deployment');
     }
   }
+  if (sourceType === 'internal') {
+    if (!input.internalConfig?.provider?.trim()) {
+      throw new Error('internalConfig.provider is required for source type "internal"');
+    }
+    if (!input.internalConfig?.instanceKey?.trim()) {
+      throw new Error('internalConfig.instanceKey is required for source type "internal"');
+    }
+  }
   return sourceType;
 }
 
@@ -428,12 +437,26 @@ export async function createMcpServer(
 
   const stdioConfig = input.stdioConfig ? sealStdioEnv(input.stdioConfig) : undefined;
 
+  let internalMetadata: Record<string, unknown> | undefined;
+  let description = input.description?.trim();
+  if (sourceType === 'internal') {
+    const ctx = { tenantDbName, tenantId, projectId };
+    const provider = requireInternalMcpProvider(input.internalConfig!.provider);
+    const instanceKey = input.internalConfig!.instanceKey;
+    const config = input.internalConfig!.config ?? {};
+    await provider.validateInstance(ctx, instanceKey, config);
+    const built = await provider.buildTools(ctx, instanceKey, config);
+    tools = built.tools;
+    description = description || built.suggestedDescription;
+    internalMetadata = { provider: provider.id, instanceKey, config };
+  }
+
   const server = await db.createMcpServer({
     tenantId,
     projectId: projectId ?? undefined,
     key,
     name: input.name.trim(),
-    description: input.description?.trim(),
+    description,
     sourceType,
     openApiSpec: normalizedSpec,
     remoteConfig: input.remoteConfig,
@@ -447,6 +470,7 @@ export async function createMcpServer(
     status: 'active',
     endpointSlug,
     totalRequests: 0,
+    metadata: internalMetadata ? { internal: internalMetadata } : undefined,
     createdBy: userId,
   });
 
@@ -618,6 +642,27 @@ export async function updateMcpServer(
     && (updateData.stdioConfig as IMcpStdioConfig).executionMode === 'subprocess') {
     updateData.tools = await stdioListTools(updateData.stdioConfig as IMcpStdioConfig);
     updateData.toolsDiscoveredAt = new Date();
+  }
+  if (sourceType === 'internal' && input.internalConfig !== undefined) {
+    const existingInternal = (existing.metadata as Record<string, unknown> | undefined)?.internal as
+      | { provider?: string; instanceKey?: string; config?: Record<string, unknown> }
+      | undefined;
+    const providerId = input.internalConfig.provider || existingInternal?.provider;
+    const instanceKey = input.internalConfig.instanceKey || existingInternal?.instanceKey;
+    if (!providerId || !instanceKey) {
+      throw new Error('internalConfig.provider and internalConfig.instanceKey are required');
+    }
+    const config = { ...(existingInternal?.config ?? {}), ...(input.internalConfig.config ?? {}) };
+    const provider = requireInternalMcpProvider(providerId);
+    const ctx = { tenantDbName, tenantId: existing.tenantId, projectId: existing.projectId };
+    await provider.validateInstance(ctx, instanceKey, config);
+    const built = await provider.buildTools(ctx, instanceKey, config);
+    updateData.tools = built.tools;
+    updateData.toolsDiscoveredAt = new Date();
+    updateData.metadata = {
+      ...((updateData.metadata as Record<string, unknown> | undefined) ?? existing.metadata),
+      internal: { provider: provider.id, instanceKey, config },
+    };
   }
 
   // Tool enable/disable list (metadata-backed). Runs after tool rediscovery so
@@ -1086,6 +1131,26 @@ export async function executeMcpToolLocal(
           auth: openAuthConfig(server.upstreamAuth),
           extraHeaders: runtimeHeaders,
         },
+        toolName,
+        effectiveArgs,
+      );
+    } else if (sourceType === 'internal') {
+      const internal = (server.metadata as Record<string, unknown> | undefined)?.internal as
+        | { provider?: string; instanceKey?: string; config?: Record<string, unknown> }
+        | undefined;
+      if (!internal?.provider || !internal.instanceKey) {
+        throw new Error(`MCP server "${server.name}" has no internal provider configured`);
+      }
+      const provider = requireInternalMcpProvider(internal.provider);
+      const db = await getDatabase();
+      const tenant = await db.findTenantById(server.tenantId);
+      if (!tenant?.dbName) {
+        throw new Error('Could not resolve tenant database for internal MCP execution');
+      }
+      result = await provider.execute(
+        { tenantDbName: tenant.dbName, tenantId: server.tenantId, projectId: server.projectId },
+        internal.instanceKey,
+        internal.config ?? {},
         toolName,
         effectiveArgs,
       );

--- a/src/lib/services/mcp/types.ts
+++ b/src/lib/services/mcp/types.ts
@@ -82,8 +82,20 @@ export interface CreateMcpServerInput {
   remoteConfig?: IMcpRemoteConfig;
   /** Stdio launch config (sourceType 'stdio'). */
   stdioConfig?: IMcpStdioConfig;
+  /** Console-native capability config (sourceType 'internal'). */
+  internalConfig?: InternalMcpConfigInput;
   exposure?: IMcpExposureConfig;
   aegis?: IMcpAegisConfig;
+}
+
+/** Which internal capability backs the server, and its instance + settings. */
+export interface InternalMcpConfigInput {
+  /** Provider id from the internal MCP provider registry, e.g. 'knowledge-base'. */
+  provider: string;
+  /** The provider-specific instance key, e.g. a RAG module key. */
+  instanceKey: string;
+  /** Provider-defined settings (e.g. answerModelKey for 'knowledge-base'). */
+  config?: Record<string, unknown>;
 }
 
 export interface UpdateMcpServerInput {
@@ -95,6 +107,8 @@ export interface UpdateMcpServerInput {
   upstreamAuth?: IMcpAuthConfig;
   remoteConfig?: IMcpRemoteConfig;
   stdioConfig?: IMcpStdioConfig;
+  /** Console-native capability config (sourceType 'internal'). */
+  internalConfig?: InternalMcpConfigInput;
   exposure?: IMcpExposureConfig;
   aegis?: IMcpAegisConfig;
   status?: string;

--- a/src/server/api/plugins/mcp.ts
+++ b/src/server/api/plugins/mcp.ts
@@ -30,7 +30,8 @@ import {
   isStdioRunnerEnabled,
   updateMcpServer,
 } from '@/lib/services/mcp';
-import type { McpAuditContext } from '@/lib/services/mcp';
+import type { McpAuditContext, InternalMcpConfigInput } from '@/lib/services/mcp';
+import { INTERNAL_MCP_PROVIDERS } from '@/lib/services/mcp/internal/registry';
 import {
   buildRuntimeContextFromRequest,
   describeRuntimeAuth,
@@ -49,7 +50,7 @@ import {
 
 const logger = createLogger('api:mcp');
 const VALID_AUTH_TYPES: McpAuthType[] = ['none', 'token', 'header', 'basic'];
-const VALID_SOURCE_TYPES = ['openapi', 'remote', 'stdio'] as const;
+const VALID_SOURCE_TYPES = ['openapi', 'remote', 'stdio', 'internal'] as const;
 
 function auditContextFor(request: FastifyRequest, userId: string): McpAuditContext {
   const ua = request.headers['user-agent'];
@@ -89,6 +90,20 @@ function parseRemoteConfig(raw: unknown): IMcpRemoteConfig | undefined {
   return {
     url: value.url.trim(),
     transport: value.transport === 'sse' ? 'sse' : 'streamable-http',
+  };
+}
+
+function parseInternalConfig(raw: unknown): InternalMcpConfigInput | undefined {
+  if (!raw || typeof raw !== 'object') return undefined;
+  const value = raw as { provider?: unknown; instanceKey?: unknown; config?: unknown };
+  if (typeof value.provider !== 'string' || !value.provider.trim()) return undefined;
+  if (typeof value.instanceKey !== 'string' || !value.instanceKey.trim()) return undefined;
+  return {
+    provider: value.provider.trim(),
+    instanceKey: value.instanceKey.trim(),
+    config: value.config && typeof value.config === 'object'
+      ? value.config as Record<string, unknown>
+      : undefined,
   };
 }
 
@@ -197,6 +212,20 @@ export const mcpApiPlugin: FastifyPluginAsync = async (app) => {
           enterpriseBuild: IS_ENTERPRISE_BUILD,
           licenseEnterprise,
         },
+        // MCP Hubs ship as a whole separate plugin in the enterprise overlay
+        // (no seam ref to check, unlike sandbox/Aegis) — the build flag alone
+        // says whether the /api/mcp/hubs routes even exist.
+        mcpHub: {
+          available: IS_ENTERPRISE_BUILD && licenseEnterprise,
+          enterpriseBuild: IS_ENTERPRISE_BUILD,
+          licenseEnterprise,
+        },
+        internalProviders: INTERNAL_MCP_PROVIDERS.map((p) => ({
+          id: p.id,
+          label: p.label,
+          description: p.description,
+          configFields: p.configFields,
+        })),
       });
     } catch (error) {
       return sendProjectContextError(reply, error)
@@ -254,7 +283,7 @@ export const mcpApiPlugin: FastifyPluginAsync = async (app) => {
 
       const sourceType = typeof body.sourceType === 'string' ? body.sourceType : 'openapi';
       if (!VALID_SOURCE_TYPES.includes(sourceType as typeof VALID_SOURCE_TYPES[number])) {
-        return reply.code(400).send({ error: 'sourceType must be "openapi", "remote", or "stdio"' });
+        return reply.code(400).send({ error: 'sourceType must be "openapi", "remote", "stdio", or "internal"' });
       }
 
       if (sourceType === 'openapi' && typeof body.openApiSpec !== 'string') {
@@ -269,6 +298,16 @@ export const mcpApiPlugin: FastifyPluginAsync = async (app) => {
       const stdioConfig = parseStdioConfig(body.stdioConfig);
       if (sourceType === 'stdio' && !stdioConfig) {
         return reply.code(400).send({ error: 'stdioConfig.packageName is required' });
+      }
+
+      const internalConfig = parseInternalConfig(body.internalConfig);
+      if (sourceType === 'internal') {
+        if (!internalConfig) {
+          return reply.code(400).send({ error: 'internalConfig.provider and internalConfig.instanceKey are required' });
+        }
+        if (!INTERNAL_MCP_PROVIDERS.some((p) => p.id === internalConfig.provider)) {
+          return reply.code(400).send({ error: `Unknown internal provider "${internalConfig.provider}"` });
+        }
       }
 
       // Enterprise sub-feature: persistent sandbox execution needs the runtime
@@ -309,7 +348,7 @@ export const mcpApiPlugin: FastifyPluginAsync = async (app) => {
         {
           description: typeof body.description === 'string' ? body.description.trim() : undefined,
           name: body.name.trim(),
-          sourceType: sourceType as 'openapi' | 'remote' | 'stdio',
+          sourceType: sourceType as 'openapi' | 'remote' | 'stdio' | 'internal',
           openApiSpec: typeof body.openApiSpec === 'string' ? body.openApiSpec : undefined,
           specFormat: typeof body.specFormat === 'string' ? body.specFormat as SpecFormatHint : undefined,
           upstreamAuth: body.upstreamAuth as IMcpAuthConfig,
@@ -318,6 +357,7 @@ export const mcpApiPlugin: FastifyPluginAsync = async (app) => {
             : undefined,
           remoteConfig,
           stdioConfig,
+          internalConfig,
           exposure: parseExposure(body.exposure),
           aegis: aegisConfig,
         },
@@ -430,6 +470,7 @@ export const mcpApiPlugin: FastifyPluginAsync = async (app) => {
         upstreamBaseUrl: body.upstreamBaseUrl as string | undefined,
         remoteConfig: body.remoteConfig !== undefined ? parseRemoteConfig(body.remoteConfig) : undefined,
         stdioConfig: nextStdioConfig,
+        internalConfig: body.internalConfig !== undefined ? parseInternalConfig(body.internalConfig) : undefined,
         exposure: body.exposure !== undefined ? parseExposure(body.exposure) : undefined,
         aegis: nextAegis,
         runtimeHeaders: body.runtimeHeaders as { allow?: boolean; allowedNames?: string[] } | null | undefined,


### PR DESCRIPTION
Lets a Knowledge Base (RAG module) be published as an MCP tool without
hand-writing an OpenAPI spec: the "Add MCP server" modal gains a new
"Internal service" source type, backed by an extensible internal MCP
provider registry (src/lib/services/mcp/internal/) so future
console-native capabilities can register the same way.

The Knowledge Base provider exposes a single grounded "ask" tool
(answerWithRag under the hood) and, on the same create flow, can
attach the new server to an existing MCP Hub or create a default one
when the enterprise mcp-hub module is licensed.