### PR TITLE
fix(vector): Azure document keys cannot start with an underscore

### DIFF
--- a/src/__tests__/contracts/azure-ai-search-vector.test.ts
+++ b/src/__tests__/contracts/azure-ai-search-vector.test.ts
@@ -32,7 +32,16 @@ vi.mock('@azure/search-documents', () => ({
 import { AzureAiSearchVectorProviderContract } from '@/lib/providers/contracts/azureAiSearchVector.contract';
 import type { VectorProviderRuntime, VectorIndexHandle } from '@/lib/providers/domains/vector';
 
-const AZURE_KEY_PATTERN = /^[A-Za-z0-9_\-=]+$/;
+/**
+ * Azure's ACTUAL rule, which is the charset PLUS "may not start with an
+ * underscore". The pattern here used to omit that second half, so it happily
+ * accepted the `_b64_` marker this provider was producing — every upsert against
+ * a real index came back
+ * "Invalid document key: '_b64_…'. Keys cannot start with a leading underscore."
+ * while this suite stayed green. A mocked SDK can only ever check what the
+ * assertion knows, so the assertion has to carry the whole rule.
+ */
+const AZURE_KEY_PATTERN = /^[A-Za-z0-9\-=][A-Za-z0-9_\-=]*$/;
 
 /** An index created before filterable metadata existed. */
 const HANDLE: VectorIndexHandle = {
@@ -90,6 +99,27 @@ describe('AzureAiSearchVectorProvider — document key encoding', () => {
     expect(docs).toHaveLength(1);
     expect(docs[0].id).not.toBe(unsafeId);
     expect(docs[0].id).toMatch(AZURE_KEY_PATTERN);
+  });
+
+  it('never produces a key Azure would reject, for any shape of caller id', async () => {
+    // The ids a real deployment actually sends, including the ones that made the
+    // marker itself illegal.
+    const ids = [
+      'akbank-55d99256:6a87cf02fca13acf380663aa:0',
+      '_leading-underscore',
+      'with space',
+      'türkçe-karakter:1',
+      'a=b',
+      'safe_id-123=',
+    ];
+
+    for (const id of ids) {
+      vi.clearAllMocks();
+      await runtime.upsertVectors(HANDLE, [{ id, values: [0.1, 0.2, 0.3] }]);
+      const [docs] = mergeOrUploadDocuments.mock.calls[0];
+      expect(docs[0].id, `key for ${id}`).toMatch(AZURE_KEY_PATTERN);
+      expect(docs[0].id.startsWith('_'), `key for ${id} starts with _`).toBe(false);
+    }
   });
 
   it('leaves already-safe ids untouched on upsert', async () => {

--- a/src/lib/providers/contracts/azureAiSearchVector.contract.ts
+++ b/src/lib/providers/contracts/azureAiSearchVector.contract.ts
@@ -109,11 +109,18 @@ function guardCandidateCount(topK: number): number {
 }
 
 // Azure AI Search document keys may only contain letters, digits, underscore (_),
-// dash (-), or equal sign (=). Caller-supplied vector ids (e.g. Knowledge Engine's
-// "module:documentId:chunkIndex") routinely violate that, so unsafe ids are stored
-// under a marked, URL-safe Base64 form and transparently decoded on the way out.
-const SAFE_KEY_PATTERN = /^[A-Za-z0-9_\-=]+$/;
-const ENCODED_KEY_PREFIX = '_b64_';
+// dash (-), or equal sign (=), AND MAY NOT START WITH AN UNDERSCORE. Caller-supplied
+// vector ids (e.g. Knowledge Engine's "module:documentId:chunkIndex") routinely
+// violate that, so unsafe ids are stored under a marked, URL-safe Base64 form and
+// transparently decoded on the way out.
+//
+// The marker therefore starts with a letter. A leading underscore is the one thing
+// that looks like a natural marker here and is exactly what Azure rejects:
+// "Invalid document key: '_b64_…'. Keys cannot start with a leading underscore."
+const SAFE_KEY_PATTERN = /^[A-Za-z0-9\-=][A-Za-z0-9_\-=]*$/;
+const ENCODED_KEY_PREFIX = 'b64_';
+/** Only ever produced by a build that used the rejected marker; decoded for safety. */
+const LEGACY_ENCODED_KEY_PREFIX = '_b64_';
 
 function encodeVectorId(id: string): string {
     if (SAFE_KEY_PATTERN.test(id) && !id.startsWith(ENCODED_KEY_PREFIX)) {
@@ -123,11 +130,14 @@ function encodeVectorId(id: string): string {
 }
 
 function decodeVectorId(key: string): string {
-    if (!key.startsWith(ENCODED_KEY_PREFIX)) {
+    const prefix = key.startsWith(ENCODED_KEY_PREFIX)
+        ? ENCODED_KEY_PREFIX
+        : (key.startsWith(LEGACY_ENCODED_KEY_PREFIX) ? LEGACY_ENCODED_KEY_PREFIX : undefined);
+    if (!prefix) {
         return key;
     }
     try {
-        return Buffer.from(key.slice(ENCODED_KEY_PREFIX.length), 'base64url').toString('utf8');
+        return Buffer.from(key.slice(prefix.length), 'base64url').toString('utf8');
     } catch {
         return key;
     }


### PR DESCRIPTION
**Production is failing right now.** Every Knowledge Engine upsert and delete against Azure AI Search is rejected:

```
Invalid document key: '_b64_YWtiYW5r…'. Keys cannot start with a leading underscore.
```

### Cause

Azure's document-key rule has two halves: the charset (letters, digits, `_`, `-`, `=`) **and** "may not start with an underscore". The code carried the first half only, and the marker chosen for base64-encoded ids was `_b64_` — so the marker itself was illegal and no id that needed encoding could ever be written. Knowledge Engine ids are `module:documentId:chunkIndex`, so every one of them needs encoding.

### Fix

- Marker starts with a letter: `b64_`.
- `SAFE_KEY_PATTERN` rejects a leading underscore, so a caller id like `_foo` is encoded rather than passed through to the same rejection.
- Decoding still accepts the old marker. Nothing was written under it — every such write failed — but tolerating it costs nothing.

### Why the tests did not catch it

The contract suite *did* assert the produced key against a pattern. The pattern was the same incomplete rule, so it accepted `_b64_` and stayed green while production rejected every batch. A mocked SDK can only check what the assertion knows, so the assertion now carries the whole rule, and a sweep asserts it across the id shapes a real deployment sends — including the one from the production error.

`tsc` clean · 3734 tests · `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KG71cnyfK5GGwbXb25pxsd