### PR TITLE
fix(mcp): resolve production build type error in CreateMcpModal

### DIFF
--- a/src/components/mcp/CreateMcpModal.tsx
+++ b/src/components/mcp/CreateMcpModal.tsx
@@ -693,7 +693,9 @@ export default function CreateMcpModal({
                   .map((p) => ({ value: p.id, label: p.label }))}
                 value={v.internalProvider}
                 onChange={(val) => {
-                  form.setFieldValue('internalProvider', val);
+                  // ChipPicker<T> types onChange as T | Set<T> for multi-select;
+                  // this usage is single-select, so val is always a plain string.
+                  form.setFieldValue('internalProvider', val as string);
                   // Instance picking only applies to Knowledge Base today —
                   // reset it when switching so a stale key can't leak through.
                   form.setFieldValue('internalInstanceKey', '');


### PR DESCRIPTION
## Problem

`v1.2.33-community` (and the SaaS/on-prem builds layered on top of it) all failed the production build with:

```
./src/components/mcp/CreateMcpModal.tsx:696:58
Type error: Argument of type 'string | Set<string>' is not assignable to parameter of type 'string | ((prevValue: string) => string)'.
```

## Root cause

`ChipPicker<T>` types `onChange` as `(next: T | Set<T>) => void` to support both single- and multi-select usage. This call site is single-select (no `multiple` prop), so `val` is always a plain string at runtime, but the type checker still sees the full union. Every other `ChipPicker` usage in this file already narrows with an `as` cast (`val as SourceType`, `val as AuthType`, etc.) — this one, added in the Knowledge Base internal MCP source work, was missed.

## Fix

Cast `val as string` before passing it to `form.setFieldValue('internalProvider', ...)`, consistent with the existing pattern in this file.

## Validation

- `npx tsc --noEmit` no longer reports this error.