### PR TITLE
Add MongoDB Community vector store; default it when DB_PROVIDER=mongodb

### DIFF
--- a/src/__tests__/unit/builtin-providers.test.ts
+++ b/src/__tests__/unit/builtin-providers.test.ts
@@ -7,7 +7,8 @@
  * never throws into the calling read path.
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { reloadConfig } from '@/lib/core/config';
 
 const mockDb = {
   switchToTenant: vi.fn(),
@@ -58,6 +59,12 @@ function freshScope() {
   };
 }
 
+// The built-in vector driver depends on DB_PROVIDER (mongodb-community-vector
+// vs. sqlite-vector — see builtinProviders.ts). Pin it to sqlite here so
+// these tests are deterministic regardless of the environment they run in;
+// the DB_PROVIDER=mongodb branch gets its own dedicated test below.
+const previousDbProvider = process.env.DB_PROVIDER;
+
 beforeEach(() => {
   vi.clearAllMocks();
   mockDb.switchToTenant.mockResolvedValue(undefined);
@@ -66,6 +73,17 @@ beforeEach(() => {
   mockCreateProviderConfig.mockResolvedValue({} as never);
   mockUpdateProviderConfig.mockResolvedValue({} as never);
   mockCreateFileBucket.mockResolvedValue({} as never);
+  process.env.DB_PROVIDER = 'sqlite';
+  reloadConfig();
+});
+
+afterEach(() => {
+  if (previousDbProvider === undefined) {
+    delete process.env.DB_PROVIDER;
+  } else {
+    process.env.DB_PROVIDER = previousDbProvider;
+  }
+  reloadConfig();
 });
 
 describe('ensureBuiltinProviders', () => {
@@ -168,6 +186,20 @@ describe('ensureBuiltinProviders', () => {
     await expect(
       ensureBuiltinProviders(tenantDbName, TENANT_ID, projectId, USER_ID),
     ).resolves.toBeUndefined();
+  });
+
+  it('uses the MongoDB community vector driver when DB_PROVIDER=mongodb', async () => {
+    const { tenantDbName, projectId } = freshScope();
+
+    process.env.DB_PROVIDER = 'mongodb';
+    reloadConfig();
+
+    await ensureBuiltinProviders(tenantDbName, TENANT_ID, projectId, USER_ID);
+
+    const vectorPayload = mockCreateProviderConfig.mock.calls.find(
+      ([, , payload]) => payload.key === BUILTIN_VECTOR_PROVIDER_KEY,
+    )![2];
+    expect(vectorPayload.driver).toBe('mongodb-community-vector');
   });
 
   it('memoises successful provisioning per tenant/project pair', async () => {

--- a/src/__tests__/unit/mongo-community-vector-contract.test.ts
+++ b/src/__tests__/unit/mongo-community-vector-contract.test.ts
@@ -1,0 +1,213 @@
+/**
+ * Unit tests — MongoDB Community Vector Provider Contract
+ *
+ * Runs the same contract behaviour as the SQLite vector store tests, but
+ * against a real MongoDB instance (mongodb-memory-server) — no Atlas
+ * `$vectorSearch` index involved, since this contract scores candidates in
+ * application code.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { createRequire } from 'node:module';
+import { MongoCommunityVectorProviderContract } from '@/lib/providers/contracts/mongoCommunityVector.contract';
+import type { VectorProviderRuntime } from '@/lib/providers/domains/vector';
+
+const MONGO_AVAILABLE: boolean = (() => {
+  try {
+    createRequire(import.meta.url).resolve('mongodb-memory-server');
+    return true;
+  } catch {
+    return false;
+  }
+})();
+
+const TENANT_ID = 'test-tenant-1';
+const PROVIDER_KEY = 'test-mongo-vec-provider';
+
+describe.runIf(MONGO_AVAILABLE)('MongoCommunityVectorProviderContract', () => {
+  let server: { getUri(): string; stop(): Promise<boolean> };
+  let runtime: VectorProviderRuntime;
+
+  beforeAll(async () => {
+    const { MongoMemoryServer } = await import('mongodb-memory-server');
+    server = await MongoMemoryServer.create();
+
+    runtime = await MongoCommunityVectorProviderContract.createRuntime({
+      tenantId: TENANT_ID,
+      providerKey: PROVIDER_KEY,
+      credentials: { uri: server.getUri() },
+      settings: { database: 'test_vectors' },
+    });
+  });
+
+  afterAll(async () => {
+    await server?.stop();
+  });
+
+  // ── Contract shape ────────────────────────────────────────────────────
+
+  it('has the correct id and declares vector domain', () => {
+    expect(MongoCommunityVectorProviderContract.id).toBe('mongodb-community-vector');
+    expect(MongoCommunityVectorProviderContract.domains).toContain('vector');
+  });
+
+  it('declares the builtin capability without being node-local', () => {
+    expect(MongoCommunityVectorProviderContract.capabilities?.builtin).toBe(true);
+    expect(MongoCommunityVectorProviderContract.capabilities?.local).toBe(false);
+  });
+
+  it('has an optional uri credential (falls back to the app MongoDB connection)', () => {
+    const fields = MongoCommunityVectorProviderContract.form.sections.flatMap((s) => s.fields);
+    const uriField = fields.find((f) => f.name === 'uri');
+    expect(uriField).toBeDefined();
+    expect(uriField!.required).toBe(false);
+    expect(uriField!.scope).toBe('credentials');
+  });
+
+  // ── Index CRUD ────────────────────────────────────────────────────────
+
+  it('creates an index and returns a handle', async () => {
+    const handle = await runtime.createIndex({ name: 'test-index', dimension: 3, metric: 'cosine' });
+    expect(handle.externalId).toBeTruthy();
+    expect(handle.name).toBe('test-index');
+    expect(handle.dimension).toBe(3);
+    expect(handle.metric).toBe('cosine');
+  });
+
+  it('lists indexes', async () => {
+    const indexes = await runtime.listIndexes();
+    expect(indexes.find((i) => i.name === 'test-index')).toBeDefined();
+  });
+
+  it('deletes an index and cascades its vectors', async () => {
+    const handle = await runtime.createIndex({ name: 'to-delete', dimension: 2 });
+    await runtime.upsertVectors(handle, [{ id: 'x1', values: [1, 0] }]);
+
+    await runtime.deleteIndex({ externalId: handle.externalId });
+
+    const indexes = await runtime.listIndexes();
+    expect(indexes.find((i) => i.name === 'to-delete')).toBeUndefined();
+
+    // Recreating with the same handle id space must not resurrect old vectors.
+    const revived = await runtime.createIndex({ name: 'to-delete', dimension: 2 });
+    const result = await runtime.queryVectors(revived, { vector: [1, 0], topK: 10 });
+    expect(result.matches).toHaveLength(0);
+  });
+
+  // ── Vector operations ─────────────────────────────────────────────────
+
+  describe('Vector upsert and query', () => {
+    let handle: Awaited<ReturnType<typeof runtime.createIndex>>;
+
+    beforeAll(async () => {
+      handle = await runtime.createIndex({ name: 'query-test', dimension: 3, metric: 'cosine' });
+      await runtime.upsertVectors(handle, [
+        { id: 'v1', values: [1, 0, 0], metadata: { label: 'x-axis' } },
+        { id: 'v2', values: [0, 1, 0], metadata: { label: 'y-axis' } },
+        { id: 'v3', values: [0, 0, 1], metadata: { label: 'z-axis' } },
+        { id: 'v4', values: [0.7071, 0.7071, 0], metadata: { label: 'xy-diagonal' } },
+      ]);
+    });
+
+    it('returns top-K results sorted by cosine similarity', async () => {
+      const result = await runtime.queryVectors(handle, { vector: [1, 0, 0], topK: 2 });
+      expect(result.matches).toHaveLength(2);
+      expect(result.matches[0].id).toBe('v1');
+      expect(result.matches[0].score).toBeCloseTo(1.0, 4);
+      expect(result.matches[1].id).toBe('v4');
+    });
+
+    it('includes metadata in query results', async () => {
+      const result = await runtime.queryVectors(handle, { vector: [0, 1, 0], topK: 1 });
+      expect(result.matches[0].id).toBe('v2');
+      expect(result.matches[0].metadata).toEqual({ label: 'y-axis' });
+    });
+
+    it('reports usage with candidate count', async () => {
+      const result = await runtime.queryVectors(handle, { vector: [0, 0, 1], topK: 10 });
+      expect(result.usage?.candidateCount).toBe(4);
+      expect(result.matches).toHaveLength(4);
+    });
+
+    it('upserts (updates) existing vectors in place', async () => {
+      await runtime.upsertVectors(handle, [{ id: 'v1', values: [0, 0, 1], metadata: { label: 'updated-to-z' } }]);
+      const result = await runtime.queryVectors(handle, { vector: [0, 0, 1], topK: 1 });
+      expect(result.matches[0].id).toBe('v1');
+      expect(result.matches[0].metadata).toEqual({ label: 'updated-to-z' });
+    });
+
+    it('deletes vectors by id', async () => {
+      await runtime.deleteVectors(handle, ['v1']);
+      const result = await runtime.queryVectors(handle, { vector: [1, 0, 0], topK: 10 });
+      expect(result.matches.map((m) => m.id)).not.toContain('v1');
+      expect(result.matches).toHaveLength(3);
+    });
+  });
+
+  // ── Tenant isolation ──────────────────────────────────────────────────
+
+  it('does not leak vectors between tenant/provider collection pairs', async () => {
+    const handleA = await runtime.createIndex({ name: 'iso-a', dimension: 2 });
+    await runtime.upsertVectors(handleA, [{ id: 'a1', values: [1, 0] }]);
+
+    const runtimeB = await MongoCommunityVectorProviderContract.createRuntime({
+      tenantId: 'other-tenant',
+      providerKey: PROVIDER_KEY,
+      credentials: { uri: server.getUri() },
+      settings: { database: 'test_vectors' },
+    });
+
+    const indexesB = await runtimeB.listIndexes();
+    expect(indexesB.find((i) => i.name === 'iso-a')).toBeUndefined();
+  });
+
+  // ── Dimension validation ────────────────────────────────────────────
+
+  it('rejects upsert/query with mismatched dimensions', async () => {
+    const handle = await runtime.createIndex({ name: 'dim-check', dimension: 2 });
+    await expect(
+      runtime.upsertVectors(handle, [{ id: 'd1', values: [1, 2, 3] }]),
+    ).rejects.toThrow(/dimension mismatch/i);
+    await expect(
+      runtime.queryVectors(handle, { vector: [1, 2, 3], topK: 1 }),
+    ).rejects.toThrow(/dimension mismatch/i);
+  });
+
+  // ── Edge cases ────────────────────────────────────────────────────────
+
+  it('handles empty upsert/delete gracefully', async () => {
+    const h = await runtime.createIndex({ name: 'empty-ops', dimension: 2 });
+    await expect(runtime.upsertVectors(h, [])).resolves.toBeUndefined();
+    await expect(runtime.deleteVectors(h, [])).resolves.toBeUndefined();
+  });
+
+  // ── Pagination ──────────────────────────────────────────────────────
+
+  it('paginates listVectors and returns the true top-K on query', async () => {
+    const h = await runtime.createIndex({ name: 'bulk-topk', dimension: 2, metric: 'dot' });
+    const items = Array.from({ length: 150 }, (_, i) => ({ id: `bulk-${i}`, values: [i, 1] }));
+    await runtime.upsertVectors(h, items);
+
+    const result = await runtime.queryVectors(h, { vector: [1, 0], topK: 5 });
+    expect(result.matches.map((m) => m.id)).toEqual([
+      'bulk-149',
+      'bulk-148',
+      'bulk-147',
+      'bulk-146',
+      'bulk-145',
+    ]);
+
+    const page1 = await runtime.listVectors(h, { limit: 100 });
+    expect(page1.items).toHaveLength(100);
+    expect(page1.total).toBe(150);
+    expect(page1.nextCursor).toBeDefined();
+
+    const page2 = await runtime.listVectors(h, { limit: 100, cursor: page1.nextCursor });
+    expect(page2.items).toHaveLength(50);
+    expect(page2.nextCursor).toBeUndefined();
+  });
+});
+
+describe.skipIf(MONGO_AVAILABLE)('MongoCommunityVectorProviderContract', () => {
+  it.skip('mongodb-memory-server not installed — skipping', () => {});
+});

--- a/src/config/service-catalog.json
+++ b/src/config/service-catalog.json
@@ -200,6 +200,17 @@
       "aliases": ["atlas"]
     },
     {
+      "id": "mongodb-community-vector",
+      "driver": "mongodb-community-vector",
+      "name": "MongoDB Vector Store",
+      "tagline": "Shared vector store on any MongoDB (no Atlas required)",
+      "description": "Brute-force similarity search computed at query time against a standard MongoDB deployment (self-hosted Community or Atlas). No Atlas Search index needed — safe for clustered/multi-instance deployments since data lives in MongoDB, not on node-local disk.",
+      "domains": ["vector"],
+      "color": "#10b981",
+      "tags": ["built-in", "self-hosted", "default"],
+      "aliases": ["mongo-community", "mongo-vector"]
+    },
+    {
       "id": "postgres",
       "driver": "postgres",
       "name": "PostgreSQL (pgvector)",

--- a/src/lib/providers/contracts/index.ts
+++ b/src/lib/providers/contracts/index.ts
@@ -21,6 +21,7 @@ import { MilvusVectorProviderContract } from './milvusVector.contract';
 import { MilvusCloudVectorProviderContract } from './milvusCloudVector.contract';
 import { MilvusLocalVectorProviderContract } from './milvusLocalVector.contract';
 import { MongoDbVectorProviderContract } from './mongodbVector.contract';
+import { MongoCommunityVectorProviderContract } from './mongoCommunityVector.contract';
 import { OramaVectorProviderContract } from './oramaVector.contract';
 import { PostgresVectorProviderContract } from './postgresVector.contract';
 import { SystemDefaultVectorProviderContract } from './systemDefaultVector.contract';
@@ -42,6 +43,7 @@ export const CORE_PROVIDER_CONTRACTS = [
   MilvusCloudVectorProviderContract,
   MilvusLocalVectorProviderContract,
   MongoDbVectorProviderContract,
+  MongoCommunityVectorProviderContract,
   OramaVectorProviderContract,
   PostgresVectorProviderContract,
   SystemDefaultVectorProviderContract,

--- a/src/lib/providers/contracts/mongoCommunityVector.contract.ts
+++ b/src/lib/providers/contracts/mongoCommunityVector.contract.ts
@@ -1,0 +1,448 @@
+import { MongoClient, type Db, type Collection } from 'mongodb';
+import { getConfig } from '@/lib/core/config';
+import type { ProviderContract } from '../types';
+import type {
+  CreateVectorIndexInput,
+  VectorDeleteIndexInput,
+  VectorIndexHandle,
+  VectorProviderRuntime,
+  VectorQueryInput,
+  VectorQueryResult,
+  VectorUpsertItem,
+  VectorListInput,
+  VectorListResult,
+} from '../domains/vector';
+
+/**
+ * MongoDB Community Vector Store — brute-force similarity, no Atlas required.
+ *
+ * The `mongodb` (Atlas Vector Search) contract needs a `$vectorSearch` index
+ * created ahead of time via the Atlas UI/API, which only exists on Atlas
+ * clusters. Self-hosted MongoDB (the `mongo:7` image in docker-compose, or
+ * any Community server) has no equivalent. This contract scores every
+ * candidate in application code instead — same trade-off the built-in SQLite
+ * Vector Store already makes — so it works against any MongoDB deployment.
+ *
+ * Unlike the SQLite store, data lives in MongoDB rather than on node-local
+ * disk: every app instance in a cluster reads/writes the same collections,
+ * so indexing on one node and querying from another (the failure mode that
+ * makes the local SQLite store unsafe in multi-instance deployments) cannot
+ * happen here.
+ */
+
+interface MongoCommunityVectorCredentials {
+  uri?: string;
+}
+
+interface MongoCommunityVectorSettings {
+  database?: string;
+  collectionPrefix?: string;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Similarity                                                         */
+/* ------------------------------------------------------------------ */
+
+function computeScore(
+  query: number[],
+  candidate: number[],
+  metric: 'cosine' | 'dot' | 'euclidean',
+): number {
+  const len = Math.min(query.length, candidate.length);
+
+  switch (metric) {
+    case 'dot': {
+      let dot = 0;
+      for (let i = 0; i < len; i++) dot += query[i] * candidate[i];
+      return dot;
+    }
+    case 'euclidean': {
+      let sum = 0;
+      for (let i = 0; i < len; i++) {
+        const d = query[i] - candidate[i];
+        sum += d * d;
+      }
+      return 1 / (1 + Math.sqrt(sum));
+    }
+    case 'cosine':
+    default: {
+      let dot = 0;
+      let magQ = 0;
+      let magC = 0;
+      for (let i = 0; i < len; i++) {
+        dot += query[i] * candidate[i];
+        magQ += query[i] * query[i];
+        magC += candidate[i] * candidate[i];
+      }
+      if (magQ === 0 || magC === 0) return 0;
+      return dot / (Math.sqrt(magQ) * Math.sqrt(magC));
+    }
+  }
+}
+
+/* ------------------------------------------------------------------ */
+/*  Row types                                                          */
+/* ------------------------------------------------------------------ */
+
+interface IndexDoc {
+  _id: string;
+  name: string;
+  dimension: number;
+  metric: 'cosine' | 'dot' | 'euclidean';
+  metadata?: Record<string, unknown> | null;
+  createdAt: Date;
+}
+
+interface EntryDoc {
+  _id: string;
+  indexId: string;
+  vectorId: string;
+  values: number[];
+  metadata?: Record<string, unknown> | null;
+  createdAt: Date;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Connection resolution                                              */
+/* ------------------------------------------------------------------ */
+
+function resolveUri(credentials: MongoCommunityVectorCredentials): string {
+  const explicit = credentials?.uri?.trim();
+  if (explicit) return explicit;
+
+  // Zero-config path: reuse the app's own MongoDB connection when it is
+  // already the main database, mirroring the SQLite store's "no external
+  // service required" positioning for Mongo-backed deployments.
+  const cfg = getConfig();
+  if (cfg.database.provider === 'mongodb' && cfg.database.uri) {
+    return cfg.database.uri;
+  }
+
+  throw new Error(
+    'MongoDB Vector Store requires a connection URI. Set DB_PROVIDER=mongodb (so the app\'s own MongoDB connection can be reused), or provide a "uri" credential explicitly.',
+  );
+}
+
+// One collection pair per tenant+provider — the Mongo equivalent of the
+// SQLite store's per-tenant file. Physically separates tenants instead of
+// relying only on query filters to enforce isolation.
+function buildCollectionNames(
+  settings: MongoCommunityVectorSettings,
+  tenantId: string,
+  providerKey: string,
+): { dbName: string; indexesCollection: string; entriesCollection: string } {
+  const dbName = settings.database?.trim() || 'cognipeer_vectors';
+  const prefix = settings.collectionPrefix?.trim() || 'vec';
+  const safeTenant = tenantId.replace(/[^a-zA-Z0-9_]/g, '_');
+  const safeProvider = providerKey.replace(/[^a-zA-Z0-9_]/g, '_');
+  const suffix = `${safeTenant}__${safeProvider}`;
+  return {
+    dbName,
+    indexesCollection: `${prefix}_indexes__${suffix}`,
+    entriesCollection: `${prefix}_entries__${suffix}`,
+  };
+}
+
+/* ------------------------------------------------------------------ */
+/*  Contract                                                           */
+/* ------------------------------------------------------------------ */
+
+export const MongoCommunityVectorProviderContract: ProviderContract<
+  VectorProviderRuntime,
+  MongoCommunityVectorCredentials,
+  MongoCommunityVectorSettings
+> = {
+  id: 'mongodb-community-vector',
+  version: '1.0.0',
+  domains: ['vector'],
+  display: {
+    label: 'MongoDB Vector Store',
+    description:
+      'Shared vector store backed by any MongoDB deployment (self-hosted Community or Atlas). Scores candidates at query time instead of relying on an Atlas Search index, so it works out of the box in clustered/multi-instance deployments.',
+  },
+  form: {
+    sections: [
+      {
+        title: 'Connection',
+        description: 'Leave empty to reuse the app\'s own MongoDB connection (when DB_PROVIDER=mongodb).',
+        fields: [
+          {
+            name: 'uri',
+            label: 'Connection URI',
+            type: 'password',
+            required: false,
+            placeholder: 'mongodb://user:pass@host:27017',
+            description: 'Optional. Defaults to the app\'s MONGODB_URI when left empty.',
+            scope: 'credentials',
+          },
+        ],
+      },
+      {
+        title: 'Storage',
+        fields: [
+          {
+            name: 'database',
+            label: 'Database',
+            type: 'text',
+            required: false,
+            placeholder: 'cognipeer_vectors',
+            description: 'Optional. Defaults to a dedicated "cognipeer_vectors" database.',
+            scope: 'settings',
+          },
+          {
+            name: 'collectionPrefix',
+            label: 'Collection Prefix',
+            type: 'text',
+            required: false,
+            placeholder: 'vec',
+            description: 'Optional. A tenant-scoped collection pair is created per Knowledge Engine using this prefix.',
+            scope: 'settings',
+          },
+        ],
+      },
+    ],
+  },
+  capabilities: {
+    supportsUpsert: true,
+    supportsQuery: true,
+    supportsDelete: true,
+    supportsMetadataFilter: false,
+    local: false,
+    builtin: true,
+    shared: true,
+  },
+
+  async createRuntime({ tenantId, providerKey, credentials, settings, logger }) {
+    const uri = resolveUri(credentials);
+    const { dbName, indexesCollection, entriesCollection } = buildCollectionNames(
+      settings,
+      tenantId,
+      providerKey,
+    );
+
+    const client = new MongoClient(uri);
+    await client.connect();
+    const db: Db = client.db(dbName);
+    const indexes: Collection<IndexDoc> = db.collection(indexesCollection);
+    const entries: Collection<EntryDoc> = db.collection(entriesCollection);
+
+    await Promise.all([
+      entries.createIndex({ indexId: 1 }),
+      entries.createIndex({ indexId: 1, vectorId: 1 }, { unique: true }),
+    ]);
+
+    logger?.info?.('MongoDB community vector runtime initialised', {
+      providerKey,
+      dbName,
+      indexesCollection,
+      entriesCollection,
+    });
+
+    const runtime: VectorProviderRuntime = {
+      /* ---- createIndex ---- */
+      async createIndex(input: CreateVectorIndexInput): Promise<VectorIndexHandle> {
+        const metric = input.metric ?? 'cosine';
+        const id = `idx-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+        await indexes.insertOne({
+          _id: id,
+          name: input.name,
+          dimension: input.dimension,
+          metric,
+          metadata: input.metadata ?? null,
+          createdAt: new Date(),
+        });
+
+        logger?.info?.('Created vector index', { providerKey, indexId: id, name: input.name });
+
+        return {
+          externalId: id,
+          name: input.name,
+          dimension: input.dimension,
+          metric,
+          metadata: input.metadata,
+        };
+      },
+
+      /* ---- deleteIndex ---- */
+      async deleteIndex({ externalId }: VectorDeleteIndexInput): Promise<void> {
+        await indexes.deleteOne({ _id: externalId });
+        await entries.deleteMany({ indexId: externalId });
+        logger?.info?.('Deleted vector index', { providerKey, externalId });
+      },
+
+      /* ---- listIndexes ---- */
+      async listIndexes(): Promise<VectorIndexHandle[]> {
+        const docs = await indexes.find({}).sort({ createdAt: 1 }).toArray();
+        return docs.map((d) => ({
+          externalId: d._id,
+          name: d.name,
+          dimension: d.dimension,
+          metric: d.metric,
+          metadata: d.metadata ?? undefined,
+        }));
+      },
+
+      /* ---- upsertVectors ---- */
+      async upsertVectors(handle: VectorIndexHandle, items: VectorUpsertItem[]): Promise<void> {
+        if (items.length === 0) return;
+
+        for (const item of items) {
+          if (item.values.length !== handle.dimension) {
+            throw new Error(
+              `Dimension mismatch: expected ${handle.dimension}, got ${item.values.length} for vector id=${item.id}`,
+            );
+          }
+        }
+
+        // Self-heal the index doc, mirroring the SQLite store: the console
+        // keeps the index handle forever, so a parent row wiped independently
+        // (manual cleanup, a dropped collection) must not break future writes.
+        await indexes.updateOne(
+          { _id: handle.externalId },
+          {
+            $setOnInsert: {
+              _id: handle.externalId,
+              name: handle.name,
+              dimension: handle.dimension,
+              metric: handle.metric,
+              metadata: handle.metadata ?? null,
+              createdAt: new Date(),
+            },
+          },
+          { upsert: true },
+        );
+
+        const now = new Date();
+        await entries.bulkWrite(
+          items.map((item) => ({
+            replaceOne: {
+              filter: { _id: `${handle.externalId}:${item.id}` },
+              replacement: {
+                _id: `${handle.externalId}:${item.id}`,
+                indexId: handle.externalId,
+                vectorId: item.id,
+                values: item.values,
+                metadata: item.metadata ?? null,
+                createdAt: now,
+              },
+              upsert: true,
+            },
+          })),
+        );
+
+        logger?.debug?.('Upserted vectors', {
+          providerKey,
+          externalId: handle.externalId,
+          count: items.length,
+        });
+      },
+
+      /* ---- deleteVectors ---- */
+      async deleteVectors(handle: VectorIndexHandle, ids: string[]): Promise<void> {
+        if (ids.length === 0) return;
+        await entries.deleteMany({ indexId: handle.externalId, vectorId: { $in: ids } });
+        logger?.debug?.('Deleted vectors', {
+          providerKey,
+          externalId: handle.externalId,
+          count: ids.length,
+        });
+      },
+
+      /* ---- queryVectors ---- */
+      async queryVectors(
+        handle: VectorIndexHandle,
+        query: VectorQueryInput,
+      ): Promise<VectorQueryResult> {
+        if (query.vector.length !== handle.dimension) {
+          throw new Error(
+            `Query dimension mismatch: expected ${handle.dimension}, got ${query.vector.length}`,
+          );
+        }
+
+        const metric = handle.metric ?? 'cosine';
+        const topK = Math.max(1, query.topK);
+
+        // Stream candidates and keep only the current top-K so memory stays
+        // flat regardless of index size — same approach as the SQLite store.
+        const best: Array<{ id: string; score: number; metadata?: Record<string, unknown> | null }> = [];
+        let minIdx = 0;
+        let candidateCount = 0;
+
+        const cursor = entries.find(
+          { indexId: handle.externalId },
+          { projection: { vectorId: 1, values: 1, metadata: 1 } },
+        );
+
+        for await (const doc of cursor) {
+          candidateCount += 1;
+          const score = computeScore(query.vector, doc.values, metric);
+
+          if (best.length < topK) {
+            best.push({ id: doc.vectorId, score, metadata: doc.metadata });
+            if (best.length === topK) {
+              minIdx = 0;
+              for (let i = 1; i < best.length; i++) {
+                if (best[i].score < best[minIdx].score) minIdx = i;
+              }
+            }
+            continue;
+          }
+
+          if (score > best[minIdx].score) {
+            best[minIdx] = { id: doc.vectorId, score, metadata: doc.metadata };
+            minIdx = 0;
+            for (let i = 1; i < best.length; i++) {
+              if (best[i].score < best[minIdx].score) minIdx = i;
+            }
+          }
+        }
+
+        best.sort((a, b) => b.score - a.score);
+
+        return {
+          matches: best.map((entry) => ({
+            id: entry.id,
+            score: entry.score,
+            metadata: entry.metadata ?? undefined,
+          })),
+          usage: { candidateCount, metric },
+        };
+      },
+
+      /* ---- listVectors ---- */
+      async listVectors(
+        handle: VectorIndexHandle,
+        input?: VectorListInput,
+      ): Promise<VectorListResult> {
+        const limit = input?.limit ?? 100;
+        const offset = input?.cursor ? parseInt(input.cursor, 10) : 0;
+
+        const [docs, total] = await Promise.all([
+          entries
+            .find({ indexId: handle.externalId })
+            .sort({ _id: 1 })
+            .skip(offset)
+            .limit(limit + 1)
+            .toArray(),
+          entries.countDocuments({ indexId: handle.externalId }),
+        ]);
+
+        const hasMore = docs.length > limit;
+        const pageDocs = hasMore ? docs.slice(0, limit) : docs;
+
+        return {
+          items: pageDocs.map((doc) => ({
+            id: doc.vectorId,
+            values: doc.values,
+            metadata: doc.metadata ?? undefined,
+          })),
+          nextCursor: hasMore ? String(offset + limit) : undefined,
+          total,
+        };
+      },
+    };
+
+    return runtime;
+  },
+};

--- a/src/lib/services/providers/builtinProviders.ts
+++ b/src/lib/services/providers/builtinProviders.ts
@@ -1,5 +1,6 @@
 import { getDatabase } from '@/lib/database';
 import { createLogger } from '@/lib/core/logger';
+import { getConfig } from '@/lib/core/config';
 import {
   createProviderConfig,
   updateProviderConfig,
@@ -9,11 +10,18 @@ import { createFileBucket } from '@/lib/services/files';
 /**
  * Built-in zero-configuration providers.
  *
- * Every tenant/project gets a local vector provider (SQLite) and a local
- * file provider (server filesystem) without any manual setup, so knowledge
- * bases can be created out of the box — no external services, credentials
- * or settings required. Data lives under DATA_DIR (the mounted app-data
- * volume in Docker).
+ * Every tenant/project gets a vector provider and a local file provider
+ * without any manual setup, so knowledge bases can be created out of the
+ * box — no external services, credentials or settings required.
+ *
+ * The vector driver depends on the main database:
+ *  - DB_PROVIDER=sqlite → local SQLite files under DATA_DIR. Fine as long as
+ *    the app runs as a single instance (the store is node-local disk).
+ *  - DB_PROVIDER=mongodb → the app already has a shared MongoDB connection,
+ *    so the vector store lives there too (brute-force query, no Atlas Search
+ *    index required — see mongoCommunityVector.contract.ts). This keeps
+ *    indexing and querying consistent across every node in a cluster, which
+ *    a node-local SQLite file cannot guarantee.
  */
 
 export const BUILTIN_VECTOR_PROVIDER_KEY = 'builtin-vector';
@@ -35,24 +43,40 @@ interface BuiltinProviderSpec {
   description: string;
 }
 
-const BUILTIN_PROVIDER_SPECS: BuiltinProviderSpec[] = [
-  {
-    key: BUILTIN_VECTOR_PROVIDER_KEY,
-    type: 'vector',
-    driver: 'sqlite-vector',
-    label: 'Built-in Vector Store',
-    description:
-      'Local persistent vector store (SQLite). No external service or credentials required.',
-  },
-  {
-    key: BUILTIN_FILE_PROVIDER_KEY,
-    type: 'file',
-    driver: 'local-filesystem',
-    label: 'Built-in File Storage',
-    description:
-      'Local persistent file storage on the server disk. No external service or credentials required.',
-  },
-];
+function builtinVectorSpec(): BuiltinProviderSpec {
+  const isMongo = getConfig().database.provider === 'mongodb';
+  return isMongo
+    ? {
+        key: BUILTIN_VECTOR_PROVIDER_KEY,
+        type: 'vector',
+        driver: 'mongodb-community-vector',
+        label: 'Built-in Vector Store',
+        description:
+          'Shared vector store on the app\'s own MongoDB connection. No external service, credentials, or Atlas Search index required.',
+      }
+    : {
+        key: BUILTIN_VECTOR_PROVIDER_KEY,
+        type: 'vector',
+        driver: 'sqlite-vector',
+        label: 'Built-in Vector Store',
+        description:
+          'Local persistent vector store (SQLite). No external service or credentials required.',
+      };
+}
+
+function builtinProviderSpecs(): BuiltinProviderSpec[] {
+  return [
+    builtinVectorSpec(),
+    {
+      key: BUILTIN_FILE_PROVIDER_KEY,
+      type: 'file',
+      driver: 'local-filesystem',
+      label: 'Built-in File Storage',
+      description:
+        'Local persistent file storage on the server disk. No external service or credentials required.',
+    },
+  ];
+}
 
 function isAlreadyExistsError(error: unknown): boolean {
   return error instanceof Error && /already exists/i.test(error.message);
@@ -160,7 +184,7 @@ export async function ensureBuiltinProviders(
   if (ensured.has(memoKey)) return;
 
   try {
-    for (const spec of BUILTIN_PROVIDER_SPECS) {
+    for (const spec of builtinProviderSpecs()) {
       await ensureProviderRecord(tenantDbName, tenantId, projectId, userId, spec);
     }
     await ensureBuiltinBucket(tenantDbName, tenantId, projectId, userId);


### PR DESCRIPTION
The built-in SQLite vector store persists to node-local disk with no
cluster affinity for reads/writes, so in a multi-instance deployment a
knowledge_search tool call can land on a different node than the one
that indexed the documents and silently return zero matches.

Add a new brute-force vector provider (mongodb-community-vector) that
scores candidates in application code against any MongoDB deployment
(self-hosted Community or Atlas) instead of relying on an Atlas
$vectorSearch index, so it works with the plain `mongo:7` image and is
safe across instances since the data lives in shared MongoDB rather
than on a single node's disk. New tenant/project provisioning now
defaults the built-in vector provider to this driver when
DB_PROVIDER=mongodb, keeping sqlite-vector as the default otherwise.
Existing provider records are left untouched.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017VTQazexHVJjkoLRj3ocU8