### PR TITLE
Allow public exposure for internal-sourced MCP servers, add custom endpoint path

### DIFF
--- a/src/__tests__/integration/mcp-composite.test.ts
+++ b/src/__tests__/integration/mcp-composite.test.ts
@@ -143,24 +143,93 @@ describe('composite create — naming, tool count, hasInternalMember', () => {
     })).rejects.toThrow(/different project/i);
   });
 
-  it('rejects public exposure when a member is internal-sourced', async () => {
-    await expect(createMcpServer(TENANT_DB_NAME, TENANT_ID, USER_ID, PROJECT_ID, {
+  it('allows public exposure when a member is internal-sourced (exposing tenant data is intentional)', async () => {
+    const composite = await createMcpServer(TENANT_DB_NAME, TENANT_ID, USER_ID, PROJECT_ID, {
       name: 'Public Composite Attempt',
       sourceType: 'composite',
       upstreamAuth: { type: 'none' },
       compositeConfig: { members: [{ serverId: String(memberA._id) }] },
       exposure: { protocols: ['streamable-http'], accessMode: 'public' },
-    })).rejects.toThrow(/publicly/i);
+    });
+    expect(composite.exposure?.accessMode).toBe('public');
   });
 
-  it('rejects a direct internal server going public (the pre-existing gap this closes)', async () => {
-    await expect(createMcpServer(TENANT_DB_NAME, TENANT_ID, USER_ID, PROJECT_ID, {
+  it('allows a direct internal server going public', async () => {
+    const server = await createMcpServer(TENANT_DB_NAME, TENANT_ID, USER_ID, PROJECT_ID, {
       name: 'Public Internal Attempt',
       sourceType: 'internal',
       upstreamAuth: { type: 'none' },
       internalConfig: { provider: 'agent-observability', instanceKey: 'project' },
       exposure: { protocols: ['streamable-http'], accessMode: 'public' },
-    })).rejects.toThrow(/publicly/i);
+    });
+    expect(server.exposure?.accessMode).toBe('public');
+  });
+});
+
+describe('custom endpoint slug — public-path override', () => {
+  it('mints a random slug when none is requested', async () => {
+    const server = await createAgentObsMember('Default Slug Server');
+    expect(server.endpointSlug).toHaveLength(16);
+  });
+
+  it('accepts a caller-supplied path, normalized like a slug', async () => {
+    const server = await createMcpServer(TENANT_DB_NAME, TENANT_ID, USER_ID, PROJECT_ID, {
+      name: 'Custom Slug Server',
+      sourceType: 'internal',
+      upstreamAuth: { type: 'none' },
+      internalConfig: { provider: 'agent-observability', instanceKey: 'project' },
+      endpointSlug: 'My Cool Webhook',
+    });
+    expect(server.endpointSlug).toBe('my-cool-webhook');
+  });
+
+  it('rejects a path already used by another server', async () => {
+    await createMcpServer(TENANT_DB_NAME, TENANT_ID, USER_ID, PROJECT_ID, {
+      name: 'Slug Owner',
+      sourceType: 'internal',
+      upstreamAuth: { type: 'none' },
+      internalConfig: { provider: 'agent-observability', instanceKey: 'project' },
+      endpointSlug: 'taken-path',
+    });
+    await expect(createMcpServer(TENANT_DB_NAME, TENANT_ID, USER_ID, PROJECT_ID, {
+      name: 'Slug Squatter',
+      sourceType: 'internal',
+      upstreamAuth: { type: 'none' },
+      internalConfig: { provider: 'agent-observability', instanceKey: 'project' },
+      endpointSlug: 'taken-path',
+    })).rejects.toThrow(/already used/i);
+  });
+
+  it('rejects a path shorter than the minimum once normalized', async () => {
+    await expect(createMcpServer(TENANT_DB_NAME, TENANT_ID, USER_ID, PROJECT_ID, {
+      name: 'Short Slug Attempt',
+      sourceType: 'internal',
+      upstreamAuth: { type: 'none' },
+      internalConfig: { provider: 'agent-observability', instanceKey: 'project' },
+      endpointSlug: 'ab',
+    })).rejects.toThrow(/at least/i);
+  });
+
+  it('lets an update rename the path, and re-allows its own previous path', async () => {
+    const server = await createMcpServer(TENANT_DB_NAME, TENANT_ID, USER_ID, PROJECT_ID, {
+      name: 'Renamable Slug Server',
+      sourceType: 'internal',
+      upstreamAuth: { type: 'none' },
+      internalConfig: { provider: 'agent-observability', instanceKey: 'project' },
+      endpointSlug: 'first-path',
+    });
+
+    const renamed = await updateMcpServer(TENANT_DB_NAME, String(server._id), USER_ID, {
+      endpointSlug: 'second-path',
+    });
+    expect(renamed?.endpointSlug).toBe('second-path');
+
+    // Re-submitting the server's own current path must not trip the
+    // uniqueness check against itself (excludeId).
+    const resaved = await updateMcpServer(TENANT_DB_NAME, String(server._id), USER_ID, {
+      endpointSlug: 'second-path',
+    });
+    expect(resaved?.endpointSlug).toBe('second-path');
   });
 });
 

--- a/src/__tests__/unit/mcp-composite.test.ts
+++ b/src/__tests__/unit/mcp-composite.test.ts
@@ -1,15 +1,14 @@
 /**
  * Unit tests — composite MCP server domain logic (no DB, no execution).
- * Covers the naming/collision algorithm, the public-exposure gate, and the
- * config accessors. DB-backed create/execute/reconcile behavior is covered
- * in `src/__tests__/integration/mcp-composite.test.ts`.
+ * Covers the naming/collision algorithm and the config accessors. DB-backed
+ * create/execute/reconcile behavior is covered in
+ * `src/__tests__/integration/mcp-composite.test.ts`.
  */
 
 import { describe, expect, it } from 'vitest';
 import {
   allocateExposedNames,
   assertMemberUsable,
-  assertPublicExposureAllowed,
   defaultMemberPrefix,
   getCompositeConfig,
   getCompositeMemberSummaries,
@@ -98,26 +97,6 @@ describe('allocateExposedNames', () => {
       entry({ serverId: 's1', prefixBase: 'srv', realName: 'weird name!!', alwaysPrefix: true }),
     ]);
     expect(names[0]).toMatch(/^[a-zA-Z0-9_-]+$/);
-  });
-});
-
-describe('assertPublicExposureAllowed', () => {
-  it('allows token access regardless of source', () => {
-    expect(() => assertPublicExposureAllowed('internal', true, 'token')).not.toThrow();
-    expect(() => assertPublicExposureAllowed('composite', true, 'token')).not.toThrow();
-    expect(() => assertPublicExposureAllowed('openapi', false, 'public')).not.toThrow();
-  });
-
-  it('rejects a direct internal server going public', () => {
-    expect(() => assertPublicExposureAllowed('internal', true, 'public')).toThrow(/publicly/i);
-  });
-
-  it('rejects a composite with an internal member going public', () => {
-    expect(() => assertPublicExposureAllowed('composite', true, 'public')).toThrow(/publicly/i);
-  });
-
-  it('allows a composite with no internal member to go public', () => {
-    expect(() => assertPublicExposureAllowed('composite', false, 'public')).not.toThrow();
   });
 });
 

--- a/src/app/dashboard/mcp/[id]/page.tsx
+++ b/src/app/dashboard/mcp/[id]/page.tsx
@@ -43,6 +43,7 @@ import {
   IconEdit,
   IconExternalLink,
   IconHistory,
+  IconInfoCircle,
   IconList,
   IconPlayerPlay,
   IconPlugConnected,
@@ -122,6 +123,9 @@ export default function McpDetailPage() {
   const [keyEditing, setKeyEditing] = useState(false);
   const [keyDraft, setKeyDraft] = useState('');
   const [savingKey, setSavingKey] = useState(false);
+  const [slugEditing, setSlugEditing] = useState(false);
+  const [slugDraft, setSlugDraft] = useState('');
+  const [savingSlug, setSavingSlug] = useState(false);
   const [deleteOpen, setDeleteOpen] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const [activeTab, setActiveTab] = useState<string>(initialTab);
@@ -391,6 +395,38 @@ export default function McpDetailPage() {
     }
   };
 
+  const handleSaveSlug = async () => {
+    if (!server || !slugDraft.trim() || slugDraft.trim() === server.endpointSlug) {
+      setSlugEditing(false);
+      return;
+    }
+    setSavingSlug(true);
+    try {
+      const res = await fetch(`/api/mcp/${server.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ endpointSlug: slugDraft.trim() }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(data.error || 'Failed to update endpoint path');
+      setServer(data.server);
+      setSlugEditing(false);
+      notifications.show({
+        title: 'Endpoint path updated',
+        message: `Now using "${data.server.endpointSlug}" — update any URL you've already shared.`,
+        color: 'teal',
+      });
+    } catch (err) {
+      notifications.show({
+        title: 'Error',
+        message: err instanceof Error ? err.message : 'Failed to update endpoint path',
+        color: 'red',
+      });
+    } finally {
+      setSavingSlug(false);
+    }
+  };
+
   const handleRefreshTools = async () => {
     if (!params.id) return;
     setRefreshingTools(true);
@@ -613,6 +649,11 @@ export default function McpDetailPage() {
   }
 
   const internalServiceLink = getInternalServiceLink(server);
+  // An internal-service server (or a composite with one as a member) reads
+  // tenant-private data with no credential of its own — worth a loud warning
+  // once it's exposed on a public, unauthenticated URL.
+  const readsInternalData = server.sourceType === 'internal'
+    || (server.sourceType === 'composite' && (server.members ?? []).some((m) => m.sourceType === 'internal'));
   const totalRequests = overviewAggregate?.totalRequests ?? 0;
   const successCount = overviewAggregate?.successCount ?? 0;
   const errorCount = overviewAggregate?.errorCount ?? 0;
@@ -1049,8 +1090,76 @@ export default function McpDetailPage() {
 
           <Paper withBorder p="md" radius="md">
             <Text size="xs" c="dimmed" tt="uppercase" fw={600} mb="xs">Endpoint Slug</Text>
-            <Code>{server.endpointSlug}</Code>
+            {slugEditing ? (
+              <Group gap="sm">
+                <TextInput
+                  value={slugDraft}
+                  onChange={(e) => setSlugDraft(e.currentTarget.value)}
+                  placeholder={server.endpointSlug}
+                  size="xs"
+                  w={260}
+                />
+                <Button size="compact-xs" color="teal" loading={savingSlug} onClick={handleSaveSlug}>
+                  Save
+                </Button>
+                <Button
+                  variant="subtle"
+                  size="compact-xs"
+                  color="gray"
+                  disabled={savingSlug}
+                  onClick={() => setSlugEditing(false)}
+                >
+                  Cancel
+                </Button>
+              </Group>
+            ) : (
+              <Group gap="sm">
+                <Code>{server.endpointSlug}</Code>
+                <CopyButton value={server.endpointSlug}>
+                  {({ copied, copy }) => (
+                    <Tooltip label={copied ? 'Copied' : 'Copy'}>
+                      <Button
+                        variant="subtle"
+                        size="compact-xs"
+                        color={copied ? 'teal' : 'gray'}
+                        onClick={copy}
+                        leftSection={copied ? <IconCheck size={12} /> : <IconCopy size={12} />}
+                      >
+                        {copied ? 'Copied' : 'Copy'}
+                      </Button>
+                    </Tooltip>
+                  )}
+                </CopyButton>
+                <Tooltip label="Set a custom path for the public URL">
+                  <ActionIcon
+                    variant="subtle"
+                    color="gray"
+                    size="sm"
+                    onClick={() => {
+                      setSlugDraft(server.endpointSlug);
+                      setSlugEditing(true);
+                    }}
+                  >
+                    <IconEdit size={13} />
+                  </ActionIcon>
+                </Tooltip>
+              </Group>
+            )}
+            <Text size="xs" c="dimmed" mt={6}>
+              The path segment in the public URL — changing it invalidates any public URL already shared.
+            </Text>
           </Paper>
+
+          {server.exposure?.accessMode === 'public' && readsInternalData ? (
+            <Alert color="orange" icon={<IconInfoCircle size={16} />} mt="md">
+              {server.sourceType === 'internal'
+                ? 'This is an internal-service server, which reads tenant-private data.'
+                : 'This composite includes an internal-service member, which reads tenant-private data.'}
+              {' '}It is exposed on a public URL with no authentication — anyone who has the link (or the
+              custom path above) can read that data. Switch back to &quot;API token required&quot; if that
+              is not intended.
+            </Alert>
+          ) : null}
         </Tabs.Panel>
 
         {/* ── Usage Tab ── */}

--- a/src/components/mcp/CreateMcpModal.tsx
+++ b/src/components/mcp/CreateMcpModal.tsx
@@ -133,6 +133,7 @@ interface FormValues {
   protocolHttp: boolean;
   protocolSse: boolean;
   accessMode: AccessMode;
+  endpointSlug: string;
   // aegis
   aegisMode: AegisMode;
   aegisShieldId: string;
@@ -202,6 +203,7 @@ export default function CreateMcpModal({
       protocolHttp: true,
       protocolSse: true,
       accessMode: 'token',
+      endpointSlug: '',
       aegisMode: 'off',
       aegisShieldId: '',
     },
@@ -330,20 +332,6 @@ export default function CreateMcpModal({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [opened, hubs, capabilities, form.values.sourceType]);
 
-  // A composite that picks up an internal-service member can't stay public —
-  // the backend rejects that combination outright, so fix it up here instead
-  // of letting the user hit a submit-time error.
-  useEffect(() => {
-    if (form.values.sourceType !== 'composite') return;
-    const hasInternal = form.values.compositeMembers.some(
-      (id) => memberOptions.find((m) => m.id === id)?.sourceType === 'internal',
-    );
-    if (hasInternal && form.values.accessMode === 'public') {
-      form.setFieldValue('accessMode', 'token');
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [form.values.sourceType, form.values.compositeMembers, memberOptions]);
-
   // Providers without a per-instance picker (anything but Knowledge Base, for
   // now) always target the same single project-scoped instance.
   useEffect(() => {
@@ -395,6 +383,9 @@ export default function CreateMcpModal({
           protocols: protocols.length ? protocols : ['streamable-http', 'sse'],
           accessMode: v.accessMode,
         },
+        endpointSlug: v.accessMode === 'public' && v.endpointSlug.trim()
+          ? v.endpointSlug.trim()
+          : undefined,
         aegis: v.aegisMode !== 'off' || v.aegisShieldId
           ? { mode: v.aegisMode, shieldId: v.aegisShieldId || undefined }
           : undefined,
@@ -522,9 +513,11 @@ export default function CreateMcpModal({
   ]);
   const validExposure = v.protocolHttp || v.protocolSse;
   // An internal-service member reads tenant-private data with no credential
-  // of its own — the backend rejects saving this combination as public.
+  // of its own — exposing it publicly is allowed (that's the point of a
+  // public URL), but it's worth a loud warning before the operator commits.
   const compositeHasInternalMember = v.sourceType === 'composite'
     && v.compositeMembers.some((id) => memberOptions.find((m) => m.id === id)?.sourceType === 'internal');
+  const readsInternalData = v.sourceType === 'internal' || compositeHasInternalMember;
 
   const checklist = [
     { id: 1, label: 'Name provided', done: validIdentity },
@@ -652,6 +645,9 @@ export default function CreateMcpModal({
           label="Access"
           value={v.accessMode === 'public' ? 'Public URL (no auth)' : 'API token required'}
         />
+        {v.accessMode === 'public' ? (
+          <SummaryKV label="Custom path" value={v.endpointSlug.trim() || 'Auto-generated'} />
+        ) : null}
         {v.aegisMode !== 'off' ? (
           <SummaryKV label="Aegis" value={`${v.aegisMode}${v.aegisShieldId ? ' · shield' : ''}`} />
         ) : null}
@@ -1077,16 +1073,19 @@ export default function CreateMcpModal({
             }}
           />
         </FormField>
-        {compositeHasInternalMember ? (
+        {readsInternalData && v.accessMode === 'public' ? (
           <Alert color="orange" icon={<IconInfoCircle size={16} />}>
-            This composite includes an internal-service member, which reads tenant-private data.
-            It can only be exposed with an API token, never as a public URL.
+            {compositeHasInternalMember
+              ? 'This composite includes an internal-service member, which reads tenant-private data.'
+              : 'This is an internal-service server, which reads tenant-private data.'}
+            {' '}A public URL means anyone who has it can read that data with no authentication —
+            make sure that is really what you want before saving.
           </Alert>
         ) : null}
         <FormField
           label="Access mode"
           hint={v.accessMode === 'public'
-            ? 'Anyone with the unguessable URL can call this server — treat it like a webhook URL.'
+            ? 'Anyone with the URL can call this server — treat it like a webhook URL.'
             : 'Callers must send a Cognipeer API token (PAT) in the Authorization header.'}
         >
           <ChipPicker<AccessMode>
@@ -1095,12 +1094,22 @@ export default function CreateMcpModal({
               { value: 'public', label: 'Public URL (no auth)' },
             ]}
             value={v.accessMode}
-            onChange={(val) => {
-              if (val === 'public' && compositeHasInternalMember) return;
-              form.setFieldValue('accessMode', val as AccessMode);
-            }}
+            onChange={(val) => form.setFieldValue('accessMode', val as AccessMode)}
           />
         </FormField>
+        {v.accessMode === 'public' ? (
+          <FormField
+            label="Custom path"
+            optional
+            hint="Leave blank for a random unguessable path. Set your own to get a memorable, stable public URL — it must be unique and at least 8 characters (letters, numbers, hyphens)."
+          >
+            <TextInput
+              placeholder="e.g. acme-support-tools"
+              value={v.endpointSlug}
+              onChange={(e) => form.setFieldValue('endpointSlug', e.currentTarget.value)}
+            />
+          </FormField>
+        ) : null}
       </FormSection>
 
       <FormSection

--- a/src/lib/services/mcp/composite.ts
+++ b/src/lib/services/mcp/composite.ts
@@ -7,15 +7,15 @@
  * and its own Aegis binding — the composite only decides *which* member
  * tools are included and what name they're exposed under.
  *
- * This module owns the config shape, the public-exposure gate (an
- * internal-service member must never be reachable without a token — see
- * `isInternalSourced`), and the naming/collision algorithm. The DB-touching
+ * This module owns the config shape (including `isInternalSourced`, which
+ * flags an internal-service member so operators can be warned before they
+ * expose it publicly) and the naming/collision algorithm. The DB-touching
  * orchestration (fetching members, persisting the rebuilt snapshot,
  * executing a routed call) lives in `mcpService.ts`, which imports from
  * here — never the other way, to keep this module import-cycle-free.
  */
 
-import type { IMcpServer, IMcpTool, McpAccessMode, McpSourceType } from '@/lib/database';
+import type { IMcpServer, IMcpTool, McpSourceType } from '@/lib/database';
 import slugify from 'slugify';
 
 /** One member entry as stored in a composite server's `metadata.composite.members`. */
@@ -89,33 +89,17 @@ export function metadataWithComposite(
 /**
  * A server is "internal-sourced" when calling it can read tenant-private
  * data with no external credential of its own — a direct 'internal' server,
- * or a composite that includes one as a member. Gates public exposure both
- * at write time (`assertPublicExposureAllowed`) and at the public-endpoint
- * read path (defense in depth — see `public-mcp.ts`).
+ * or a composite that includes one as a member. Public exposure of an
+ * internal-sourced server is allowed (publishing tenant data on a public URL
+ * is a deliberate, supported use case), but callers that offer the choice
+ * should warn the operator with this flag before they flip it on — see the
+ * "Endpoint exposure" warning in `CreateMcpModal.tsx`.
  */
 export function isInternalSourced(server: Pick<IMcpServer, 'sourceType' | 'metadata'>): boolean {
   const sourceType = server.sourceType ?? 'openapi';
   if (sourceType === 'internal') return true;
   if (sourceType === 'composite') return getCompositeConfig(server).hasInternalMember;
   return false;
-}
-
-export function assertPublicExposureAllowed(
-  sourceType: McpSourceType,
-  hasInternalMember: boolean,
-  accessMode: McpAccessMode | undefined,
-): void {
-  if (accessMode !== 'public') return;
-  if (sourceType === 'internal') {
-    throw new Error(
-      'Internal-service MCP servers read tenant-private data and cannot be exposed publicly. Use "API token required" access instead.',
-    );
-  }
-  if (sourceType === 'composite' && hasInternalMember) {
-    throw new Error(
-      'This composite includes an internal-service member and cannot be exposed publicly. Use "API token required" access instead.',
-    );
-  }
 }
 
 /** Reference to the composite record itself, for the self/tenant/project checks below. */

--- a/src/lib/services/mcp/mcpService.ts
+++ b/src/lib/services/mcp/mcpService.ts
@@ -55,7 +55,6 @@ import { requireInternalMcpProvider } from './internal/registry';
 import {
   allocateExposedNames,
   assertMemberUsable,
-  assertPublicExposureAllowed,
   defaultMemberPrefix,
   getCompositeConfig,
   getCompositeMemberSummaries,
@@ -336,6 +335,48 @@ function generateEndpointSlug(): string {
   return randomUUID().replace(/-/g, '').substring(0, 16);
 }
 
+// The public-MCP route (public-mcp.ts) rejects any slug under 8 chars
+// outright (same floor `a2aExposure.ts` uses for agent slugs) — keep this in
+// sync with that so a custom path never gets saved just to 404 at call time.
+const MIN_ENDPOINT_SLUG_LENGTH = 8;
+const MAX_ENDPOINT_SLUG_LENGTH = 80;
+
+function normalizeCustomEndpointSlug(desired: string): string {
+  const slug = slugify(desired, SLUG_OPTIONS).substring(0, MAX_ENDPOINT_SLUG_LENGTH);
+  if (slug.length < MIN_ENDPOINT_SLUG_LENGTH) {
+    throw new Error(
+      `Custom path must be at least ${MIN_ENDPOINT_SLUG_LENGTH} characters (letters, numbers, hyphens).`,
+    );
+  }
+  return slug;
+}
+
+/**
+ * Resolve the path segment a server (or MCP Hub) is addressed by under
+ * `/api/public/mcp/:tenantId/:endpointSlug`. Omitting `desired` mints a
+ * random unguessable slug, same as before custom paths existed. A
+ * caller-supplied `desired` becomes this server's public URL path — unlike
+ * `key` it is never silently de-duplicated with a numeric suffix (that would
+ * surprise whoever the URL was shared with), so it must be unique or the
+ * caller picks a different one. `excludeId` lets a rename check uniqueness
+ * without colliding with the record being renamed.
+ */
+async function resolveEndpointSlug(
+  tenantDbName: string,
+  desired: string | undefined,
+  excludeId?: string,
+): Promise<string> {
+  if (!desired?.trim()) return generateEndpointSlug();
+  const slug = normalizeCustomEndpointSlug(desired);
+  const db = await getDatabase();
+  await db.switchToTenant(tenantDbName);
+  const existing = await db.findMcpServerByEndpointSlug(slug);
+  if (existing && String(existing._id) !== excludeId) {
+    throw new Error(`The path "${slug}" is already used by another MCP server. Choose a different one.`);
+  }
+  return slug;
+}
+
 // ── OpenAPI Parsing ───────────────────────────────────────────────────────
 
 export function parseOpenApiSpec(specString: string, format: SpecFormatHint = 'auto'): {
@@ -572,7 +613,6 @@ function validateCreateInput(input: CreateMcpServerInput): McpSourceType {
     if (!input.internalConfig?.instanceKey?.trim()) {
       throw new Error('internalConfig.instanceKey is required for source type "internal"');
     }
-    assertPublicExposureAllowed('internal', true, input.exposure?.accessMode);
   }
   if (sourceType === 'composite') {
     if (!input.compositeConfig?.members?.length) {
@@ -778,7 +818,7 @@ export async function createMcpServer(
   const sourceType = validateCreateInput(input);
 
   const key = await generateUniqueKey(tenantDbName, projectId, input.key?.trim() || input.name);
-  const endpointSlug = generateEndpointSlug();
+  const endpointSlug = await resolveEndpointSlug(tenantDbName, input.endpointSlug);
 
   let tools: IMcpTool[] = [];
   let normalizedSpec: string | undefined;
@@ -830,7 +870,6 @@ export async function createMcpServer(
       alwaysPrefix: m.alwaysPrefix,
     }));
     const built = await buildCompositeTools(db, { tenantId, projectId }, memberConfigs);
-    assertPublicExposureAllowed('composite', built.hasInternalMember, input.exposure?.accessMode);
     tools = built.tools;
     compositeMetadata = metadataWithComposite(
       undefined,
@@ -983,6 +1022,9 @@ export async function updateMcpServer(
     updateData.upstreamAuth = mergeAuthConfigUpdate(existing.upstreamAuth, input.upstreamAuth);
   }
   if (input.exposure !== undefined) updateData.exposure = normalizeExposure(input.exposure);
+  if (input.endpointSlug !== undefined) {
+    updateData.endpointSlug = await resolveEndpointSlug(tenantDbName, input.endpointSlug, serverId);
+  }
   if (input.aegis !== undefined) updateData.aegis = input.aegis;
   if (input.remoteConfig !== undefined) updateData.remoteConfig = input.remoteConfig;
   if (input.stdioConfig !== undefined) {
@@ -1062,9 +1104,6 @@ export async function updateMcpServer(
   // "previous" set keeps stable exposed names across the rebuild — see
   // allocateExposedNames). Omitting compositeConfig leaves the member list
   // untouched (e.g. a PATCH that only renames the server or flips status).
-  let compositeHasInternalMember = sourceType === 'composite'
-    ? getCompositeConfig(existing).hasInternalMember
-    : false;
   if (sourceType === 'composite' && input.compositeConfig !== undefined) {
     if (!input.compositeConfig.members.length) {
       throw new Error('compositeConfig.members must include at least one member server');
@@ -1082,25 +1121,12 @@ export async function updateMcpServer(
     );
     updateData.tools = built.tools;
     updateData.toolsDiscoveredAt = new Date();
-    compositeHasInternalMember = built.hasInternalMember;
     updateData.metadata = metadataWithComposite(
       (updateData.metadata as Record<string, unknown> | undefined) ?? existing.metadata,
       { members: built.members, hasInternalMember: built.hasInternalMember },
       built.memberSummaries,
     );
   }
-
-  // Public-exposure gate: an internal-sourced server (direct 'internal', or
-  // a composite with an internal member) must never be reachable without a
-  // Cognipeer token — runs on every update, not just ones that touch
-  // exposure or compositeConfig, since either one alone can flip the
-  // effective combination into a disallowed state.
-  const effectiveExposure = (updateData.exposure as IMcpExposureConfig | undefined) ?? resolveExposure(existing);
-  assertPublicExposureAllowed(
-    sourceType,
-    sourceType === 'internal' ? true : compositeHasInternalMember,
-    effectiveExposure.accessMode,
-  );
 
   // Tool enable/disable list (metadata-backed). Runs after tool rediscovery so
   // the incoming names are validated against the tool list being persisted.

--- a/src/lib/services/mcp/types.ts
+++ b/src/lib/services/mcp/types.ts
@@ -99,6 +99,9 @@ export interface CreateMcpServerInput {
   /** Member MCP servers to republish (sourceType 'composite'). */
   compositeConfig?: CompositeConfigInput;
   exposure?: IMcpExposureConfig;
+  /** Custom public-URL path segment (default: a random unguessable slug). Only
+   *  meaningful once exposure.accessMode is 'public'; must be unique tenant-wide. */
+  endpointSlug?: string;
   aegis?: IMcpAegisConfig;
 }
 
@@ -140,6 +143,8 @@ export interface UpdateMcpServerInput {
   /** Full replacement member list (sourceType 'composite'). */
   compositeConfig?: CompositeConfigInput;
   exposure?: IMcpExposureConfig;
+  /** Rename the server's public-URL path segment; must be unique tenant-wide. */
+  endpointSlug?: string;
   aegis?: IMcpAegisConfig;
   status?: string;
   /** Opt-in policy for caller-supplied runtime header passthrough (null clears). */

--- a/src/server/api/plugins/mcp.ts
+++ b/src/server/api/plugins/mcp.ts
@@ -7,7 +7,7 @@ import type {
   IUser,
   McpAuthType,
 } from '@/lib/database';
-import type { FastifyPluginAsync, FastifyRequest } from 'fastify';
+import type { FastifyPluginAsync, FastifyReply, FastifyRequest } from 'fastify';
 import type { SpecFormatHint } from '@/lib/services/specImport';
 import { createLogger } from '@/lib/core/logger';
 import {
@@ -82,6 +82,18 @@ async function serverInProjectScope(
   if (user.role === 'owner' || user.role === 'admin') return server;
   if (!server.projectId) return server;
   return String(server.projectId) === String(projectId) ? server : null;
+}
+
+/** Maps `resolveEndpointSlug`'s thrown errors to proper status codes; null if `error` isn't one of them. */
+function sendEndpointSlugError(reply: FastifyReply, error: unknown): ReturnType<FastifyReply['send']> | null {
+  if (!(error instanceof Error)) return null;
+  if (error.message.startsWith('Custom path must be')) {
+    return reply.code(400).send({ error: error.message });
+  }
+  if (error.message.includes('is already used by another MCP server')) {
+    return reply.code(409).send({ error: error.message });
+  }
+  return null;
 }
 
 function auditContextFor(request: FastifyRequest, userId: string): McpAuditContext {
@@ -418,6 +430,9 @@ export const mcpApiPlugin: FastifyPluginAsync = async (app) => {
           internalConfig,
           compositeConfig,
           exposure: parseExposure(body.exposure),
+          endpointSlug: typeof body.endpointSlug === 'string' && body.endpointSlug.trim()
+            ? body.endpointSlug.trim()
+            : undefined,
           aegis: aegisConfig,
         },
         auditContextFor(request, session.userId),
@@ -429,6 +444,7 @@ export const mcpApiPlugin: FastifyPluginAsync = async (app) => {
     } catch (error) {
       logger.error('Create MCP server error', { error });
       return sendProjectContextError(reply, error)
+        ?? sendEndpointSlugError(reply, error)
         ?? reply.code(500).send({
           error: error instanceof Error ? error.message : 'Internal error',
         });
@@ -561,6 +577,9 @@ export const mcpApiPlugin: FastifyPluginAsync = async (app) => {
         internalConfig: body.internalConfig !== undefined ? parseInternalConfig(body.internalConfig) : undefined,
         compositeConfig: body.compositeConfig !== undefined ? parseCompositeConfig(body.compositeConfig) : undefined,
         exposure: body.exposure !== undefined ? parseExposure(body.exposure) : undefined,
+        endpointSlug: typeof body.endpointSlug === 'string' && body.endpointSlug.trim()
+          ? body.endpointSlug.trim()
+          : undefined,
         aegis: nextAegis,
         runtimeHeaders: body.runtimeHeaders as { allow?: boolean; allowedNames?: string[] } | null | undefined,
         disabledTools: body.disabledTools as string[] | undefined,
@@ -577,6 +596,7 @@ export const mcpApiPlugin: FastifyPluginAsync = async (app) => {
     } catch (error) {
       logger.error('Update MCP server error', { error });
       return sendProjectContextError(reply, error)
+        ?? sendEndpointSlugError(reply, error)
         ?? reply.code(500).send({
           error: error instanceof Error ? error.message : 'Internal error',
         });

--- a/src/server/api/plugins/public-mcp.ts
+++ b/src/server/api/plugins/public-mcp.ts
@@ -22,7 +22,6 @@ import { getDatabase } from '@/lib/database';
 import { createLogger } from '@/lib/core/logger';
 import {
   executeMcpTool,
-  isInternalSourced,
   listMcpToolDescriptors,
   logMcpRequest,
   mcpRequestSecretValues,
@@ -83,12 +82,6 @@ async function resolvePublicServer(
 
   if (!server || server.status !== 'active') return null;
   if (resolveExposure(server).accessMode !== 'public') return null;
-  // Defense in depth: an internal-sourced server (direct 'internal', or a
-  // composite with an internal member) reads tenant-private data with no
-  // credential of its own — create/update already reject saving it as
-  // public (see assertPublicExposureAllowed), but a stale/malformed record
-  // must not be served here regardless.
-  if (isInternalSourced(server)) return null;
   return { tenant, server };
 }
 


### PR DESCRIPTION
## Summary

An MCP server sourced from an internal Console capability (`sourceType: 'internal'`, or a composite with such a member) could not be exposed on a public, unauthenticated URL — `assertPublicExposureAllowed` rejected the save. That restriction is removed: publishing that data publicly is now an intentional, supported choice, surfaced with a warning instead of a hard block. Separately, a server's public endpoint path (`endpointSlug`) can now be a caller-chosen value instead of only a random 16-char slug.

## Changes

- Remove `assertPublicExposureAllowed` (`composite.ts`) and its three call sites in `mcpService.ts` (create/composite-create/update). `isInternalSourced` is kept — it now only drives the UI warning, no longer gates a write.
- Remove the matching defense-in-depth 404 in `public-mcp.ts` (`resolvePublicServer`) that blocked serving an internal-sourced server even if one were saved as public.
- Add `endpointSlug?: string` to `CreateMcpServerInput`/`UpdateMcpServerInput`. A new `resolveEndpointSlug` in `mcpService.ts` normalizes the caller's value (slugify, 8–80 chars — the 8-char floor matches what `public-mcp.ts` already requires and what `a2aExposure.ts` uses for agent slugs), checks tenant-wide uniqueness via `findMcpServerByEndpointSlug`, and errors (never silently de-duplicates, unlike `key`) if it's taken. Omitting it keeps today's random-slug behavior.
- `plugins/mcp.ts`: parse `body.endpointSlug` on create/update; map the new service errors to 400 (bad format) / 409 (path taken) instead of falling through to 500.
- `CreateMcpModal.tsx`: removed the JS-side auto-reset that flipped a composite back to "API token required" when it picked up an internal member while public was selected; added an orange warning `Alert` (now covers both plain `internal` sourceType and composite-with-internal-member, previously only the latter) and a "Custom path" `TextInput` shown when access mode is public.
- `[id]/page.tsx` (server detail page): the previously read-only "Endpoint Slug" panel is now inline-editable (mirrors the existing "Server Key" edit pattern), and the same orange warning is shown on the Overview tab when an internal-sourced server is currently public.
- Updated/added unit + integration tests for the removed gate (now asserts success instead of a throw) and the new custom-slug behavior (format validation, uniqueness conflict, rename, re-saving one's own current path).

## Validation

- [x] `npm run lint` (0 errors; 1 pre-existing unrelated warning in `CreateMcpModal.tsx`)
- [x] `npm run test` (full suite; all non-MongoDB-backed tests pass — the MongoDB-parity suites fail in this sandbox because `mongodb-memory-server` can't download its binary without network access, unrelated to this change)
- [x] `npm run build`
- [ ] `npm run docs:build` (no docs changed)

## Release Notes

- [ ] Docs updated when behavior changed — no user-facing docs currently describe MCP exposure rules; happy to add a note if there's a place for it.
- [x] Security-sensitive changes reviewed — this intentionally removes a guardrail that blocked exposing tenant-internal data publicly; the new behavior is opt-in per server and surfaced with an explicit warning in both the create form and the server detail page.
- [ ] License or policy files updated — n/a

---
Requested via chat: "Bu kuralı kaldıralım ek olarak public olanda da özel path verebilmemiz lazım. Amaç zaten içerideki datayı dışarı açmak. Ama uyarı çıksın ekranda."


---
_Generated by [Claude Code](https://claude.ai/code/session_01KqpV85EuDbbVMpXsxmbESX)_