### PR TITLE
feat(redis): name the cache and queue connections with the node

### DIFF
--- a/src/lib/core/cache/redisCacheProvider.ts
+++ b/src/lib/core/cache/redisCacheProvider.ts
@@ -7,6 +7,7 @@
  */
 
 import { randomUUID } from 'crypto';
+import { getThisNodeName } from '../cluster/nodeRegistry';
 import type { CacheProvider } from './cacheProvider.interface';
 
 // ioredis is an optional dependency — only imported when this provider is used
@@ -60,6 +61,7 @@ export class RedisCacheProvider implements CacheProvider {
       maxRetriesPerRequest: 3,
       retryStrategy: (times) => Math.min(times * 200, 3000),
       lazyConnect: true,
+      connectionName: `console:${getThisNodeName()}:cache`,
     });
     await this.client.connect();
   }

--- a/src/lib/core/queue/bullmqQueueProvider.ts
+++ b/src/lib/core/queue/bullmqQueueProvider.ts
@@ -50,8 +50,8 @@ export class BullMQQueueProvider implements QueueProvider {
   }
 
   async init(): Promise<void> {
-    this.connection = this.createConnection();
-    this.subscriberConnection = this.createConnection();
+    this.connection = this.createConnection('queue');
+    this.subscriberConnection = this.createConnection('queue-sub');
     // No-op until first publish/consume — keeps boot cheap on idle nodes.
   }
 
@@ -152,10 +152,11 @@ export class BullMQQueueProvider implements QueueProvider {
 
   // ── Internals ─────────────────────────────────────────────────────
 
-  private createConnection(): Redis {
+  private createConnection(role: string): Redis {
     return new Redis(this.cfg.redisUrl, {
       maxRetriesPerRequest: null,
       enableReadyCheck: false,
+      connectionName: `console:${getThisNodeName()}:${role}`,
     });
   }
 


### PR DESCRIPTION
## Why

Redis connections arrived unnamed, so `CLIENT LIST` on the server could not say which node or which component owned a connection. That is the first question asked when connections leak or `maxclients` fills up — and it is a hard requirement from the bank we are onboarding.

## What

Both Redis clients now send `CLIENT SETNAME`:

| Site | Name |
| --- | --- |
| `src/lib/core/cache/redisCacheProvider.ts` | `console:<node>:cache` |
| `src/lib/core/queue/bullmqQueueProvider.ts` | `console:<node>:queue`, `console:<node>:queue-sub` |

No second identity scheme was introduced: the node name comes from the existing `getThisNodeName()` (`NODE_NAME`, else `hostname-pid`), which the queue provider already imported.

## Why this is safe on production

- ioredis sends `CLIENT SETNAME` in the same awaited batch as the two `CLIENT SETINFO` commands it already sends on every connect, and wraps it in `.catch(noop)`. A server or proxy that rejects the command still connects.
- Both providers are opt-in (`CACHE_PROVIDER=redis`, `QUEUE_PROVIDER=bullmq`); memory and MongoDB paths are untouched.
- No key, TTL or payload changed — only connection metadata. The name is re-sent on every reconnect, so it survives a failover.

## Verification

- `tsc --noEmit`: no new errors (the three pre-existing `agentService.ts` trace-type errors are unrelated and untouched)
- `src/__tests__/unit/cache-provider.test.ts` passing
- After deploy: `redis-cli client list | grep -o 'name=[^ ]*' | sort | uniq -c`
