### PR TITLE
Bound provider calls, cache quota policies, and unblock queue consumers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -77,7 +77,7 @@ PROVIDER_ENCRYPTION_SECRET=                        # (required) Independent encr
 # SMTP_FROM=noreply@example.com                     # Sender address (defaults to SMTP_USER)
 
 # ---- Gateway / Resilience ------------------------------------
-# GATEWAY_REQUEST_TIMEOUT_MS=120000                 # Request timeout for provider calls (ms)
+# GATEWAY_REQUEST_TIMEOUT_MS=120000                 # Per-attempt timeout for provider calls (ms); a retry gets the full budget again. 0 disables
 # GATEWAY_RETRY_ENABLED=true                        # Enable retry on provider failures
 # GATEWAY_RETRY_MAX_ATTEMPTS=3                      # Max retry attempts (1 = no retry)
 # GATEWAY_RETRY_INITIAL_DELAY_MS=200                # Initial retry delay (exponential backoff)
@@ -97,6 +97,11 @@ CACHE_PROVIDER=memory                              # Cache provider (no fallback
 # memory/redis providers use the active cache provider; set CACHE_PROVIDER to the same value.
 RATE_LIMIT_PROVIDER=memory                         # Rate limit backend
 # RATE_LIMIT_SYNC_INTERVAL_MS=5000                  # Sync interval for distributed counters
+#
+# The tenant license + quota policies behind a limit check are cached for this
+# long (policy edits through the API invalidate it immediately). 0 disables the
+# cache and every guarded request re-reads both from the database.
+# QUOTA_POLICY_CACHE_TTL_SECONDS=30                 # Quota policy cache TTL (seconds)
 
 # ---- Logging -------------------------------------------------
 # LOG_LEVEL=debug                                   # error | warn | info | debug
@@ -125,6 +130,10 @@ NEXT_PUBLIC_APP_URL=http://localhost:3000           # Public application URL (us
 
 # ---- Provider Runtime Pool -----------------------------------
 # PROVIDER_RUNTIME_CACHE_TTL_SECONDS=300            # SDK client cache TTL (0 = no caching)
+# An evicted runtime keeps its connections (pg pool, Elasticsearch client) for
+# this long before they are closed, so a request still holding it can finish.
+# 0 closes immediately.
+# PROVIDER_RUNTIME_DISPOSE_GRACE_SECONDS=300        # Grace before an evicted runtime's connections close
 
 # ---- Browser Runtime -----------------------------------------
 # BROWSER_DEFAULT_MAX_CONCURRENT=10                 # Default concurrent browser sessions per tenant
@@ -170,3 +179,17 @@ NEXT_PUBLIC_APP_URL=http://localhost:3000           # Public application URL (us
 # such interrupted crawls (bounded per job) so they recover on their own. Point
 # QUEUE_REDIS_URL/REDIS_URL at Redis so BullMQ persists the job across restarts.
 # CRAWLER_RESTART_ORPHANED_RUNS=true                # default true (bounded auto-restart of orphaned runs); set false to fail them for manual re-run instead
+#
+# Per-node consumer concurrency. These four used to be fixed at 1, which
+# head-of-line blocked every cross-node job behind the slowest one until the
+# queue's 60s invoke timeout failed the ones still waiting.
+# AGENT_CHAT_CONCURRENCY=4                          # Concurrent agent turns per node
+# MCP_INVOKE_CONCURRENCY=4                          # Concurrent MCP tool invocations per node
+# BROWSER_ACTION_CONCURRENCY=4                      # Concurrent browser actions per node
+# CRAWLER_RUN_CONCURRENCY=2                         # Concurrent crawl jobs per node (each fans out to ~16 fetches)
+#
+# Knowledge Engine ingest queue. Used when a client posts an ingest with
+# `async: true`: the document is stored as `pending` and chunked + embedded by
+# a job instead of inside the HTTP request.
+# RAG_INGEST_CONCURRENCY=2                          # Documents indexed concurrently per node
+# RAG_INGEST_BOOT_RESUME_MAX=500                    # Cap on pending documents re-published per boot sweep

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -6582,7 +6582,18 @@ paths:
       tags:
         - Knowledge Engine
       summary: Ingest a document into a Knowledge Engine module
-      description: Ingests a document into a Knowledge Engine module. Provide `content` for raw text, or `data` for a base64-encoded (or data-URI) binary file which is converted to Markdown before chunking and embedding. `fileName` is always required. Pass `chunkConfig` to split this one document differently from the rest of the module.
+      description: >-
+        Ingests a document into a Knowledge Engine module. Provide `content` for raw text, or
+        `data` for a base64-encoded (or data-URI) binary file which is converted to Markdown
+        before chunking and embedding. `fileName` is always required. Pass `chunkConfig` to
+        split this one document differently from the rest of the module.
+
+
+        Ingestion is synchronous by default: the call returns `201` once the document is
+        `indexed` and searchable. Set `async: true` to return `202` as soon as the document is
+        stored — it comes back `pending`, is chunked and embedded by a background job, and is
+        not searchable until its `status` reaches `indexed`. Poll the document endpoint to
+        follow it; a failure lands on the record as `failed` with `errorMessage`.
       operationId: ingestRagDocument
       parameters:
         - name: key
@@ -6627,9 +6638,24 @@ paths:
                   example:
                     source: docs
                     version: "2.0"
+                async:
+                  type: boolean
+                  default: false
+                  description: >-
+                    Return as soon as the document is stored, leaving chunking and embedding to
+                    a background job. The response is `202` and the document is `pending`.
       responses:
         "201":
-          description: Ingested document.
+          description: Ingested document, already indexed.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  document:
+                    $ref: "#/components/schemas/RagDocument"
+        "202":
+          description: "Document stored and queued for indexing (`async: true`). Its `status` is `pending`."
           content:
             application/json:
               schema:

--- a/src/__tests__/unit/quota-policy-cache.test.ts
+++ b/src/__tests__/unit/quota-policy-cache.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Unit tests — quota policy source caching
+ *
+ * Every guarded request used to re-read the tenant record and the policy
+ * collection, and an inference call resolves limits three times before the
+ * model is reached. These cover the cache that amortizes those reads, and the
+ * per-request filtering that must NOT be cached with them.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createMockDb } from '../helpers/db.mock';
+
+const cacheStore = new Map<string, unknown>();
+const config = { quota: { policyCacheTtlSeconds: 30 } };
+
+vi.mock('@/lib/database', () => ({ getDatabase: vi.fn() }));
+
+vi.mock('@/lib/core/config', () => ({
+  getConfig: () => config,
+}));
+
+vi.mock('@/lib/core/cache', () => ({
+  getCache: async () => ({
+    get: async (key: string) => cacheStore.get(key),
+    set: async (key: string, value: unknown) => { cacheStore.set(key, value); },
+    del: async (key: string) => { cacheStore.delete(key); },
+  }),
+}));
+
+vi.mock('@/lib/core/logger', () => ({
+  createLogger: () => ({
+    debug: () => {}, info: () => {}, warn: () => {}, error: () => {},
+  }),
+}));
+
+import { getDatabase } from '@/lib/database';
+import { resolveEffectiveLimits, quotaPolicyCacheKey } from '@/lib/quota/quotaGuard';
+import type { QuotaContext } from '@/lib/quota/quotaGuard';
+import type { ITenant, IQuotaPolicy } from '@/lib/database';
+
+const DB_NAME = 'tenant_acme';
+const TENANT_ID = 'tenant-1';
+const PROJECT_ID = 'proj-1';
+
+function makeContext(overrides: Partial<QuotaContext> = {}): QuotaContext {
+  return {
+    tenantDbName: DB_NAME,
+    tenantId: TENANT_ID,
+    projectId: PROJECT_ID,
+    licenseType: 'enterprise',
+    domain: 'llm',
+    ...overrides,
+  } as QuotaContext;
+}
+
+/** A tenant-scoped policy and a user-scoped one, so filtering is observable. */
+function policies(): IQuotaPolicy[] {
+  return [
+    {
+      _id: 'p-tenant',
+      tenantId: TENANT_ID,
+      domain: 'llm',
+      scope: 'tenant',
+      priority: 10,
+      enabled: true,
+      limits: { rateLimit: { requests: { perMinute: 100 } } },
+    } as unknown as IQuotaPolicy,
+    {
+      _id: 'p-user',
+      tenantId: TENANT_ID,
+      domain: 'llm',
+      scope: 'user',
+      scopeId: 'user-vip',
+      priority: 20,
+      enabled: true,
+      limits: { rateLimit: { requests: { perMinute: 999 } } },
+    } as unknown as IQuotaPolicy,
+  ];
+}
+
+describe('quota policy source cache', () => {
+  let db: ReturnType<typeof createMockDb>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    cacheStore.clear();
+    config.quota.policyCacheTtlSeconds = 30;
+    db = createMockDb();
+    db.findTenantById.mockResolvedValue({ _id: TENANT_ID, slug: 'acme' } as unknown as ITenant);
+    db.listQuotaPolicies.mockResolvedValue(policies());
+    (getDatabase as ReturnType<typeof vi.fn>).mockResolvedValue(db);
+  });
+
+  it('reads the tenant and its policies once across repeated resolutions', async () => {
+    await resolveEffectiveLimits(makeContext());
+    await resolveEffectiveLimits(makeContext());
+    await resolveEffectiveLimits(makeContext());
+
+    expect(db.findTenantById).toHaveBeenCalledTimes(1);
+    expect(db.listQuotaPolicies).toHaveBeenCalledTimes(1);
+  });
+
+  it('still applies per-caller scope filtering on a cache hit', async () => {
+    const anonymous = await resolveEffectiveLimits(makeContext());
+    const vip = await resolveEffectiveLimits(makeContext({ userId: 'user-vip' }));
+
+    // Same cached policy set, different callers — the user-scoped policy must
+    // reach only the caller it names.
+    expect(anonymous.rateLimit?.requests?.perMinute).toBe(100);
+    expect(vip.rateLimit?.requests?.perMinute).toBe(999);
+    expect(db.listQuotaPolicies).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps separate entries per project', async () => {
+    await resolveEffectiveLimits(makeContext());
+    await resolveEffectiveLimits(makeContext({ projectId: 'proj-2' }));
+
+    expect(db.listQuotaPolicies).toHaveBeenCalledTimes(2);
+  });
+
+  it('goes back to the database once the entry is dropped', async () => {
+    await resolveEffectiveLimits(makeContext());
+    cacheStore.delete(quotaPolicyCacheKey(DB_NAME, TENANT_ID, PROJECT_ID));
+    await resolveEffectiveLimits(makeContext());
+
+    expect(db.listQuotaPolicies).toHaveBeenCalledTimes(2);
+  });
+
+  it('reads through on every call when the cache is disabled', async () => {
+    config.quota.policyCacheTtlSeconds = 0;
+
+    await resolveEffectiveLimits(makeContext());
+    await resolveEffectiveLimits(makeContext());
+
+    expect(db.findTenantById).toHaveBeenCalledTimes(2);
+    expect(db.listQuotaPolicies).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/__tests__/unit/rag-service.test.ts
+++ b/src/__tests__/unit/rag-service.test.ts
@@ -23,6 +23,9 @@ vi.mock('@/lib/services/vector/vectorService', () => ({
 vi.mock('@/lib/services/reranker', () => ({
   runReranker: vi.fn(),
 }));
+vi.mock('@/lib/services/rag/ragIngestJob', () => ({
+  publishRagIngestJob: vi.fn().mockResolvedValue(undefined),
+}));
 vi.mock('@/lib/services/files/fileService', () => ({
   uploadFile: vi.fn().mockResolvedValue({ record: { key: 'stored-object-key' } }),
   downloadFile: vi.fn().mockResolvedValue({
@@ -42,6 +45,7 @@ import {
   listRagModules,
   listRagDocuments,
   getRagDocument,
+  indexPendingRagDocument,
   ingestDocument,
   ingestFile,
   queryRag,
@@ -54,6 +58,7 @@ import { getDatabase } from '@/lib/database';
 import { handleEmbeddingRequest } from '@/lib/services/models/inferenceService';
 import { upsertVectors, queryVectorIndex, deleteVectors } from '@/lib/services/vector/vectorService';
 import { runReranker } from '@/lib/services/reranker';
+import { publishRagIngestJob } from '@/lib/services/rag/ragIngestJob';
 import { deleteFile, downloadFile, uploadFile } from '@/lib/services/files/fileService';
 import type { IRagDocument } from '@/lib/database';
 
@@ -491,6 +496,96 @@ describe('RAG Service', () => {
 
   // ─── ingestDocument ─────────────────────────────────────────────────
 
+  describe('indexPendingRagDocument', () => {
+    const PENDING = {
+      ...mockDocument,
+      _id: 'ragdoc-1',
+      status: 'pending' as const,
+      chunkCount: 0,
+      sourceText: 'This is a sample document with enough content to be chunked properly.',
+    };
+
+    beforeEach(() => {
+      db.findRagModuleByKey.mockResolvedValue(mockModule);
+      db.findRagDocumentById.mockResolvedValue(PENDING);
+      db.updateRagDocument.mockResolvedValue(null);
+      db.updateRagModule.mockResolvedValue(null);
+      db.bulkInsertRagChunks.mockResolvedValue(undefined);
+    });
+
+    it('indexes the stored source and marks the document indexed', async () => {
+      await indexPendingRagDocument(DB_NAME, TENANT_ID, PROJECT_ID, 'my-rag', 'ragdoc-1');
+
+      expect(handleEmbeddingRequest).toHaveBeenCalled();
+      expect(upsertVectors).toHaveBeenCalled();
+      expect(db.updateRagDocument).toHaveBeenCalledWith(
+        'ragdoc-1',
+        expect.objectContaining({ status: 'indexed' }),
+      );
+    });
+
+    it('is idempotent for a document another attempt already indexed', async () => {
+      db.findRagDocumentById.mockResolvedValue({ ...PENDING, status: 'indexed' });
+
+      await indexPendingRagDocument(DB_NAME, TENANT_ID, PROJECT_ID, 'my-rag', 'ragdoc-1');
+
+      expect(handleEmbeddingRequest).not.toHaveBeenCalled();
+      expect(db.updateRagDocument).not.toHaveBeenCalled();
+    });
+
+    it('does nothing when the document was deleted before the job ran', async () => {
+      db.findRagDocumentById.mockResolvedValue(null);
+
+      await indexPendingRagDocument(DB_NAME, TENANT_ID, PROJECT_ID, 'my-rag', 'ragdoc-1');
+
+      expect(handleEmbeddingRequest).not.toHaveBeenCalled();
+      expect(db.updateRagDocument).not.toHaveBeenCalled();
+    });
+
+    it('marks the document failed when its module is gone', async () => {
+      db.findRagModuleByKey.mockResolvedValue(null);
+
+      await indexPendingRagDocument(DB_NAME, TENANT_ID, PROJECT_ID, 'my-rag', 'ragdoc-1');
+
+      expect(db.updateRagDocument).toHaveBeenCalledWith(
+        'ragdoc-1',
+        expect.objectContaining({ status: 'failed' }),
+      );
+      expect(handleEmbeddingRequest).not.toHaveBeenCalled();
+    });
+
+    it('marks the document failed when the stored source is unavailable', async () => {
+      db.findRagDocumentById.mockResolvedValue({
+        ...PENDING, sourceText: undefined, sourceTextKey: undefined,
+      });
+
+      await indexPendingRagDocument(DB_NAME, TENANT_ID, PROJECT_ID, 'my-rag', 'ragdoc-1');
+
+      expect(db.updateRagDocument).toHaveBeenCalledWith(
+        'ragdoc-1',
+        expect.objectContaining({ status: 'failed' }),
+      );
+    });
+
+    it('records the error on the document when indexing throws', async () => {
+      (handleEmbeddingRequest as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+        new Error('embedding provider unavailable'),
+      );
+
+      await expect(
+        indexPendingRagDocument(DB_NAME, TENANT_ID, PROJECT_ID, 'my-rag', 'ragdoc-1'),
+      ).rejects.toThrow(/embedding provider unavailable/);
+
+      expect(db.updateRagDocument).toHaveBeenCalledWith(
+        'ragdoc-1',
+        expect.objectContaining({
+          status: 'failed',
+          errorMessage: 'embedding provider unavailable',
+        }),
+      );
+    });
+  });
+
   describe('ingestDocument', () => {
     const ingestReq = {
       ragModuleKey: 'my-rag',
@@ -510,6 +605,52 @@ describe('RAG Service', () => {
     it('throws if RAG module not found', async () => {
       db.findRagModuleByKey.mockResolvedValue(null);
       await expect(ingestDocument(DB_NAME, TENANT_ID, PROJECT_ID, ingestReq)).rejects.toThrow(/not found/i);
+    });
+
+    describe('deferIndexing', () => {
+      it('persists the document as pending and publishes a job', async () => {
+        db.createRagDocument.mockResolvedValue({
+          ...mockDocument, _id: 'ragdoc-1', status: 'pending', chunkCount: 0,
+        });
+
+        const document = await ingestDocument(DB_NAME, TENANT_ID, PROJECT_ID, {
+          ...ingestReq,
+          deferIndexing: true,
+        });
+
+        expect(db.createRagDocument).toHaveBeenCalledWith(
+          expect.objectContaining({ status: 'pending' }),
+        );
+        expect(document.status).toBe('pending');
+        expect(publishRagIngestJob).toHaveBeenCalledWith(
+          expect.objectContaining({
+            tenantDbName: DB_NAME,
+            ragModuleKey: 'my-rag',
+            documentId: 'ragdoc-1',
+          }),
+        );
+      });
+
+      it('keeps chunking and embedding off the request path', async () => {
+        db.createRagDocument.mockResolvedValue({
+          ...mockDocument, _id: 'ragdoc-1', status: 'pending', chunkCount: 0,
+        });
+
+        await ingestDocument(DB_NAME, TENANT_ID, PROJECT_ID, {
+          ...ingestReq,
+          deferIndexing: true,
+        });
+
+        expect(handleEmbeddingRequest).not.toHaveBeenCalled();
+        expect(upsertVectors).not.toHaveBeenCalled();
+      });
+
+      it('still embeds inline when the flag is absent', async () => {
+        await ingestDocument(DB_NAME, TENANT_ID, PROJECT_ID, ingestReq);
+
+        expect(publishRagIngestJob).not.toHaveBeenCalled();
+        expect(handleEmbeddingRequest).toHaveBeenCalled();
+      });
     });
 
     it('throws if RAG module is not active', async () => {

--- a/src/__tests__/unit/resilience-timeout.test.ts
+++ b/src/__tests__/unit/resilience-timeout.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Unit tests — withResilience per-attempt timeout
+ *
+ * GATEWAY_REQUEST_TIMEOUT_MS was configured but never read, so a provider that
+ * stopped responding held its socket and its request context indefinitely.
+ * These cover the timeout firing, the signal it aborts with, and the cases
+ * where it must stay out of the way.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const gateway = {
+  requestTimeoutMs: 50,
+  retryEnabled: false,
+  retryMaxAttempts: 3,
+  retryInitialDelayMs: 1,
+  circuitBreakerEnabled: false,
+  circuitBreakerThreshold: 5,
+  circuitBreakerResetMs: 30_000,
+};
+
+vi.mock('@/lib/core/config', () => ({
+  getConfig: () => ({ gateway }),
+}));
+
+vi.mock('@/lib/core/logger', () => ({
+  createLogger: () => ({
+    debug: () => {},
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+  }),
+}));
+
+import { withResilience, RequestTimeoutError } from '@/lib/core/resilience';
+
+/** A call that never settles — the hung upstream this guard exists for. */
+function neverSettles(): Promise<never> {
+  return new Promise<never>(() => {});
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+describe('withResilience timeout', () => {
+  beforeEach(() => {
+    gateway.requestTimeoutMs = 50;
+    gateway.retryEnabled = false;
+    gateway.circuitBreakerEnabled = false;
+  });
+
+  it('rejects a hung operation with RequestTimeoutError', async () => {
+    await expect(
+      withResilience(() => neverSettles(), { key: 'chat:test' }),
+    ).rejects.toBeInstanceOf(RequestTimeoutError);
+  });
+
+  it('aborts the signal it handed the operation, so the socket is released', async () => {
+    let observed: AbortSignal | undefined;
+
+    await expect(
+      withResilience((signal) => {
+        observed = signal;
+        return neverSettles();
+      }, { key: 'chat:test' }),
+    ).rejects.toBeInstanceOf(RequestTimeoutError);
+
+    expect(observed?.aborted).toBe(true);
+    expect(observed?.reason).toBeInstanceOf(RequestTimeoutError);
+  });
+
+  it('leaves an operation that finishes in time untouched', async () => {
+    const result = await withResilience(async () => {
+      await sleep(5);
+      return 'ok';
+    }, { key: 'chat:test' });
+
+    expect(result).toBe('ok');
+  });
+
+  it('does not abort the signal after a successful call', async () => {
+    let observed: AbortSignal | undefined;
+
+    await withResilience(async (signal) => {
+      observed = signal;
+      return 'ok';
+    }, { key: 'chat:test' });
+
+    await sleep(80); // past the configured timeout
+    expect(observed?.aborted).toBe(false);
+  });
+
+  it('honours a per-call override', async () => {
+    gateway.requestTimeoutMs = 10_000;
+
+    await expect(
+      withResilience(() => neverSettles(), { key: 'chat:test', timeoutMs: 20 }),
+    ).rejects.toBeInstanceOf(RequestTimeoutError);
+  });
+
+  it('treats timeoutMs 0 as no timeout', async () => {
+    const result = await withResilience(async () => {
+      await sleep(80); // longer than the configured 50ms
+      return 'ok';
+    }, { key: 'chat:test', timeoutMs: 0 });
+
+    expect(result).toBe('ok');
+  });
+
+  it('applies the budget per attempt, not per call', async () => {
+    gateway.retryEnabled = true;
+    gateway.retryMaxAttempts = 2;
+    let attempts = 0;
+
+    const result = await withResilience(async () => {
+      attempts += 1;
+      if (attempts === 1) await sleep(80); // first attempt times out
+      return 'ok';
+    }, { key: 'chat:test' });
+
+    expect(attempts).toBe(2);
+    expect(result).toBe('ok');
+  });
+});

--- a/src/__tests__/unit/runtime-pool-disposal.test.ts
+++ b/src/__tests__/unit/runtime-pool-disposal.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Unit tests — RuntimePool connection disposal
+ *
+ * Evicting a cached runtime used to be a bare `delete`, which dropped the
+ * reference while its pg pool / Elasticsearch client kept every socket open —
+ * an unbounded FD leak across tenant×provider combinations. These cover the
+ * deferred close, and the grace period that keeps it from cutting a request
+ * that is still holding the runtime.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const providerRuntime = {
+  cacheTtlSeconds: 300,
+  disposeGraceSeconds: 0,
+};
+
+vi.mock('@/lib/core/config', () => ({
+  getConfig: () => ({ providerRuntime }),
+}));
+
+vi.mock('@/lib/core/logger', () => ({
+  createLogger: () => ({
+    debug: () => {},
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+  }),
+}));
+
+import { runtimePool } from '@/lib/core/runtimePool';
+
+interface Closable {
+  id: string;
+  closed: boolean;
+  close: () => Promise<void>;
+}
+
+function makeClosable(id: string): Closable {
+  const runtime: Closable = {
+    id,
+    closed: false,
+    close: async () => { runtime.closed = true; },
+  };
+  return runtime;
+}
+
+/** Let the queued close microtasks settle. */
+function flush(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe('RuntimePool disposal', () => {
+  beforeEach(() => {
+    providerRuntime.cacheTtlSeconds = 300;
+    providerRuntime.disposeGraceSeconds = 0;
+    runtimePool.invalidateByPrefix('test:');
+  });
+
+  it('closes a runtime dropped by an explicit invalidate', async () => {
+    const runtime = makeClosable('a');
+    await runtimePool.getOrCreate('test:a', 'hash-1', async () => runtime);
+
+    runtimePool.invalidate('test:a');
+    await flush();
+
+    expect(runtime.closed).toBe(true);
+  });
+
+  it('closes the old runtime when credentials change', async () => {
+    const first = makeClosable('first');
+    const second = makeClosable('second');
+
+    await runtimePool.getOrCreate('test:b', 'hash-1', async () => first);
+    await runtimePool.getOrCreate('test:b', 'hash-2', async () => second);
+    await flush();
+
+    expect(first.closed).toBe(true);
+    expect(second.closed).toBe(false);
+  });
+
+  it('holds the close until the grace period elapses', async () => {
+    providerRuntime.disposeGraceSeconds = 60;
+    const runtime = makeClosable('c');
+    await runtimePool.getOrCreate('test:c', 'hash-1', async () => runtime);
+
+    runtimePool.invalidate('test:c');
+    await flush();
+
+    // A request that already holds this runtime must be allowed to finish.
+    expect(runtime.closed).toBe(false);
+  });
+
+  it('leaves a runtime that is still cached open', async () => {
+    const runtime = makeClosable('d');
+    await runtimePool.getOrCreate('test:d', 'hash-1', async () => runtime);
+    await runtimePool.getOrCreate('test:d', 'hash-1', async () => makeClosable('unused'));
+    await flush();
+
+    expect(runtime.closed).toBe(false);
+  });
+
+  it('closes every runtime dropped by a prefix invalidate', async () => {
+    const one = makeClosable('one');
+    const two = makeClosable('two');
+    await runtimePool.getOrCreate('test:tenant:one', 'hash-1', async () => one);
+    await runtimePool.getOrCreate('test:tenant:two', 'hash-1', async () => two);
+
+    runtimePool.invalidateByPrefix('test:tenant:');
+    await flush();
+
+    expect(one.closed).toBe(true);
+    expect(two.closed).toBe(true);
+  });
+
+  it('ignores a runtime that exposes no close()', async () => {
+    const plain = { id: 'plain' };
+    await runtimePool.getOrCreate('test:plain', 'hash-1', async () => plain);
+
+    expect(() => runtimePool.invalidate('test:plain')).not.toThrow();
+  });
+
+  it('survives a close() that throws', async () => {
+    const runtime = {
+      close: async () => { throw new Error('connection already gone'); },
+    };
+    await runtimePool.getOrCreate('test:throws', 'hash-1', async () => runtime);
+
+    runtimePool.invalidate('test:throws');
+    await expect(flush()).resolves.toBeUndefined();
+  });
+});

--- a/src/lib/core/config.ts
+++ b/src/lib/core/config.ts
@@ -139,6 +139,11 @@ export interface AppConfig {
     syncIntervalMs: number;
   };
 
+  quota: {
+    /** TTL for the cached tenant license + policy set. 0 disables the cache. */
+    policyCacheTtlSeconds: number;
+  };
+
   logging: {
     level: 'error' | 'warn' | 'info' | 'debug';
     format: 'json' | 'pretty';
@@ -170,6 +175,11 @@ export interface AppConfig {
 
   providerRuntime: {
     cacheTtlSeconds: number;
+    /**
+     * How long an evicted runtime is held before its connections are closed.
+     * Covers requests still holding a reference. 0 closes immediately.
+     */
+    disposeGraceSeconds: number;
   };
 
   browser: {
@@ -404,6 +414,10 @@ function buildConfig(source: ConfigSource): AppConfig {
       syncIntervalMs: int(source, 'RATE_LIMIT_SYNC_INTERVAL_MS', 5000),
     },
 
+    quota: {
+      policyCacheTtlSeconds: int(source, 'QUOTA_POLICY_CACHE_TTL_SECONDS', 30),
+    },
+
     logging: {
       level: oneOf(source, 'LOG_LEVEL', ['error', 'warn', 'info', 'debug'], nodeEnv === 'production' ? 'info' : 'debug'),
       format: oneOf(source, 'LOG_FORMAT', ['json', 'pretty'], nodeEnv === 'production' ? 'json' : 'pretty'),
@@ -437,6 +451,7 @@ function buildConfig(source: ConfigSource): AppConfig {
 
     providerRuntime: {
       cacheTtlSeconds: int(source, 'PROVIDER_RUNTIME_CACHE_TTL_SECONDS', 300),
+      disposeGraceSeconds: int(source, 'PROVIDER_RUNTIME_DISPOSE_GRACE_SECONDS', 300),
     },
 
     browser: {

--- a/src/lib/core/resilience.ts
+++ b/src/lib/core/resilience.ts
@@ -29,6 +29,14 @@ export interface ResilienceOptions {
   retry?: Partial<RetryConfig>;
   /** Override circuit breaker config */
   circuitBreaker?: Partial<CircuitBreakerConfig>;
+  /**
+   * Per-attempt timeout in ms. Defaults to GATEWAY_REQUEST_TIMEOUT_MS.
+   * `0` disables the timeout for this call.
+   *
+   * The budget is per attempt, not per call: a retried operation gets the full
+   * timeout again, the same way an HTTP client's timeout applies to each try.
+   */
+  timeoutMs?: number;
 }
 
 export interface RetryConfig {
@@ -98,6 +106,23 @@ export class CircuitOpenError extends Error {
   constructor(key: string) {
     super(`Circuit breaker is open for "${key}" — request rejected`);
     this.name = 'CircuitOpenError';
+  }
+}
+
+/**
+ * Raised when an attempt exceeds its timeout budget.
+ *
+ * Treated as retryable: a single upstream stall is usually transient, and a
+ * provider that keeps stalling trips the circuit breaker after `threshold`
+ * failed calls, which is what stops the bleeding.
+ */
+export class RequestTimeoutError extends Error {
+  readonly timeoutMs: number;
+
+  constructor(key: string, timeoutMs: number) {
+    super(`Request to "${key}" timed out after ${timeoutMs}ms`);
+    this.name = 'RequestTimeoutError';
+    this.timeoutMs = timeoutMs;
   }
 }
 
@@ -171,6 +196,48 @@ function sleep(ms: number): Promise<void> {
 }
 
 /* ------------------------------------------------------------------ */
+/*  Per-attempt timeout                                               */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Run one attempt under a timeout.
+ *
+ * The signal is handed to the operation so a timeout *aborts* the upstream
+ * call instead of merely abandoning it — abandoning leaves the socket, the
+ * request context and (on a streaming call) the provider's generation alive,
+ * which is the leak this guards against. Operations that ignore the signal
+ * still stop blocking the caller, they just release their socket later.
+ */
+async function runAttempt<T>(
+  operation: (signal: AbortSignal) => Promise<T>,
+  key: string,
+  timeoutMs: number,
+): Promise<T> {
+  if (timeoutMs <= 0) {
+    return operation(new AbortController().signal);
+  }
+
+  const controller = new AbortController();
+  let timer: ReturnType<typeof setTimeout> | undefined;
+
+  const expiry = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => {
+      const error = new RequestTimeoutError(key, timeoutMs);
+      controller.abort(error);
+      reject(error);
+    }, timeoutMs);
+    // Never hold the event loop open for a timer that only guards a request.
+    timer.unref?.();
+  });
+
+  try {
+    return await Promise.race([operation(controller.signal), expiry]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+/* ------------------------------------------------------------------ */
 /*  Main API                                                          */
 /* ------------------------------------------------------------------ */
 
@@ -181,7 +248,7 @@ function sleep(ms: number): Promise<void> {
  * @param options Resilience options (key is required for circuit breaker state)
  */
 export async function withResilience<T>(
-  operation: () => Promise<T>,
+  operation: (signal: AbortSignal) => Promise<T>,
   options: ResilienceOptions,
 ): Promise<T> {
   const cfg = getConfig();
@@ -202,6 +269,8 @@ export async function withResilience<T>(
     ...options.circuitBreaker,
   };
 
+  const timeoutMs = options.timeoutMs ?? cfg.gateway.requestTimeoutMs;
+
   // Circuit breaker check (before any attempt)
   checkCircuit(options.key, cbCfg);
 
@@ -211,7 +280,7 @@ export async function withResilience<T>(
 
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
     try {
-      const result = await operation();
+      const result = await runAttempt(operation, options.key, timeoutMs);
       recordSuccess(options.key, cbCfg);
       return result;
     } catch (error) {

--- a/src/lib/core/runtimePool.ts
+++ b/src/lib/core/runtimePool.ts
@@ -33,12 +33,35 @@ interface PoolEntry<T = unknown> {
   lastUsedAt: number;
 }
 
+/**
+ * A runtime that owns connections (a pg pool, an Elasticsearch client) and can
+ * release them. Detected structurally so any driver can opt in by exposing
+ * `close()` — runtimes without one are dropped as before.
+ */
+interface DisposableRuntime {
+  close(): Promise<void> | void;
+}
+
+function asDisposable(runtime: unknown): DisposableRuntime | null {
+  if (!runtime || typeof runtime !== 'object') return null;
+  const close = (runtime as { close?: unknown }).close;
+  return typeof close === 'function' ? (runtime as DisposableRuntime) : null;
+}
+
+/** An evicted runtime waiting out its grace period before being closed. */
+interface PendingDisposal {
+  key: string;
+  runtime: unknown;
+  disposeAt: number;
+}
+
 /* ------------------------------------------------------------------ */
 /*  Pool Implementation                                               */
 /* ------------------------------------------------------------------ */
 
 class RuntimePool {
   private pool = new Map<string, PoolEntry>();
+  private pendingDisposal: PendingDisposal[] = [];
   private sweepTimer: ReturnType<typeof setInterval> | null = null;
 
   constructor() {
@@ -72,7 +95,7 @@ class RuntimePool {
       }
 
       // Remove stale entry
-      this.pool.delete(key);
+      this.evict(key);
       if (credentialsChanged) {
         log.debug(`Runtime credentials changed, refreshing: ${key}`);
       }
@@ -96,16 +119,16 @@ class RuntimePool {
    * Invalidate a specific cached runtime.
    */
   invalidate(key: string): void {
-    this.pool.delete(key);
+    this.evict(key);
   }
 
   /**
    * Invalidate all runtimes for a tenant.
    */
   invalidateByPrefix(prefix: string): void {
-    for (const key of this.pool.keys()) {
+    for (const key of [...this.pool.keys()]) {
       if (key.startsWith(prefix)) {
-        this.pool.delete(key);
+        this.evict(key);
       }
     }
   }
@@ -114,14 +137,74 @@ class RuntimePool {
    * Remove all expired entries.
    */
   private sweep(): void {
+    // Runs before the TTL check: entries retired by an explicit invalidate
+    // still have connections to release even when expiration is disabled.
+    this.drainDisposals();
+
     const ttl = getConfig().providerRuntime.cacheTtlSeconds * 1000;
     if (ttl <= 0) return; // no expiration
 
     const now = Date.now();
-    for (const [key, entry] of this.pool) {
+    for (const [key, entry] of [...this.pool]) {
       if (now - entry.createdAt > ttl) {
-        this.pool.delete(key);
+        this.evict(key, entry);
       }
+    }
+  }
+
+  /**
+   * Drop an entry from the pool and queue its connections for release.
+   *
+   * Eviction used to be a bare `delete`, which left every pooled pg/Elasticsearch
+   * socket open for the lifetime of the process — a slow but unbounded FD leak
+   * across tenant×provider combinations.
+   */
+  private evict(key: string, known?: PoolEntry): void {
+    const entry = known ?? this.pool.get(key);
+    this.pool.delete(key);
+    if (!entry || !asDisposable(entry.runtime)) return;
+
+    const graceMs = getConfig().providerRuntime.disposeGraceSeconds * 1000;
+    if (graceMs <= 0) {
+      void this.closeRuntime(key, entry.runtime);
+      return;
+    }
+
+    // A request that already holds this runtime must be allowed to finish;
+    // closing underneath it would fail a live query to fix a slow leak.
+    this.pendingDisposal.push({
+      key,
+      runtime: entry.runtime,
+      disposeAt: Date.now() + graceMs,
+    });
+  }
+
+  private async closeRuntime(key: string, runtime: unknown): Promise<void> {
+    try {
+      await asDisposable(runtime)?.close();
+      log.debug(`Runtime connections released: ${key}`);
+    } catch (error) {
+      log.warn(`Failed to release runtime connections: ${key}`, {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  /** Close every retired runtime whose grace period has elapsed. */
+  private drainDisposals(force = false): void {
+    if (this.pendingDisposal.length === 0) return;
+
+    const now = Date.now();
+    const due: PendingDisposal[] = [];
+    const waiting: PendingDisposal[] = [];
+
+    for (const item of this.pendingDisposal) {
+      (force || item.disposeAt <= now ? due : waiting).push(item);
+    }
+
+    this.pendingDisposal = waiting;
+    for (const item of due) {
+      void this.closeRuntime(item.key, item.runtime);
     }
   }
 
@@ -140,6 +223,12 @@ class RuntimePool {
       clearInterval(this.sweepTimer);
       this.sweepTimer = null;
     }
+    for (const key of [...this.pool.keys()]) {
+      this.evict(key);
+    }
+    // Shutdown skips the grace period: the process is going away, and holding
+    // sockets open past this point only delays a clean exit.
+    this.drainDisposals(true);
     this.pool.clear();
   }
 }

--- a/src/lib/providers/contracts/elasticsearchCloudVector.contract.ts
+++ b/src/lib/providers/contracts/elasticsearchCloudVector.contract.ts
@@ -214,6 +214,9 @@ export const ElasticsearchCloudVectorProviderContract: ProviderContract<
     const dimensions = getCloudDimensions(settings);
 
     const runtime: VectorProviderRuntime = {
+      async close(): Promise<void> {
+        await client.close();
+      },
       async createIndex(input: CreateVectorIndexInput): Promise<VectorIndexHandle> {
         const indexName = input.name || settings.indexName;
         if (!indexName) {

--- a/src/lib/providers/contracts/elasticsearchSelfHostedVector.contract.ts
+++ b/src/lib/providers/contracts/elasticsearchSelfHostedVector.contract.ts
@@ -137,6 +137,9 @@ export const ElasticsearchSelfHostedVectorProviderContract: ProviderContract<
     const dimensions = getSelfHostedDimensions(settings);
 
     const runtime: VectorProviderRuntime = {
+      async close(): Promise<void> {
+        await client.close();
+      },
       async createIndex(input: CreateVectorIndexInput): Promise<VectorIndexHandle> {
         const indexName = input.name || settings.indexName;
         if (!indexName) {

--- a/src/lib/providers/contracts/elasticsearchVector.contract.ts
+++ b/src/lib/providers/contracts/elasticsearchVector.contract.ts
@@ -33,6 +33,7 @@ interface ElasticsearchSettings {
 
 type EsClient = {
   ping: () => Promise<boolean>;
+  close: () => Promise<void>;
   indices: {
     exists: (p: { index: string }) => Promise<boolean>;
     create: (p: { index: string; mappings: unknown }) => Promise<unknown>;
@@ -202,6 +203,9 @@ export const ElasticsearchVectorProviderContract: ProviderContract<
     const client: EsClient = buildEsClient(credentials, settings, Client);
 
     const runtime: VectorProviderRuntime = {
+      async close(): Promise<void> {
+        await client.close();
+      },
       async createIndex(input: CreateVectorIndexInput): Promise<VectorIndexHandle> {
         const indexName = input.name || settings.indexName;
         if (!indexName) {

--- a/src/lib/providers/contracts/postgresVector.contract.ts
+++ b/src/lib/providers/contracts/postgresVector.contract.ts
@@ -261,6 +261,9 @@ export const PostgresVectorProviderContract: ProviderContract<
     }
 
     const runtime: VectorProviderRuntime = {
+      async close(): Promise<void> {
+        await pool.end();
+      },
       async createIndex(input: CreateVectorIndexInput): Promise<VectorIndexHandle> {
         const dim = input.dimension || dimensions;
         const metric = input.metric ?? 'cosine';

--- a/src/lib/providers/domains/vector.ts
+++ b/src/lib/providers/domains/vector.ts
@@ -135,4 +135,12 @@ export interface VectorProviderRuntime {
     handle: VectorIndexHandle,
     input?: VectorListInput,
   ): Promise<VectorListResult>;
+  /**
+   * Release any connections this runtime owns.
+   *
+   * Called by the runtime pool once an evicted runtime's grace period has
+   * elapsed. Implement it on any driver that holds a pool or a keep-alive
+   * client; stateless drivers can leave it out.
+   */
+  close?(): Promise<void> | void;
 }

--- a/src/lib/quota/quotaGuard.ts
+++ b/src/lib/quota/quotaGuard.ts
@@ -138,12 +138,91 @@ async function incrementRateLimitCounter(
   );
 }
 
+/**
+ * The tenant license + policy set behind an effective-limit resolution.
+ *
+ * Cached as the *inputs*, never as the merged result: the merge depends on the
+ * caller's user, token, resource, provider and domain, so caching the outcome
+ * would need a key per requester and could hand one caller another's limits.
+ * Filtering stays on the request path; only the two DB reads are amortized.
+ *
+ * TREAT AS READ-ONLY. The memory cache provider hands back the stored object
+ * itself, so mutating either field would corrupt it for every later request on
+ * this node. `mergeLimits` builds new objects rather than writing into its base
+ * for exactly this reason.
+ */
+interface QuotaPolicySource {
+  licenseDefaults: QuotaLimits;
+  policies: IQuotaPolicy[];
+}
+
+export function quotaPolicyCacheKey(
+  tenantDbName: string,
+  tenantId: string,
+  projectId: string,
+): string {
+  return `quota:policy-src:${tenantDbName}:${tenantId}:${projectId}`;
+}
+
+/**
+ * Load the tenant license defaults and quota policies, through a short-lived
+ * cache.
+ *
+ * Every guarded request used to re-read the tenant document and the policy
+ * collection, and an inference request runs three resolutions before the model
+ * is even called — six reads against a 10-connection pool on the hottest path
+ * in the product. Policy edits invalidate this explicitly (see quotaService);
+ * the TTL is the backstop for edits made elsewhere.
+ */
+async function loadPolicySource(
+  context: QuotaContext,
+): Promise<QuotaPolicySource> {
+  const ttlSeconds = getConfig().quota.policyCacheTtlSeconds;
+  const cacheKey = quotaPolicyCacheKey(
+    context.tenantDbName,
+    context.tenantId,
+    context.projectId,
+  );
+
+  if (ttlSeconds > 0) {
+    try {
+      const cache = await getCache();
+      const cached = await cache.get<QuotaPolicySource>(cacheKey);
+      if (cached) return cached;
+    } catch {
+      /* cache miss or unavailable — fall through to the database */
+    }
+  }
+
+  const db = await getDatabase();
+  // Read the tenant before switching databases: fetchPolicies switches the
+  // connection to the tenant DB, and the tenant record lives in the main one.
+  const tenant = await db.findTenantById(context.tenantId);
+  const licenseDefaults = LicenseManager.getQuotaLimitsForTenant(tenant);
+  const policies = await fetchPolicies(
+    context.tenantDbName,
+    context.tenantId,
+    context.projectId,
+  );
+
+  const source: QuotaPolicySource = { licenseDefaults, policies };
+
+  if (ttlSeconds > 0) {
+    try {
+      const cache = await getCache();
+      await cache.set(cacheKey, source, ttlSeconds);
+    } catch {
+      /* best-effort cache write */
+    }
+  }
+
+  return source;
+}
+
 export async function resolveEffectiveLimits(
   context: QuotaContext,
 ): Promise<QuotaLimits> {
-  const db = await getDatabase();
-  const tenant = await db.findTenantById(context.tenantId);
-  const licenseDefaults = LicenseManager.getQuotaLimitsForTenant(tenant);
+  const { licenseDefaults, policies } = await loadPolicySource(context);
   let effectiveLimits: QuotaLimits = {
     ...licenseDefaults,
     quotas: { ...licenseDefaults.quotas },
@@ -151,12 +230,6 @@ export async function resolveEffectiveLimits(
       ? { ...licenseDefaults.rateLimit }
       : undefined,
   };
-
-  const policies = await fetchPolicies(
-    context.tenantDbName,
-    context.tenantId,
-    context.projectId,
-  );
 
   const applicable = policies
     .filter((p) => matchesScope(p, context) && matchesDomain(p, context))

--- a/src/lib/services/agents/agentConsumer.ts
+++ b/src/lib/services/agents/agentConsumer.ts
@@ -20,6 +20,15 @@ import {
 const log = createLogger('agent.consumer');
 let started = false;
 
+/**
+ * Concurrent agent turns per node.
+ *
+ * These jobs are LLM round-trips — almost entirely I/O wait — so serialising
+ * them head-of-line blocked every cross-node turn behind the slowest one, and
+ * the queue's 60s invoke timeout then failed the ones still waiting.
+ */
+const CONCURRENCY = Math.max(1, Number(process.env.AGENT_CHAT_CONCURRENCY ?? 4) || 4);
+
 export async function startAgentQueueConsumer(): Promise<void> {
   if (started) return;
   const queue = await getQueue();
@@ -31,7 +40,7 @@ export async function startAgentQueueConsumer(): Promise<void> {
       return executePlaygroundChatLocal(ctx.data as unknown as AgentPlaygroundChatRequest);
     }
     throw new Error(`Unknown agent job: ${ctx.name}`);
-  });
+  }, { concurrency: CONCURRENCY });
   started = true;
-  log.info('Agent queue consumer registered');
+  log.info('Agent queue consumer registered', { concurrency: CONCURRENCY });
 }

--- a/src/lib/services/browser/browserConsumer.ts
+++ b/src/lib/services/browser/browserConsumer.ts
@@ -28,6 +28,12 @@ interface RunActionPayload {
   action: BrowserAction;
 }
 
+/**
+ * Concurrent browser actions per node. Individual actions are short (bounded by
+ * BROWSER_DEFAULT_ACTION_TIMEOUT_MS); the per-tenant session cap still applies.
+ */
+const CONCURRENCY = Math.max(1, Number(process.env.BROWSER_ACTION_CONCURRENCY ?? 4) || 4);
+
 export async function startBrowserQueueConsumer(): Promise<void> {
   if (started) return;
   const queue = await getQueue();
@@ -37,7 +43,7 @@ export async function startBrowserQueueConsumer(): Promise<void> {
       return runBrowserActionLocal(payload.ctx, payload.sessionKey, payload.action);
     }
     throw new Error(`Unknown browser job: ${ctx.name}`);
-  });
+  }, { concurrency: CONCURRENCY });
   started = true;
-  log.info('Browser queue consumer registered');
+  log.info('Browser queue consumer registered', { concurrency: CONCURRENCY });
 }

--- a/src/lib/services/crawler/crawlerConsumer.ts
+++ b/src/lib/services/crawler/crawlerConsumer.ts
@@ -27,6 +27,15 @@ interface RunPayload {
   jobId: string;
 }
 
+/**
+ * Concurrent crawl jobs per node.
+ *
+ * Kept lower than the other consumers on purpose: a single job already fans out
+ * to as many as 16 concurrent fetches and may drive a Chromium instance, so the
+ * real footprint is this number multiplied by that fan-out.
+ */
+const CONCURRENCY = Math.max(1, Number(process.env.CRAWLER_RUN_CONCURRENCY ?? 2) || 2);
+
 export async function startCrawlerQueueConsumer(): Promise<void> {
   if (started) return;
   const queue = await getQueue();
@@ -37,7 +46,7 @@ export async function startCrawlerQueueConsumer(): Promise<void> {
       return { ok: true };
     }
     throw new Error(`Unknown crawler job: ${ctx.name}`);
-  });
+  }, { concurrency: CONCURRENCY });
   started = true;
-  log.info('Crawler queue consumer registered');
+  log.info('Crawler queue consumer registered', { concurrency: CONCURRENCY });
 }

--- a/src/lib/services/mcp/mcpConsumer.ts
+++ b/src/lib/services/mcp/mcpConsumer.ts
@@ -19,6 +19,12 @@ interface InvokePayload {
   runtimeHeaders?: Record<string, string>;
 }
 
+/**
+ * Concurrent MCP tool invocations per node. Stdio servers stay bounded by
+ * MCP_STDIO_MAX_CONCURRENT underneath this.
+ */
+const CONCURRENCY = Math.max(1, Number(process.env.MCP_INVOKE_CONCURRENCY ?? 4) || 4);
+
 export async function startMcpQueueConsumer(): Promise<void> {
   if (started) return;
   const queue = await getQueue();
@@ -28,7 +34,7 @@ export async function startMcpQueueConsumer(): Promise<void> {
       return executeMcpToolLocal(payload.server, payload.toolName, payload.args, payload.runtimeHeaders);
     }
     throw new Error(`Unknown mcp job: ${ctx.name}`);
-  });
+  }, { concurrency: CONCURRENCY });
   started = true;
-  log.info('MCP queue consumer registered');
+  log.info('MCP queue consumer registered', { concurrency: CONCURRENCY });
 }

--- a/src/lib/services/models/inferenceService.ts
+++ b/src/lib/services/models/inferenceService.ts
@@ -1198,7 +1198,7 @@ export async function handleChatCompletion(params: {
     let asyncIterator: AsyncIterable<AIMessageChunk>;
     if (disableProviderStreaming) {
       const eagerMessage = await withResilience(
-        () => chatModel.invoke(messages, callOptions),
+        (signal) => chatModel.invoke(messages, { ...callOptions, signal }),
         { key: `chat:${model.providerKey}` },
       );
       asyncIterator = (async function* () {
@@ -1215,7 +1215,17 @@ export async function handleChatCompletion(params: {
       })();
     } else {
       asyncIterator = await withResilience(
-        () => chatModel.stream!(messages, streamCallOptions) as Promise<AsyncIterable<AIMessageChunk>>,
+        (signal) => {
+          // The stream already aborts on client disconnect; chain the gateway's
+          // timeout into the same controller so a provider that never opens the
+          // stream is cut loose too, instead of holding the socket.
+          signal.addEventListener(
+            'abort',
+            () => abortController.abort(signal.reason),
+            { once: true },
+          );
+          return chatModel.stream!(messages, streamCallOptions) as Promise<AsyncIterable<AIMessageChunk>>;
+        },
         { key: `chat-stream:${model.providerKey}` },
       );
     }
@@ -1512,7 +1522,7 @@ export async function handleChatCompletion(params: {
   }
 
   const aiMessage = await withResilience(
-    () => chatModel.invoke(messages, callOptions),
+    (signal) => chatModel.invoke(messages, { ...callOptions, signal }),
     { key: `chat:${model.providerKey}` },
   );
 

--- a/src/lib/services/quota/quotaService.ts
+++ b/src/lib/services/quota/quotaService.ts
@@ -1,6 +1,39 @@
 import { getDatabase, type IQuotaPolicy } from '@/lib/database';
+import { getCache } from '@/lib/core/cache';
+import { createLogger } from '@/lib/core/logger';
 import { LicenseManager } from '@/lib/license/license-manager';
+import { quotaPolicyCacheKey } from '@/lib/quota/quotaGuard';
 import type { QuotaDomain, QuotaPolicy, QuotaPolicyInput, QuotaScope } from '@/lib/quota/types';
+
+const logger = createLogger('quota-service');
+
+/**
+ * Drop the cached license + policy set so an edit applies to the next request
+ * instead of after QUOTA_POLICY_CACHE_TTL_SECONDS.
+ *
+ * Best-effort, and only for a mutation that names a project. A tenant-wide
+ * policy carries no project yet applies to every one of them, and the cache is
+ * keyed per project — there is no single key to drop, so those edits land on
+ * the TTL instead.
+ */
+async function invalidatePolicyCache(
+  tenantDbName: string,
+  tenantId: string,
+  projectId?: string,
+): Promise<void> {
+  if (!projectId) return;
+
+  try {
+    const cache = await getCache();
+    await cache.del(quotaPolicyCacheKey(tenantDbName, tenantId, projectId));
+  } catch (error) {
+    logger.warn('Failed to invalidate quota policy cache; entry expires on TTL', {
+      tenantId,
+      projectId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
 
 function normalizePolicy(policy: IQuotaPolicy): QuotaPolicy {
   return {
@@ -63,6 +96,8 @@ export async function createQuotaPolicy(
     updatedAt: now,
   });
 
+  await invalidatePolicyCache(tenantDbName, tenantId, payload.projectId);
+
   return normalizePolicy(policy);
 }
 
@@ -81,6 +116,8 @@ export async function updateQuotaPolicy(
     updatedAt: new Date(),
   }, projectId);
 
+  await invalidatePolicyCache(tenantDbName, tenantId, projectId);
+
   return updated ? normalizePolicy(updated) : null;
 }
 
@@ -92,5 +129,9 @@ export async function deleteQuotaPolicy(
 ): Promise<boolean> {
   const db = await getDatabase();
   await db.switchToTenant(tenantDbName);
-  return db.deleteQuotaPolicy(id, tenantId, projectId);
+  const deleted = await db.deleteQuotaPolicy(id, tenantId, projectId);
+
+  await invalidatePolicyCache(tenantDbName, tenantId, projectId);
+
+  return deleted;
 }

--- a/src/lib/services/rag/ragIngestConsumer.ts
+++ b/src/lib/services/rag/ragIngestConsumer.ts
@@ -1,0 +1,47 @@
+/**
+ * Knowledge Engine ingest queue consumer — registered on every node at
+ * bootstrap.
+ *
+ * Mirrors the re-index consumer: on single-node (memory queue) deployments it
+ * drains locally; on multi-node BullMQ deployments it indexes the documents
+ * routed to this node.
+ */
+
+import { createLogger } from '@/lib/core/logger';
+import { getQueue, type JobContext, type QueuePayload } from '@/lib/core/queue';
+import {
+  RAG_INGEST_JOB,
+  RAG_INGEST_QUEUE,
+  runRagIngestJob,
+  type RagIngestJobPayload,
+} from './ragIngestJob';
+
+const log = createLogger('rag-ingest:consumer');
+let started = false;
+
+/**
+ * Documents indexed concurrently on this node.
+ *
+ * Higher than the re-index default (1) because these are single documents
+ * rather than whole corpora, but still modest: each one streams its chunks
+ * through the embedding provider, and going wide mostly buys rate-limit errors.
+ */
+const CONCURRENCY = Math.max(1, Number(process.env.RAG_INGEST_CONCURRENCY ?? 2) || 2);
+
+export async function startRagIngestQueueConsumer(): Promise<void> {
+  if (started) return;
+  const queue = await getQueue();
+  queue.consume(
+    RAG_INGEST_QUEUE,
+    async (ctx: JobContext<QueuePayload>) => {
+      if (ctx.name === RAG_INGEST_JOB) {
+        await runRagIngestJob(ctx.data as unknown as RagIngestJobPayload);
+        return { ok: true };
+      }
+      throw new Error(`Unknown Knowledge Engine ingest job: ${ctx.name}`);
+    },
+    { concurrency: CONCURRENCY },
+  );
+  started = true;
+  log.info('Knowledge Engine ingest queue consumer registered', { concurrency: CONCURRENCY });
+}

--- a/src/lib/services/rag/ragIngestJob.ts
+++ b/src/lib/services/rag/ragIngestJob.ts
@@ -1,0 +1,130 @@
+/**
+ * Knowledge Engine ingest background job.
+ *
+ * Ingesting a document means chunking it, embedding every chunk against the
+ * provider and upserting the vectors — work measured in seconds to minutes for
+ * anything larger than a FAQ. Running that inside the HTTP request held a
+ * worker (and the client's socket) open for the whole run, with no request
+ * timeout to bound it, so a handful of concurrent ingests could occupy every
+ * connection the node had.
+ *
+ * Deferred ingestion instead persists the document's source, writes the record
+ * as `pending`, and publishes a job here. The consumer
+ * (`ragIngestConsumer.ts`) indexes it on whichever node picks it up and moves
+ * the record to `indexed` or `failed`; callers follow the document's `status`.
+ *
+ * The source is stored BEFORE the job is published, so a crash between the two
+ * loses the indexing, never the content: `resumePendingRagIngests` re-publishes
+ * every `pending` document at boot, which is what makes this survive a restart
+ * on the memory queue driver.
+ */
+
+import { getDatabase, runWithTenantScope } from '@/lib/database';
+import { createLogger } from '@/lib/core/logger';
+import { getQueue, type QueuePayload } from '@/lib/core/queue';
+import { indexPendingRagDocument } from './ragService';
+
+const logger = createLogger('rag-ingest-job');
+
+export const RAG_INGEST_QUEUE = 'rag-ingest';
+export const RAG_INGEST_JOB = 'rag-ingest.document';
+
+export interface RagIngestJobPayload extends QueuePayload {
+  tenantDbName: string;
+  tenantId: string;
+  projectId?: string;
+  ragModuleKey: string;
+  documentId: string;
+}
+
+/**
+ * Cap on documents re-published by one boot sweep.
+ *
+ * A tenant that queued thousands of documents before a crash would otherwise
+ * turn every startup into a full re-publish storm competing with the readiness
+ * probe. What the cap skips stays `pending` and is picked up by the next sweep.
+ */
+const BOOT_RESUME_MAX = Math.max(
+  1,
+  Number(process.env.RAG_INGEST_BOOT_RESUME_MAX ?? 500) || 500,
+);
+
+export async function publishRagIngestJob(
+  payload: RagIngestJobPayload,
+): Promise<void> {
+  const queue = await getQueue();
+  await queue.publish(RAG_INGEST_QUEUE, RAG_INGEST_JOB, payload, {
+    // No driver-level retry: a run that dies part-way has already written some
+    // of the document's chunks, and re-running it would embed those a second
+    // time. A failure lands on the record as `failed` + `errorMessage`, exactly
+    // as it does on the synchronous path, and re-ingesting is the operator's
+    // call (the same way a failed upload is re-uploaded).
+    attempts: 1,
+    // The boot sweep re-publishes every `pending` document, which can race a
+    // job still sitting in the queue from before the restart.
+    dedupKey: `${payload.tenantDbName}:${payload.documentId}`,
+  });
+}
+
+export async function runRagIngestJob(
+  payload: RagIngestJobPayload,
+): Promise<void> {
+  await indexPendingRagDocument(
+    payload.tenantDbName,
+    payload.tenantId,
+    payload.projectId,
+    payload.ragModuleKey,
+    payload.documentId,
+  );
+}
+
+/**
+ * Re-publish documents left `pending` by a restart.
+ *
+ * Runs after the consumer is registered, mirroring the re-index job's contract.
+ * `indexPendingRagDocument` is idempotent, so a document that a surviving job
+ * already indexed is a no-op here rather than a double-embed.
+ */
+export async function resumePendingRagIngests(): Promise<number> {
+  const mainDb = await getDatabase();
+  const tenants = await mainDb.listTenants();
+  let resumed = 0;
+
+  for (const tenant of tenants) {
+    if (!tenant.dbName) continue;
+    if (resumed >= BOOT_RESUME_MAX) break;
+
+    try {
+      const pending = await runWithTenantScope(tenant.dbName, async (db) => {
+        const modules = await db.listRagModules();
+        const documents = [];
+        for (const ragModule of modules) {
+          const stuck = await db.listRagDocuments(ragModule.key, { status: 'pending' });
+          for (const doc of stuck) {
+            documents.push({
+              tenantId: doc.tenantId,
+              projectId: doc.projectId,
+              ragModuleKey: ragModule.key,
+              documentId: String(doc._id),
+            });
+          }
+        }
+        return documents;
+      });
+
+      for (const doc of pending) {
+        if (resumed >= BOOT_RESUME_MAX) break;
+        await publishRagIngestJob({ tenantDbName: tenant.dbName, ...doc });
+        resumed += 1;
+      }
+    } catch (error) {
+      logger.warn('Failed to resume pending ingests for tenant', {
+        tenant: tenant.slug,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  if (resumed > 0) logger.info('Resumed pending Knowledge Engine ingests', { resumed });
+  return resumed;
+}

--- a/src/lib/services/rag/ragService.ts
+++ b/src/lib/services/rag/ragService.ts
@@ -27,6 +27,7 @@ import { runReranker } from '@/lib/services/reranker';
 import { recordUsageEvent } from '@/lib/services/usage/usageEvents';
 import { fireAndForget } from '@/lib/core/asyncTask';
 import { chunkConfigRequiresReindex, chunkText, resolveParentWindow, type ChunkContext } from './chunking';
+import { publishRagIngestJob } from './ragIngestJob';
 import {
   discardDocumentSource,
   hashSourceText,
@@ -793,7 +794,7 @@ export async function ingestDocument(
     fileName: request.fileName,
     contentType: request.contentType,
     size: Buffer.byteLength(request.content, 'utf-8'),
-    status: 'processing',
+    status: request.deferIndexing ? 'pending' : 'processing',
     chunkConfig: request.chunkConfig,
     metadata: request.metadata,
     createdBy: request.createdBy,
@@ -801,6 +802,19 @@ export async function ingestDocument(
   });
 
   const documentId = String(docRecord._id);
+
+  // The source is committed above, so publishing after it means a crash in
+  // between costs the indexing (recovered by the boot sweep), never the content.
+  if (request.deferIndexing) {
+    await publishRagIngestJob({
+      tenantDbName,
+      tenantId,
+      projectId,
+      ragModuleKey: request.ragModuleKey,
+      documentId,
+    });
+    return withoutInlineSource(docRecord);
+  }
 
   try {
     const chunkCount = await indexDocumentContent({
@@ -834,6 +848,90 @@ export async function ingestDocument(
     await db.updateRagDocument(documentId, {
       status: 'failed',
       errorMessage: msg,
+    });
+    throw error;
+  }
+}
+
+/**
+ * Index a document whose source is already stored — the deferred half of
+ * `ingestDocument`, run by the ingest queue consumer.
+ *
+ * Idempotent on the way in: a document another attempt already indexed returns
+ * untouched, so a duplicate delivery (or the boot sweep racing a job that
+ * survived the restart) cannot embed the same content twice.
+ */
+export async function indexPendingRagDocument(
+  tenantDbName: string,
+  tenantId: string,
+  projectId: string | undefined,
+  ragModuleKey: string,
+  documentId: string,
+): Promise<void> {
+  const db = await getDatabase();
+  await db.switchToTenant(tenantDbName);
+
+  const doc = await db.findRagDocumentById(documentId);
+  if (!doc) {
+    logger.warn('Skipping ingest job for a document that no longer exists', {
+      documentId,
+      ragModuleKey,
+    });
+    return;
+  }
+  if (doc.status === 'indexed') return;
+
+  const ragModule = await db.findRagModuleByKey(ragModuleKey, projectId);
+  if (!ragModule) {
+    await db.updateRagDocument(documentId, {
+      status: 'failed',
+      errorMessage: `Knowledge Engine module "${ragModuleKey}" not found`,
+    });
+    return;
+  }
+
+  const text = await loadSourceText(tenantDbName, tenantId, projectId, doc);
+  if (!text) {
+    await db.updateRagDocument(documentId, {
+      status: 'failed',
+      errorMessage: 'Stored source text is unavailable for this document',
+    });
+    return;
+  }
+
+  await db.updateRagDocument(documentId, { status: 'processing' });
+
+  try {
+    const chunkCount = await indexDocumentContent({
+      db,
+      tenantDbName,
+      tenantId,
+      projectId,
+      ragModule,
+      chunkConfig: chunkConfigFor(ragModule, { chunkConfig: doc.chunkConfig }),
+      documentId,
+      fileName: doc.fileName,
+      text,
+      metadata: doc.metadata,
+    });
+
+    await db.updateRagDocument(documentId, {
+      status: 'indexed',
+      chunkCount,
+      lastIndexedAt: new Date(),
+    });
+
+    await db.updateRagModule(String(ragModule._id), {
+      totalDocuments: (ragModule.totalDocuments ?? 0) + 1,
+      totalChunks: (ragModule.totalChunks ?? 0) + chunkCount,
+    } as Partial<IRagModule>);
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : 'Ingestion failed';
+    await db.updateRagDocument(documentId, { status: 'failed', errorMessage: msg });
+    logger.error('Deferred Knowledge Engine ingest failed', {
+      documentId,
+      ragModuleKey,
+      error: msg,
     });
     throw error;
   }
@@ -900,6 +998,12 @@ export async function ingestFile(
     metadata?: Record<string, unknown>;
     chunkConfig?: IRagChunkConfig;
     force?: boolean;
+    /**
+     * Defer chunking + embedding to the ingest queue. File→text conversion
+     * still runs here: the bytes have to become text before the document can be
+     * persisted, and the stored text is what the job indexes.
+     */
+    deferIndexing?: boolean;
     createdBy: string;
   },
 ): Promise<RagDocument> {
@@ -925,6 +1029,7 @@ export async function ingestFile(
     contentType: request.contentType,
     chunkConfig: request.chunkConfig,
     force: request.force,
+    deferIndexing: request.deferIndexing,
     metadata: {
       ...request.metadata,
       _sourceType: isPlainText ? 'text' : 'converted',

--- a/src/lib/services/rag/types.ts
+++ b/src/lib/services/rag/types.ts
@@ -85,6 +85,14 @@ export interface RagIngestRequest {
    * embedded twice and answered from twice.
    */
   force?: boolean;
+  /**
+   * Persist the document and hand chunking + embedding to the ingest queue
+   * instead of running them inside the caller's request.
+   *
+   * The returned document is `pending`; it becomes `indexed` (or `failed`) once
+   * the job runs, and is not searchable until then.
+   */
+  deferIndexing?: boolean;
   createdBy: string;
 }
 

--- a/src/server/api/plugins/client-rag.ts
+++ b/src/server/api/plugins/client-rag.ts
@@ -210,19 +210,27 @@ export const clientRagApiPlugin: FastifyPluginAsync = async (app) => {
         return sendInvalidRequest(reply, error);
       }
 
+      // Opt-in: chunking and embedding move to the ingest queue and the call
+      // returns as soon as the document is persisted. Kept opt-in because the
+      // default response contract — 201 with an `indexed` document — is what
+      // existing clients read `chunkCount` from and query straight afterwards.
+      const deferIndexing = body.async === true;
+      const statusCode = deferIndexing ? 202 : 201;
+
       if (typeof body.data === 'string') {
         const document = await ingestFile(ctx.tenantDbName, ctx.tenantId, undefined, {
           chunkConfig,
           contentType: body.contentType as string | undefined,
           createdBy: ctx.tokenRecord.userId,
         force: body.force === true,
+          deferIndexing,
           fileData: decodeFileData(body.data),
           fileName: body.fileName,
           metadata: body.metadata as Record<string, unknown> | undefined,
           ragModuleKey: key,
         });
 
-        return reply.code(201).send({ document: withoutSourceText(document) });
+        return reply.code(statusCode).send({ document: withoutSourceText(document) });
       }
 
       if (typeof body.content !== 'string') {
@@ -236,13 +244,14 @@ export const clientRagApiPlugin: FastifyPluginAsync = async (app) => {
         content: body.content,
         contentType: body.contentType as string | undefined,
         createdBy: ctx.tokenRecord.userId,
+        deferIndexing,
         force: body.force === true,
         fileName: body.fileName,
         metadata: body.metadata as Record<string, unknown> | undefined,
         ragModuleKey: key,
       });
 
-      return reply.code(201).send({ document: withoutSourceText(document) });
+      return reply.code(statusCode).send({ document: withoutSourceText(document) });
     } catch (error) {
       logger.error('Ingest client RAG document error', { error });
       return reply.code(500).send({

--- a/src/server/bootstrap.ts
+++ b/src/server/bootstrap.ts
@@ -34,6 +34,8 @@ import { startVectorMigrationQueueConsumer } from '@/lib/services/vector/vectorM
 import { resumeInterruptedVectorMigrations } from '@/lib/services/vector/vectorMigrationJob';
 import { startRagReindexQueueConsumer } from '@/lib/services/rag/ragReindexConsumer';
 import { resumeInterruptedRagReindexRuns } from '@/lib/services/rag/ragReindexJob';
+import { startRagIngestQueueConsumer } from '@/lib/services/rag/ragIngestConsumer';
+import { resumePendingRagIngests } from '@/lib/services/rag/ragIngestJob';
 import { startPollScheduler } from '@/lib/services/inferenceMonitoring/pollScheduler';
 import { startAlertScheduler } from '@/lib/services/alerts/alertScheduler';
 import { startAnalysisScheduler } from '@/lib/services/analysis/analysisScheduler';
@@ -317,6 +319,7 @@ async function runBootstrap(): Promise<void> {
       startEvaluationRunQueueConsumer(),
       startVectorMigrationQueueConsumer(),
       startRagReindexQueueConsumer(),
+      startRagIngestQueueConsumer(),
       // Enterprise modules contribute their consumers through the seam;
       // the collection is empty in the community edition.
       ...enterpriseQueueConsumers.map((start) => start()),
@@ -344,6 +347,16 @@ async function runBootstrap(): Promise<void> {
     await resumeInterruptedRagReindexRuns();
   } catch (error) {
     logger.warn('Knowledge Engine re-index resume failed during startup', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+
+  // Documents left `pending` by a restart: the memory queue driver drops
+  // in-flight jobs, so without this sweep a deferred ingest would never run.
+  try {
+    await resumePendingRagIngests();
+  } catch (error) {
+    logger.warn('Knowledge Engine ingest resume failed during startup', {
       error: error instanceof Error ? error.message : String(error),
     });
   }


### PR DESCRIPTION
## Summary

Five load-path fixes from a capacity review of the console and its enterprise overlay. Each one addresses a place where the system had **no ceiling** under load rather than a wrong one: a provider call that could hang forever, a hot path that re-read the same two documents on every request, connections that were dropped without being closed, queue consumers pinned at one job, and document ingestion that occupied an HTTP worker for its whole run.

Behaviour is unchanged for existing clients. The one API-visible addition — deferred ingest — is opt-in, because the current `201`-with-`indexed`-document contract is what callers read `chunkCount` from and query immediately afterwards.

## Changes

- **Provider calls honour `GATEWAY_REQUEST_TIMEOUT_MS`.** The setting was defined and documented but never read, and Fastify's own `requestTimeout`/`connectionTimeout` are unset — so a stalled provider held its socket, its request context and (when streaming) its generation indefinitely. `withResilience` now applies the budget **per attempt** and hands the operation an `AbortSignal`, so a timeout *aborts* the upstream call rather than abandoning it. The chat paths pass that signal into LangChain; the streaming path chains it into the existing client-disconnect controller. `timeoutMs: 0` opts out. All 29 `withResilience` call sites inherit this.

- **Quota resolution caches the tenant license + policy set** (`QUOTA_POLICY_CACHE_TTL_SECONDS`, default 30, `0` disables). `/client/v1/chat/completions` resolves limits three times before the model is reached, each one an uncached `findTenantById` plus `listQuotaPolicies`, against a ten-connection pool. Only the **inputs** are cached — scope/domain filtering still runs per request, so a cache hit can never hand one caller another's limits (covered by a test). Policy create/update/delete invalidates the entry; the TTL is the backstop.

- **Evicted provider runtimes release their connections.** Eviction was a bare `pool.delete()`, which dropped the reference while the pg pool or Elasticsearch client kept every socket open — an unbounded FD leak across tenant×provider combinations. Runtimes opt in structurally via `close()` (implemented for pgvector and the three Elasticsearch drivers). The close is deferred by `PROVIDER_RUNTIME_DISPOSE_GRACE_SECONDS` (default 300) so a request still holding the runtime is never cut off, and runs immediately on shutdown.

- **Agent / MCP / browser / crawler consumers take a concurrency setting.** All four were fixed at `1`, so a cross-node job head-of-line blocked everything behind it until the queue's 60s `invoke` timeout failed the ones still waiting. Defaults: agent 4, MCP 4, browser 4, crawler 2 — crawler lower because a single job already fans out to as many as sixteen fetches and may drive a Chromium instance.

- **Knowledge Engine ingest can run off the request path.** Chunking, embedding and vector upsert ran inside the HTTP call with no timeout to bound them. Clients opt in with `async: true` and get `202` with a `pending` document that a queue consumer indexes. The source is committed *before* the job is published, and a boot sweep re-publishes `pending` documents, so a restart on the memory queue driver costs the indexing, never the content. `indexPendingRagDocument` returns early for an already-indexed document, so a duplicate delivery cannot double-embed.

Scope note: on the file-ingest path, file→text conversion still runs in-request — the bytes have to become text before the document can be persisted. Only chunking and embedding are deferred. Worth a follow-up.

New settings are documented in `.env.example`; the `async` flag and the `202` response are in `openapi.yaml`.

## Validation

- [x] `npm run lint` — 0 errors (164 pre-existing warnings)
- [x] `npm run test` — 3663 passed, 0 failures. 5 test *files* fail to start because `mongodb-memory-server` cannot download its binary in this sandbox (403/502 from `fastdl.mongodb.org`); confirmed identical on a clean checkout of `main`.
- [x] `npm run build`
- [x] `npm run docs:build`
- [x] `npm run test:endpoints` — 217 uncovered / 137 new, byte-identical to `main`; this change adds no uncovered routes.

Adds 28 tests: the timeout (firing, abort propagation, per-attempt budget, opt-out), the policy cache (including that filtering stays per-caller on a hit), deferred disposal (grace period, prefix invalidate, throwing `close()`), and both halves of the split ingest.

## Release Notes

- [x] Docs updated when behavior changed — `.env.example`, `openapi.yaml`
- [x] Security-sensitive changes reviewed — the quota cache stores license limits and policies keyed by tenant **and** project, and per-caller scope filtering deliberately stays outside the cache
- [ ] License or policy files updated if repo-facing behavior changed — not applicable

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ltao83ZEHPKrpAQZv3n5z1)_