### PR TITLE
Bound the gateway request path: caching, backpressure and pagination

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -102,6 +102,14 @@ RATE_LIMIT_PROVIDER=memory                         # Rate limit backend
 # long (policy edits through the API invalidate it immediately). 0 disables the
 # cache and every guarded request re-reads both from the database.
 # QUOTA_POLICY_CACHE_TTL_SECONDS=30                 # Quota policy cache TTL (seconds)
+#
+# Rate-limit counters are written as one batch per request (a Mongo bulkWrite,
+# a Redis pipeline) rather than one round trip per metric-window pair.
+
+# ---- Guardrails ----------------------------------------------------
+# A guarded model resolves its guardrail on the request path, twice when both an
+# input and an output guardrail are set. 0 disables the cache.
+# GUARDRAIL_CONFIG_CACHE_TTL_SECONDS=30             # Guardrail config cache TTL (seconds)
 
 # ---- Logging -------------------------------------------------
 # LOG_LEVEL=debug                                   # error | warn | info | debug
@@ -134,6 +142,11 @@ NEXT_PUBLIC_APP_URL=http://localhost:3000           # Public application URL (us
 # this long before they are closed, so a request still holding it can finish.
 # 0 closes immediately.
 # PROVIDER_RUNTIME_DISPOSE_GRACE_SECONDS=300        # Grace before an evicted runtime's connections close
+# The provider row behind a runtime is cached too, so a call does not re-read it
+# every time. What is cached is the row as stored — the credentials stay sealed
+# under PROVIDER_ENCRYPTION_SECRET and are decrypted per call, never cached in
+# the clear. Set 0 to keep that ciphertext out of the cache backend entirely.
+# PROVIDER_RECORD_CACHE_TTL_SECONDS=60              # Provider row cache TTL (seconds)
 
 # ---- Browser Runtime -----------------------------------------
 # BROWSER_DEFAULT_MAX_CONCURRENT=10                 # Default concurrent browser sessions per tenant
@@ -193,3 +206,19 @@ NEXT_PUBLIC_APP_URL=http://localhost:3000           # Public application URL (us
 # a job instead of inside the HTTP request.
 # RAG_INGEST_CONCURRENCY=2                          # Documents indexed concurrently per node
 # RAG_INGEST_BOOT_RESUME_MAX=500                    # Cap on pending documents re-published per boot sweep
+#
+# Parent-window retrieval reads a whole document per matched chunk — inline text
+# from the row, or a full object download for anything larger — so the fan-out
+# is capped, bounded in flight, and cached between queries.
+# RAG_PARENT_SOURCE_MAX_DOCUMENTS=25                # Documents expanded per query
+# RAG_PARENT_SOURCE_CONCURRENCY=4                   # Source loads in flight at once
+# RAG_PARENT_SOURCE_CACHE_TTL_SECONDS=60            # Reuse window for a loaded source (0 = off)
+# RAG_PARENT_SOURCE_CACHE_MAX_CHARS=65536           # Largest source kept in the cache
+
+# ---- Background tasks ----------------------------------------------
+# Usage, audit and telemetry writes run off the request path. They are queued and
+# executed by a bounded number of runners so the backlog cannot grow with the
+# request rate. Only telemetry is shed when the queue saturates; usage, billing
+# and audit writes are always kept.
+# ASYNC_TASK_MAX_CONCURRENT=32                      # Background tasks executing at once
+# ASYNC_TASK_MAX_QUEUED=1000                        # Queue depth for droppable telemetry

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -297,6 +297,23 @@ paths:
       description: List the agents available to the authenticated API token's project. Each entry exposes the agent key, name, description, status, creation time, and the resolved model configuration (modelKey, temperature, topP, maxTokens).
       operationId: listAgents
       parameters:
+        - name: limit
+          in: query
+          required: false
+          description: "Rows to return. Defaults to 100; values above 500 are clamped."
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 500
+            default: 100
+        - name: offset
+          in: query
+          required: false
+          description: Rows to skip before the page starts.
+          schema:
+            type: integer
+            minimum: 0
+            default: 0
         - name: status
           in: query
           required: false
@@ -5784,6 +5801,23 @@ paths:
       description: Returns all prompt templates in the token's project. Optionally filter by name or key using the `search` query parameter.
       operationId: listPrompts
       parameters:
+        - name: limit
+          in: query
+          required: false
+          description: "Rows to return. Defaults to 100; values above 500 are clamped."
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 500
+            default: 100
+        - name: offset
+          in: query
+          required: false
+          description: Rows to skip before the page starts.
+          schema:
+            type: integer
+            minimum: 0
+            default: 0
         - name: search
           in: query
           required: false
@@ -6410,6 +6444,23 @@ paths:
       description: Returns the documents ingested into a Knowledge Engine module.
       operationId: listRagDocuments
       parameters:
+        - name: limit
+          in: query
+          required: false
+          description: "Rows to return. Defaults to 100; values above 500 are clamped."
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 500
+            default: 100
+        - name: offset
+          in: query
+          required: false
+          description: Rows to skip before the page starts.
+          schema:
+            type: integer
+            minimum: 0
+            default: 0
         - name: key
           in: path
           required: true
@@ -9716,6 +9767,23 @@ paths:
       description: List tools available to the caller's project from the unified tool system. Tools are backed by an OpenAPI specification or an MCP server and expose discrete actions that can be invoked independently. Results are scoped to the API token's project.
       operationId: listTools
       parameters:
+        - name: limit
+          in: query
+          required: false
+          description: "Rows to return. Defaults to 100; values above 500 are clamped."
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 500
+            default: 100
+        - name: offset
+          in: query
+          required: false
+          description: Rows to skip before the page starts.
+          schema:
+            type: integer
+            minimum: 0
+            default: 0
         - name: status
           in: query
           required: false

--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -4,6 +4,7 @@
  */
 
 import { beforeEach } from 'vitest';
+import { getCache } from '@/lib/core/cache';
 import { resetRateLimitStore } from '@/lib/services/auth/rateLimiter';
 
 // Database provider — default to mongodb for existing tests
@@ -21,6 +22,16 @@ if (!process.env.DEBUG) {
   globalThis.console.debug = () => {};
 }
 
-beforeEach(() => {
+beforeEach(async () => {
   resetRateLimitStore();
+
+  // Request-path lookups (quota policies, guardrail configs, provider records,
+  // Knowledge Engine sources) are cached now, and the cache outlives a single
+  // test in the same process. Without this, one case's fixtures answer the
+  // next case's reads and the DB mock is never consulted.
+  try {
+    await (await getCache()).clear();
+  } catch {
+    /* provider not configured, or mocked without clear() — nothing to reset */
+  }
 });

--- a/src/__tests__/unit/async-task-queue.test.ts
+++ b/src/__tests__/unit/async-task-queue.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Unit tests — bounded background task queue
+ *
+ * Background work used to start the moment it was handed over, so the backlog
+ * grew with the request rate. These cover the concurrency ceiling, the shedding
+ * that protects it, and the guarantee that usage-class work is never shed.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/lib/core/logger', () => ({
+  createLogger: () => ({
+    debug: () => {}, info: () => {}, warn: () => {}, error: () => {},
+  }),
+}));
+
+vi.mock('@/lib/core/requestContext', () => ({
+  captureRequestContext: () => undefined,
+  runWithRequestContext: (_snapshot: unknown, fn: () => Promise<void>) => fn(),
+}));
+
+const MAX_CONCURRENT = 4;
+process.env.ASYNC_TASK_MAX_CONCURRENT = String(MAX_CONCURRENT);
+process.env.ASYNC_TASK_MAX_QUEUED = '5';
+
+const { fireAndForget, drainPendingTasks, pendingTaskCount, backgroundTaskStats } =
+  await import('@/lib/core/asyncTask');
+
+/** A task that only settles when its resolver is called. */
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>((r) => { resolve = () => r(); });
+  return { promise, resolve };
+}
+
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
+describe('bounded background queue', () => {
+  beforeEach(async () => {
+    await drainPendingTasks(1000);
+  });
+
+  it('runs a task and drains it', async () => {
+    const ran = vi.fn();
+    fireAndForget('unit', async () => { ran(); });
+
+    await drainPendingTasks(1000);
+    expect(ran).toHaveBeenCalledTimes(1);
+    expect(pendingTaskCount()).toBe(0);
+  });
+
+  it('never exceeds the concurrency ceiling', async () => {
+    const gates = Array.from({ length: MAX_CONCURRENT + 3 }, () => deferred());
+    let peak = 0;
+    let active = 0;
+
+    gates.forEach((gate, i) => {
+      fireAndForget(`task-${i}`, async () => {
+        active += 1;
+        peak = Math.max(peak, active);
+        await gate.promise;
+        active -= 1;
+      });
+    });
+
+    await flush();
+    expect(backgroundTaskStats().inFlight).toBe(MAX_CONCURRENT);
+    expect(backgroundTaskStats().queued).toBe(3);
+
+    gates.forEach((gate) => gate.resolve());
+    await drainPendingTasks(1000);
+
+    expect(peak).toBe(MAX_CONCURRENT);
+    expect(active).toBe(0);
+  });
+
+  it('sheds droppable work once the queue is saturated', async () => {
+    const gates = Array.from({ length: MAX_CONCURRENT }, () => deferred());
+    gates.forEach((gate, i) => fireAndForget(`block-${i}`, () => gate.promise));
+    await flush();
+
+    const ran: number[] = [];
+    // Two more than the queue holds; the oldest droppable entries give way.
+    for (let i = 0; i < 7; i++) {
+      fireAndForget(`telemetry-${i}`, async () => { ran.push(i); }, { droppable: true });
+    }
+
+    expect(backgroundTaskStats().queued).toBe(5);
+
+    gates.forEach((gate) => gate.resolve());
+    await drainPendingTasks(1000);
+
+    expect(ran).toHaveLength(5);
+    // The newest samples survive; the two oldest were shed.
+    expect(ran).toEqual([2, 3, 4, 5, 6]);
+  });
+
+  it('keeps usage-class work even past the queue bound', async () => {
+    const gates = Array.from({ length: MAX_CONCURRENT }, () => deferred());
+    gates.forEach((gate, i) => fireAndForget(`block-${i}`, () => gate.promise));
+    await flush();
+
+    const ran: number[] = [];
+    for (let i = 0; i < 12; i++) {
+      fireAndForget(`usage-${i}`, async () => { ran.push(i); });
+    }
+
+    gates.forEach((gate) => gate.resolve());
+    await drainPendingTasks(2000);
+
+    expect(ran).toHaveLength(12);
+  });
+
+  it('keeps draining when a task throws', async () => {
+    const ran = vi.fn();
+    fireAndForget('boom', async () => { throw new Error('background failure'); });
+    fireAndForget('after', async () => { ran(); });
+
+    await drainPendingTasks(1000);
+    expect(ran).toHaveBeenCalledTimes(1);
+    expect(pendingTaskCount()).toBe(0);
+  });
+});

--- a/src/__tests__/unit/guardrail-service.test.ts
+++ b/src/__tests__/unit/guardrail-service.test.ts
@@ -321,6 +321,26 @@ describe('evaluateGuardrail', () => {
     (getDatabase as ReturnType<typeof vi.fn>).mockResolvedValue(db);
   });
 
+  it('reads the guardrail config once across repeated evaluations', async () => {
+    db.findGuardrailByKey.mockResolvedValue(makeGuardrail({ enabled: false }));
+
+    const call = () => evaluateGuardrail({
+      tenantDbName: TENANT_DB,
+      tenantId: TENANT_ID,
+      projectId: PROJECT_ID,
+      guardrailKey: 'my-guardrail',
+      text: 'hello',
+    });
+
+    // A guarded model resolves its guardrail on the request path, and twice
+    // over when both an input and an output guardrail are configured.
+    await call();
+    await call();
+    await call();
+
+    expect(db.findGuardrailByKey).toHaveBeenCalledTimes(1);
+  });
+
   it('returns passed=true, disabled=true, and no findings when guardrail is disabled', async () => {
     db.findGuardrailByKey.mockResolvedValue(
       makeGuardrail({

--- a/src/__tests__/unit/pagination.test.ts
+++ b/src/__tests__/unit/pagination.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Unit tests — list pagination helpers
+ *
+ * The point of these is that an absent `limit` yields a bounded page rather
+ * than the whole collection, which is the behaviour the endpoints used to have.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  DEFAULT_PAGE_LIMIT,
+  MAX_PAGE_LIMIT,
+  overfetchLimit,
+  paginationMeta,
+  readPagination,
+  takePage,
+} from '@/lib/api/pagination';
+
+describe('readPagination', () => {
+  it('bounds a request that asks for no limit', () => {
+    expect(readPagination({})).toEqual({ limit: DEFAULT_PAGE_LIMIT, offset: 0 });
+    expect(readPagination(undefined)).toEqual({ limit: DEFAULT_PAGE_LIMIT, offset: 0 });
+  });
+
+  it('honours a caller-supplied window', () => {
+    expect(readPagination({ limit: '25', offset: '50' })).toEqual({ limit: 25, offset: 50 });
+  });
+
+  it('clamps above the ceiling', () => {
+    expect(readPagination({ limit: '100000' }).limit).toBe(MAX_PAGE_LIMIT);
+  });
+
+  it('ignores junk rather than returning everything', () => {
+    expect(readPagination({ limit: 'all' }).limit).toBe(DEFAULT_PAGE_LIMIT);
+    expect(readPagination({ limit: '-5' }).limit).toBe(DEFAULT_PAGE_LIMIT);
+    expect(readPagination({ limit: '0' }).limit).toBe(DEFAULT_PAGE_LIMIT);
+    expect(readPagination({ offset: '-5' }).offset).toBe(0);
+  });
+
+  it('accepts a per-endpoint default and ceiling', () => {
+    const page = readPagination({}, { limit: 10, maxLimit: 20 });
+    expect(page.limit).toBe(10);
+    expect(readPagination({ limit: '999' }, { maxLimit: 20 }).limit).toBe(20);
+  });
+
+  it('never lets a default exceed the ceiling', () => {
+    expect(readPagination({}, { limit: 900, maxLimit: 50 }).limit).toBe(50);
+  });
+});
+
+describe('takePage', () => {
+  const page = { limit: 3, offset: 0 };
+
+  it('asks for one row past the window', () => {
+    expect(overfetchLimit(page)).toBe(4);
+  });
+
+  it('reports another page and trims the extra row', () => {
+    const { items, hasMore } = takePage([1, 2, 3, 4], page);
+    expect(items).toEqual([1, 2, 3]);
+    expect(hasMore).toBe(true);
+  });
+
+  it('reports the last page unchanged', () => {
+    const { items, hasMore } = takePage([1, 2], page);
+    expect(items).toEqual([1, 2]);
+    expect(hasMore).toBe(false);
+  });
+
+  it('handles an exactly-full page', () => {
+    const { items, hasMore } = takePage([1, 2, 3], page);
+    expect(items).toEqual([1, 2, 3]);
+    expect(hasMore).toBe(false);
+  });
+});
+
+describe('paginationMeta', () => {
+  it('derives hasMore from a known total', () => {
+    expect(paginationMeta({ limit: 10, offset: 0 }, { total: 25 }))
+      .toEqual({ limit: 10, offset: 0, total: 25, hasMore: true });
+    expect(paginationMeta({ limit: 10, offset: 20 }, { total: 25 }).hasMore).toBe(false);
+  });
+
+  it('omits total when the caller only knows hasMore', () => {
+    const meta = paginationMeta({ limit: 10, offset: 0 }, { hasMore: true });
+    expect(meta.hasMore).toBe(true);
+    expect(meta.total).toBeUndefined();
+  });
+});

--- a/src/__tests__/unit/provider-record-cache.test.ts
+++ b/src/__tests__/unit/provider-record-cache.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Unit tests — provider record cache
+ *
+ * The SDK client behind a provider was pooled, but the row describing it was
+ * re-read on every call: one Knowledge Engine query (embedding → vector store →
+ * reranker) spent three uncached reads before doing any work.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createMockDb } from '../helpers/db.mock';
+
+const cacheStore = new Map<string, unknown>();
+const config = { providerRuntime: { cacheTtlSeconds: 300, recordCacheTtlSeconds: 60 } };
+
+vi.mock('@/lib/database', () => ({ getDatabase: vi.fn() }));
+vi.mock('@/lib/core/config', () => ({ getConfig: () => config }));
+vi.mock('@/lib/core/cache', () => ({
+  getCache: async () => ({
+    get: async (key: string) => cacheStore.get(key),
+    set: async (key: string, value: unknown) => { cacheStore.set(key, value); },
+    del: async (key: string) => { cacheStore.delete(key); },
+  }),
+}));
+vi.mock('@/lib/core/logger', () => ({
+  createLogger: () => ({ debug: () => {}, info: () => {}, warn: () => {}, error: () => {} }),
+}));
+vi.mock('@/lib/utils/crypto', () => ({
+  decryptObject: (value: string) => JSON.parse(value),
+  encryptObject: (value: unknown) => JSON.stringify(value),
+}));
+
+import { getDatabase } from '@/lib/database';
+import type { IProviderRecord } from '@/lib/database';
+import {
+  invalidateProviderRecordCache,
+  loadProviderRuntimeData,
+} from '@/lib/services/providers/providerService';
+
+const TENANT_DB = 'tenant_acme';
+const LOOKUP = { tenantId: 'tenant-1', key: 'openai-main', projectId: 'proj-1' };
+
+function providerRow(overrides: Record<string, unknown> = {}): IProviderRecord {
+  return {
+    _id: 'provider-1',
+    tenantId: 'tenant-1',
+    key: 'openai-main',
+    driver: 'openai',
+    type: 'model',
+    projectIds: ['proj-1'],
+    credentialsEnc: JSON.stringify({ apiKey: 'sk-live' }),
+    settings: {},
+    label: 'OpenAI (main)',
+    status: 'active',
+    createdBy: 'user-1',
+    ...overrides,
+  } as IProviderRecord;
+}
+
+describe('provider record cache', () => {
+  let db: ReturnType<typeof createMockDb>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    cacheStore.clear();
+    config.providerRuntime.recordCacheTtlSeconds = 60;
+    db = createMockDb();
+    db.findProviderByKey.mockResolvedValue(providerRow());
+    (getDatabase as ReturnType<typeof vi.fn>).mockResolvedValue(db);
+  });
+
+  it('reads the row once across repeated calls', async () => {
+    await loadProviderRuntimeData(TENANT_DB, LOOKUP);
+    await loadProviderRuntimeData(TENANT_DB, LOOKUP);
+    await loadProviderRuntimeData(TENANT_DB, LOOKUP);
+
+    expect(db.findProviderByKey).toHaveBeenCalledTimes(1);
+  });
+
+  it('caches the sealed row, not the decrypted credentials', async () => {
+    const { credentials } = await loadProviderRuntimeData<{ apiKey: string }>(TENANT_DB, LOOKUP);
+    expect(credentials.apiKey).toBe('sk-live');
+
+    // What lands in the cache is the row as stored: the sealed blob, and no
+    // decrypted `credentials` field alongside it. Decryption stays per call.
+    const cached = [...cacheStore.values()][0] as Record<string, unknown>;
+    expect(cached).toHaveProperty('credentialsEnc');
+    expect(cached).not.toHaveProperty('credentials');
+  });
+
+  it('keeps separate entries per project', async () => {
+    await loadProviderRuntimeData(TENANT_DB, LOOKUP);
+    await loadProviderRuntimeData(TENANT_DB, { ...LOOKUP, projectId: 'proj-2' });
+
+    expect(db.findProviderByKey).toHaveBeenCalledTimes(2);
+  });
+
+  it('goes back to the database once the entry is invalidated', async () => {
+    await loadProviderRuntimeData(TENANT_DB, LOOKUP);
+    await invalidateProviderRecordCache(TENANT_DB, providerRow());
+    await loadProviderRuntimeData(TENANT_DB, LOOKUP);
+
+    expect(db.findProviderByKey).toHaveBeenCalledTimes(2);
+  });
+
+  it('invalidates every project the provider is assigned to', async () => {
+    db.findProviderByKey.mockResolvedValue(providerRow({ projectIds: ['proj-1', 'proj-2'] }));
+    await loadProviderRuntimeData(TENANT_DB, LOOKUP);
+    await loadProviderRuntimeData(TENANT_DB, { ...LOOKUP, projectId: 'proj-2' });
+    expect(db.findProviderByKey).toHaveBeenCalledTimes(2);
+
+    await invalidateProviderRecordCache(
+      TENANT_DB,
+      providerRow({ projectIds: ['proj-1', 'proj-2'] }),
+    );
+
+    await loadProviderRuntimeData(TENANT_DB, LOOKUP);
+    await loadProviderRuntimeData(TENANT_DB, { ...LOOKUP, projectId: 'proj-2' });
+    expect(db.findProviderByKey).toHaveBeenCalledTimes(4);
+  });
+
+  it('reads through on every call when the cache is disabled', async () => {
+    config.providerRuntime.recordCacheTtlSeconds = 0;
+
+    await loadProviderRuntimeData(TENANT_DB, LOOKUP);
+    await loadProviderRuntimeData(TENANT_DB, LOOKUP);
+
+    expect(db.findProviderByKey).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/__tests__/unit/quota-policy-cache.test.ts
+++ b/src/__tests__/unit/quota-policy-cache.test.ts
@@ -47,7 +47,7 @@ function makeContext(overrides: Partial<QuotaContext> = {}): QuotaContext {
     tenantDbName: DB_NAME,
     tenantId: TENANT_ID,
     projectId: PROJECT_ID,
-    licenseType: 'enterprise',
+    licenseType: 'PROFESSIONAL',
     domain: 'llm',
     ...overrides,
   } as QuotaContext;

--- a/src/__tests__/unit/rag-service.test.ts
+++ b/src/__tests__/unit/rag-service.test.ts
@@ -1273,7 +1273,39 @@ describe('RAG Service', () => {
         expect(db.findRagDocumentById).toHaveBeenCalledTimes(1);
       });
 
-      it('falls back to the chunk when the source is gone', async () => {
+      it('caps how many document sources one query expands', async () => {
+      const matches = Array.from({ length: 30 }, (_, i) => ({
+        id: `my-rag:ragdoc-${i}:0`,
+        score: 0.9,
+        metadata: { _documentId: `ragdoc-${i}` },
+      }));
+      (queryVectorIndex as ReturnType<typeof vi.fn>).mockResolvedValue({ matches });
+      db.findRagChunksByVectorIds.mockResolvedValue(
+        matches.map((m, i) => ({
+          vectorId: m.id,
+          content: 'Delta epsilon zeta.',
+          charStart: 18,
+          charEnd: 37,
+          tenantId: TENANT_ID,
+          ragModuleKey: 'my-rag',
+          documentId: `ragdoc-${i}`,
+          chunkIndex: 0,
+        })),
+      );
+      db.findRagDocumentById.mockImplementation(async (id: string) => ({
+        ...mockDocument,
+        _id: id,
+        sourceText: source,
+      }));
+
+      await queryRag(DB_NAME, TENANT_ID, PROJECT_ID, { ...queryReq, topK: 30 });
+
+      // 25 is the default ceiling; the remaining matches keep their chunk text
+      // rather than pulling five more whole documents into the request.
+      expect(db.findRagDocumentById).toHaveBeenCalledTimes(25);
+    });
+
+    it('falls back to the chunk when the source is gone', async () => {
         db.findRagDocumentById.mockResolvedValue({ ...mockDocument });
 
         const result = await queryRag(DB_NAME, TENANT_ID, PROJECT_ID, queryReq);

--- a/src/__tests__/unit/rate-limit-batching.test.ts
+++ b/src/__tests__/unit/rate-limit-batching.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Unit tests — batched rate-limit counters
+ *
+ * A guarded request touches a counter per metric per window. Issued separately
+ * those are up to 25 concurrent round trips, enough for one caller to hold
+ * every connection in the pool while its own limits are checked.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createMockDb } from '../helpers/db.mock';
+
+const cacheStore = new Map<string, unknown>();
+const config = {
+  quota: { policyCacheTtlSeconds: 0 },
+  rateLimit: { provider: 'mongodb' as 'mongodb' | 'memory' | 'redis' },
+};
+
+vi.mock('@/lib/database', () => ({ getDatabase: vi.fn() }));
+vi.mock('@/lib/core/config', () => ({ getConfig: () => config }));
+vi.mock('@/lib/core/cache', () => ({
+  getCache: async () => ({
+    name: 'memory',
+    get: async (key: string) => cacheStore.get(key),
+    set: async (key: string, value: unknown) => { cacheStore.set(key, value); },
+    del: async (key: string) => { cacheStore.delete(key); },
+  }),
+}));
+vi.mock('@/lib/core/logger', () => ({
+  createLogger: () => ({ debug: () => {}, info: () => {}, warn: () => {}, error: () => {} }),
+}));
+vi.mock('@/lib/license/license-manager', () => ({
+  LicenseManager: {
+    getQuotaLimitsForTenant: () => ({
+      quotas: {},
+      rateLimit: {
+        requests: { perSecond: 5, perMinute: 100, perHour: 1000 },
+        tokens: { perMinute: 10_000 },
+      },
+    }),
+  },
+}));
+
+import { getDatabase } from '@/lib/database';
+import type { ITenant } from '@/lib/database';
+import { checkRateLimit } from '@/lib/quota/quotaGuard';
+import type { QuotaContext } from '@/lib/quota/quotaGuard';
+
+const CTX = {
+  tenantDbName: 'tenant_acme',
+  tenantId: 'tenant-1',
+  projectId: 'proj-1',
+  licenseType: 'PROFESSIONAL',
+  domain: 'llm',
+  userId: 'user-1',
+} as QuotaContext;
+
+describe('checkRateLimit batching', () => {
+  let db: ReturnType<typeof createMockDb>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    cacheStore.clear();
+    config.rateLimit.provider = 'mongodb';
+    db = createMockDb();
+    db.findTenantById.mockResolvedValue({ _id: 'tenant-1' } as unknown as ITenant);
+    db.listQuotaPolicies.mockResolvedValue([]);
+    (getDatabase as ReturnType<typeof vi.fn>).mockResolvedValue(db);
+  });
+
+  it('issues one batch instead of a call per window', async () => {
+    db.incrementRateLimits.mockImplementation(
+      async (entries: Array<{ amount: number }>) =>
+        entries.map(() => ({ count: 1, resetAt: new Date() })),
+    );
+
+    const result = await checkRateLimit(CTX, { requests: 1, tokens: 42 });
+
+    expect(result.allowed).toBe(true);
+    expect(db.incrementRateLimits).toHaveBeenCalledTimes(1);
+    // Three request windows carry a limit, plus one token window.
+    expect(db.incrementRateLimits.mock.calls[0][0]).toHaveLength(4);
+  });
+
+  it('skips windows with no configured limit and zero-cost metrics', async () => {
+    db.incrementRateLimits.mockImplementation(
+      async (entries: Array<unknown>) => entries.map(() => ({ count: 1, resetAt: new Date() })),
+    );
+
+    await checkRateLimit(CTX, { requests: 1, tokens: 0 });
+
+    const entries = db.incrementRateLimits.mock.calls[0][0] as Array<{ key: string }>;
+    expect(entries).toHaveLength(3);
+    expect(entries.every((e) => e.key.includes(':requests:'))).toBe(true);
+  });
+
+  it('rejects when any window is over its limit', async () => {
+    db.incrementRateLimits.mockImplementation(
+      async (entries: Array<{ key: string }>) =>
+        entries.map((entry) => ({
+          count: entry.key.includes('perSecond') ? 6 : 1,
+          resetAt: new Date(),
+        })),
+    );
+
+    const result = await checkRateLimit(CTX, { requests: 1 });
+
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toMatch(/requests perSecond \(6\/5\)/);
+  });
+
+  it('fails closed when the batch itself fails', async () => {
+    db.incrementRateLimits.mockRejectedValue(new Error('pool exhausted'));
+
+    const result = await checkRateLimit(CTX, { requests: 1 });
+
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toBe('Rate limit enforcement unavailable');
+  });
+
+  it('does no work at all when no window applies', async () => {
+    await checkRateLimit(CTX, { vectors: 0, files: 0 });
+    expect(db.incrementRateLimits).not.toHaveBeenCalled();
+  });
+
+  it('routes to the cache provider when one is configured', async () => {
+    config.rateLimit.provider = 'memory';
+    const result = await checkRateLimit(CTX, { requests: 1 });
+
+    // The mocked cache has no incrementCounters, so the batch throws and the
+    // guard fails closed — proving it never reached the database path.
+    expect(db.incrementRateLimits).not.toHaveBeenCalled();
+    expect(result.allowed).toBe(false);
+  });
+});

--- a/src/lib/api/pagination.ts
+++ b/src/lib/api/pagination.ts
@@ -1,0 +1,100 @@
+/**
+ * Query-string pagination for list endpoints.
+ *
+ * Several collections grow with usage — a Knowledge Engine module's documents,
+ * a tenant's batches — and returning them whole meant one request loading an
+ * entire collection into memory and onto the wire. Every list endpoint that
+ * can grow reads its window through here so the parameters, the ceiling and
+ * the reported shape stay identical across the API.
+ */
+
+/** Rows returned when the caller does not ask for a specific page. */
+export const DEFAULT_PAGE_LIMIT = 100;
+
+/** Hard ceiling on `limit`, whatever the caller asks for. */
+export const MAX_PAGE_LIMIT = 500;
+
+export interface PaginationParams {
+  limit: number;
+  offset: number;
+}
+
+export interface PaginationMeta extends PaginationParams {
+  /**
+   * Total rows matching the query, ignoring the window. Present only where the
+   * collection has a count that filters identically to its list — a total
+   * derived from different filters is worse than no total at all.
+   */
+  total?: number;
+  /** Whether another page follows this one. */
+  hasMore: boolean;
+}
+
+function toPositiveInt(value: unknown): number | undefined {
+  if (typeof value !== 'string' && typeof value !== 'number') return undefined;
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) return undefined;
+  const floored = Math.floor(parsed);
+  return floored >= 0 ? floored : undefined;
+}
+
+/**
+ * Read `limit` and `offset` from a query object, clamped to sane bounds.
+ *
+ * An absent or unparseable `limit` yields DEFAULT_PAGE_LIMIT rather than "all
+ * rows": an unbounded default is the behaviour this exists to remove.
+ */
+export function readPagination(
+  query: unknown,
+  defaults: { limit?: number; maxLimit?: number } = {},
+): PaginationParams {
+  const source = (query ?? {}) as Record<string, unknown>;
+  const maxLimit = defaults.maxLimit ?? MAX_PAGE_LIMIT;
+  const fallback = Math.min(defaults.limit ?? DEFAULT_PAGE_LIMIT, maxLimit);
+
+  const requested = toPositiveInt(source.limit);
+  const limit = requested === undefined || requested === 0
+    ? fallback
+    : Math.min(requested, maxLimit);
+
+  return { limit, offset: toPositiveInt(source.offset) ?? 0 };
+}
+
+/**
+ * Build the metadata block returned alongside a page of rows.
+ *
+ * Pass `total` when the collection has a matching count query; otherwise pass
+ * `hasMore` from `takePage`, which learns it without a second query.
+ */
+export function paginationMeta(
+  params: PaginationParams,
+  source: { total: number } | { hasMore: boolean },
+): PaginationMeta {
+  if ('total' in source) {
+    return {
+      ...params,
+      total: source.total,
+      hasMore: params.offset + params.limit < source.total,
+    };
+  }
+  return { ...params, hasMore: source.hasMore };
+}
+
+/**
+ * Read one row past the window to learn whether another page exists.
+ *
+ * Cheaper than a companion `COUNT(*)`, and immune to the filters of a count
+ * query drifting away from those of the list it describes.
+ */
+export function overfetchLimit(params: PaginationParams): number {
+  return params.limit + 1;
+}
+
+/** Trim an over-fetched result set back to the page, reporting what it saw. */
+export function takePage<T>(rows: T[], params: PaginationParams): {
+  items: T[];
+  hasMore: boolean;
+} {
+  const hasMore = rows.length > params.limit;
+  return { items: hasMore ? rows.slice(0, params.limit) : rows, hasMore };
+}

--- a/src/lib/core/asyncTask.ts
+++ b/src/lib/core/asyncTask.ts
@@ -20,8 +20,94 @@ import { captureRequestContext, runWithRequestContext } from './requestContext';
 
 const log = createLogger('async-task');
 
-/** Track pending promises so we can drain on shutdown. */
-const pending = new Set<Promise<void>>();
+/**
+ * Background work used to be started the moment it was handed over: every
+ * request's usage write, audit row and trace payload became a live promise in
+ * an unbounded set. The response returned fast, but under a burst the
+ * background writes grew with the request rate, competed with foreground
+ * queries for the same small connection pool, and held their payloads —
+ * trace bodies run to megabytes — in heap until they drained.
+ *
+ * So the work is queued and executed by a bounded number of runners.
+ */
+
+/** Background tasks executing at once. */
+const MAX_IN_FLIGHT = Math.max(
+  1,
+  Number(process.env.ASYNC_TASK_MAX_CONCURRENT ?? 32) || 32,
+);
+
+/**
+ * Queue depth for droppable work.
+ *
+ * Only droppable tasks are shed. Usage, billing and audit writes are always
+ * accepted: losing them silently corrupts records the product bills and
+ * answers audits from, which is worse than the memory they cost.
+ */
+const MAX_QUEUED_DROPPABLE = Math.max(
+  1,
+  Number(process.env.ASYNC_TASK_MAX_QUEUED ?? 1000) || 1000,
+);
+
+export interface FireAndForgetOptions {
+  /**
+   * Shed this task when the queue is saturated. Set it on telemetry whose loss
+   * costs visibility rather than correctness — trace payloads, last-used
+   * timestamps. Never on usage, billing or audit writes.
+   */
+  droppable?: boolean;
+}
+
+interface QueuedTask {
+  label: string;
+  run: () => Promise<void>;
+  droppable: boolean;
+}
+
+const queue: QueuedTask[] = [];
+const inFlight = new Set<Promise<void>>();
+
+let droppedSinceLastReport = 0;
+let lastDropReportAt = 0;
+
+function noteDropped(label: string): void {
+  droppedSinceLastReport += 1;
+  const now = Date.now();
+  // One line per 10s rather than one per drop: the whole point of shedding is
+  // that the process is already under pressure.
+  if (now - lastDropReportAt >= 10_000) {
+    log.warn('Background task queue saturated; dropping telemetry', {
+      dropped: droppedSinceLastReport,
+      lastLabel: label,
+      inFlight: inFlight.size,
+      queued: queue.length,
+    });
+    droppedSinceLastReport = 0;
+    lastDropReportAt = now;
+  }
+}
+
+function pump(): void {
+  while (inFlight.size < MAX_IN_FLIGHT && queue.length > 0) {
+    const next = queue.shift();
+    if (!next) break;
+
+    const task: Promise<void> = next
+      .run()
+      .catch((error) => {
+        log.error(`Async task "${next.label}" failed`, {
+          error: error instanceof Error ? error.message : String(error),
+          stack: error instanceof Error ? error.stack : undefined,
+        });
+      })
+      .finally(() => {
+        inFlight.delete(task);
+        pump();
+      });
+
+    inFlight.add(task);
+  }
+}
 
 /**
  * Schedule a non-critical async operation that should not block the caller.
@@ -32,23 +118,40 @@ const pending = new Set<Promise<void>>();
  * @param label  Short descriptive label for logging (e.g. 'log-usage')
  * @param fn     Async function to execute
  */
-export function fireAndForget(label: string, fn: () => Promise<void>): void {
+export function fireAndForget(
+  label: string,
+  fn: () => Promise<void>,
+  options: FireAndForgetOptions = {},
+): void {
   // Reopen the caller's request context around the task so attribution
   // (userId/apiTokenId/source) survives even if execution outlives the
   // request's AsyncLocalStorage scope.
   const snapshot = captureRequestContext();
-  const task = (snapshot ? runWithRequestContext(snapshot, fn) : fn())
-    .catch((error) => {
-      log.error(`Async task "${label}" failed`, {
-        error: error instanceof Error ? error.message : String(error),
-        stack: error instanceof Error ? error.stack : undefined,
-      });
-    })
-    .finally(() => {
-      pending.delete(task);
-    });
+  const droppable = options.droppable === true;
+  const task: QueuedTask = {
+    label,
+    droppable,
+    run: () => (snapshot ? runWithRequestContext(snapshot, fn) : fn()),
+  };
 
-  pending.add(task);
+  if (droppable) {
+    const queuedDroppable = queue.reduce((n, t) => (t.droppable ? n + 1 : n), 0);
+    if (queuedDroppable >= MAX_QUEUED_DROPPABLE) {
+      // Shed the oldest queued telemetry rather than the newest: the fresher
+      // sample is the more useful one to keep.
+      const oldest = queue.findIndex((t) => t.droppable);
+      if (oldest >= 0) {
+        const [victim] = queue.splice(oldest, 1);
+        noteDropped(victim.label);
+      } else {
+        noteDropped(label);
+        return;
+      }
+    }
+  }
+
+  queue.push(task);
+  pump();
 }
 
 /**
@@ -58,27 +161,45 @@ export function fireAndForget(label: string, fn: () => Promise<void>): void {
  * @param timeoutMs  Maximum time to wait (default: 5000ms)
  */
 export async function drainPendingTasks(timeoutMs = 5000): Promise<void> {
-  if (pending.size === 0) return;
+  if (pendingTaskCount() === 0) return;
 
-  log.info(`Draining ${pending.size} pending async task(s)…`);
+  log.info(`Draining ${pendingTaskCount()} pending async task(s)…`);
 
+  let timedOut = false;
   const deadline = new Promise<void>((resolve) => {
     const timer = setTimeout(() => {
-      log.warn(`Drain timeout (${timeoutMs}ms) — ${pending.size} task(s) still pending`);
+      timedOut = true;
+      log.warn(`Drain timeout (${timeoutMs}ms) — ${pendingTaskCount()} task(s) still pending`);
       resolve();
     }, timeoutMs);
     timer.unref();
   });
 
-  await Promise.race([
-    Promise.allSettled(Array.from(pending)),
-    deadline,
-  ]);
+  // The queue drains in waves of MAX_IN_FLIGHT, so awaiting the current wave
+  // once is not enough — keep going until both the queue and the runners are
+  // empty, or the deadline fires.
+  while (!timedOut && pendingTaskCount() > 0) {
+    pump();
+    if (inFlight.size === 0) break;
+    await Promise.race([
+      Promise.allSettled(Array.from(inFlight)),
+      deadline,
+    ]);
+  }
 }
 
 /**
  * Current count of pending tasks (for monitoring / health).
  */
 export function pendingTaskCount(): number {
-  return pending.size;
+  return queue.length + inFlight.size;
+}
+
+/** Split view of the backlog, for health endpoints and load debugging. */
+export function backgroundTaskStats(): {
+  queued: number;
+  inFlight: number;
+  maxInFlight: number;
+} {
+  return { queued: queue.length, inFlight: inFlight.size, maxInFlight: MAX_IN_FLIGHT };
 }

--- a/src/lib/core/cache/cacheProvider.interface.ts
+++ b/src/lib/core/cache/cacheProvider.interface.ts
@@ -36,6 +36,17 @@ export interface CacheProvider {
   ): Promise<{ count: number; resetAt: Date }>;
 
   /**
+   * Increment several counters together, returning one result per entry in
+   * input order.
+   *
+   * A guarded request touches a counter per metric per window — up to 25 — and
+   * issuing them separately turns one request into 25 concurrent round trips.
+   */
+  incrementCounters(
+    entries: Array<{ key: string; ttlSeconds: number; amount: number }>,
+  ): Promise<Array<{ count: number; resetAt: Date }>>;
+
+  /**
    * Acquire a best-effort lock with TTL. Returns an owner token when acquired,
    * or undefined when another owner already holds the lock.
    */

--- a/src/lib/core/cache/memoryCacheProvider.ts
+++ b/src/lib/core/cache/memoryCacheProvider.ts
@@ -93,6 +93,18 @@ export class MemoryCacheProvider implements CacheProvider {
     return { count: existing.count, resetAt: new Date(existing.expiresAt) };
   }
 
+  async incrementCounters(
+    entries: Array<{ key: string; ttlSeconds: number; amount: number }>,
+  ): Promise<Array<{ count: number; resetAt: Date }>> {
+    // In-process map writes — there is no round trip to batch, so the loop is
+    // the batch. It exists so callers can use one shape for every provider.
+    const results: Array<{ count: number; resetAt: Date }> = [];
+    for (const { key, ttlSeconds, amount } of entries) {
+      results.push(await this.incrementCounter(key, ttlSeconds, amount));
+    }
+    return results;
+  }
+
   async acquireLock(key: string, ttlSeconds: number): Promise<string | undefined> {
     const now = Date.now();
     const existing = this.locks.get(key);

--- a/src/lib/core/cache/nullCacheProvider.ts
+++ b/src/lib/core/cache/nullCacheProvider.ts
@@ -24,6 +24,13 @@ export class NullCacheProvider implements CacheProvider {
     const incrementBy = Math.max(0, Math.ceil(amount));
     return { count: incrementBy, resetAt: new Date(Date.now() + ttl * 1000) };
   }
+  async incrementCounters(
+    entries: Array<{ key: string; ttlSeconds: number; amount: number }>,
+  ): Promise<Array<{ count: number; resetAt: Date }>> {
+    return Promise.all(
+      entries.map((entry) => this.incrementCounter(entry.key, entry.ttlSeconds, entry.amount)),
+    );
+  }
   async acquireLock(): Promise<string | undefined> { return randomUUID(); }
   async releaseLock(): Promise<void> {}
   async destroy(): Promise<void> {}

--- a/src/lib/core/cache/redisCacheProvider.ts
+++ b/src/lib/core/cache/redisCacheProvider.ts
@@ -150,6 +150,45 @@ export class RedisCacheProvider implements CacheProvider {
     };
   }
 
+  async incrementCounters(
+    entries: Array<{ key: string; ttlSeconds: number; amount: number }>,
+  ): Promise<Array<{ count: number; resetAt: Date }>> {
+    if (entries.length === 0) return [];
+    if (entries.length === 1) {
+      const only = entries[0];
+      return [await this.incrementCounter(only.key, only.ttlSeconds, only.amount)];
+    }
+
+    // One pipeline: the same Lua script per counter, but a single write and a
+    // single read on the socket instead of one per counter.
+    const pipeline = this.ensureClient().pipeline();
+    for (const { key, ttlSeconds, amount } of entries) {
+      pipeline.eval(
+        INCREMENT_COUNTER_SCRIPT,
+        1,
+        key,
+        String(Math.max(0, Math.ceil(amount))),
+        String(Math.max(1, Math.ceil(ttlSeconds))),
+      );
+    }
+
+    const replies = await pipeline.exec();
+    if (!replies || replies.length !== entries.length) {
+      throw new Error('Unexpected Redis counter pipeline response');
+    }
+
+    const now = Date.now();
+    return replies.map(([error, result], index) => {
+      if (error) throw error;
+      if (!Array.isArray(result) || result.length < 2) {
+        throw new Error(`Unexpected Redis counter response for "${entries[index].key}"`);
+      }
+      const count = Number(result[0]);
+      const remainingTtl = Number(result[1]);
+      return { count, resetAt: new Date(now + Math.max(1, remainingTtl) * 1000) };
+    });
+  }
+
   async releaseLock(key: string, token: string): Promise<void> {
     await this.ensureClient().eval(RELEASE_LOCK_SCRIPT, 1, key, token);
   }

--- a/src/lib/core/concurrency.ts
+++ b/src/lib/core/concurrency.ts
@@ -1,0 +1,33 @@
+/**
+ * Bounded concurrency helpers.
+ *
+ * Fan-out with `Promise.all` over an unbounded list is the shape behind most of
+ * this codebase's load incidents: it looks parallel and cheap until the list is
+ * user-sized, at which point it opens as many sockets, DB connections or
+ * provider calls as the input happens to be long.
+ */
+
+/**
+ * Run `fn` over `items` with at most `limit` in flight, preserving input order.
+ *
+ * Rejections propagate like `Promise.all`: the first failure rejects, and the
+ * workers already running finish their current item.
+ */
+export async function mapLimit<T, R>(
+  items: T[],
+  limit: number,
+  fn: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  const results = new Array<R>(items.length);
+  const workerCount = Math.max(1, Math.min(limit, items.length));
+  let cursor = 0;
+
+  const workers = Array.from({ length: workerCount }, async () => {
+    for (let i = cursor++; i < items.length; i = cursor++) {
+      results[i] = await fn(items[i], i);
+    }
+  });
+
+  await Promise.all(workers);
+  return results;
+}

--- a/src/lib/core/config.ts
+++ b/src/lib/core/config.ts
@@ -144,6 +144,11 @@ export interface AppConfig {
     policyCacheTtlSeconds: number;
   };
 
+  guardrail: {
+    /** TTL for a cached guardrail config. 0 disables the cache. */
+    configCacheTtlSeconds: number;
+  };
+
   logging: {
     level: 'error' | 'warn' | 'info' | 'debug';
     format: 'json' | 'pretty';
@@ -175,6 +180,11 @@ export interface AppConfig {
 
   providerRuntime: {
     cacheTtlSeconds: number;
+    /**
+     * TTL for the cached provider row behind a runtime. 0 disables the cache
+     * and every provider call re-reads the row from the database.
+     */
+    recordCacheTtlSeconds: number;
     /**
      * How long an evicted runtime is held before its connections are closed.
      * Covers requests still holding a reference. 0 closes immediately.
@@ -418,6 +428,10 @@ function buildConfig(source: ConfigSource): AppConfig {
       policyCacheTtlSeconds: int(source, 'QUOTA_POLICY_CACHE_TTL_SECONDS', 30),
     },
 
+    guardrail: {
+      configCacheTtlSeconds: int(source, 'GUARDRAIL_CONFIG_CACHE_TTL_SECONDS', 30),
+    },
+
     logging: {
       level: oneOf(source, 'LOG_LEVEL', ['error', 'warn', 'info', 'debug'], nodeEnv === 'production' ? 'info' : 'debug'),
       format: oneOf(source, 'LOG_FORMAT', ['json', 'pretty'], nodeEnv === 'production' ? 'json' : 'pretty'),
@@ -451,6 +465,7 @@ function buildConfig(source: ConfigSource): AppConfig {
 
     providerRuntime: {
       cacheTtlSeconds: int(source, 'PROVIDER_RUNTIME_CACHE_TTL_SECONDS', 300),
+      recordCacheTtlSeconds: int(source, 'PROVIDER_RECORD_CACHE_TTL_SECONDS', 60),
       disposeGraceSeconds: int(source, 'PROVIDER_RUNTIME_DISPOSE_GRACE_SECONDS', 300),
     },
 

--- a/src/lib/database/mongodb/agent.mixin.ts
+++ b/src/lib/database/mongodb/agent.mixin.ts
@@ -75,6 +75,9 @@ export function AgentMixin<TBase extends Constructor<MongoDBProviderBase>>(Base:
       projectId?: string;
       status?: AgentStatus;
       search?: string;
+      /** Page window. Omitted means every row, which is what unbounded lists cost. */
+      limit?: number;
+      offset?: number;
     }): Promise<IAgent[]> {
       const db = this.getTenantDb();
       const filter: Record<string, unknown> = {};
@@ -88,11 +91,13 @@ export function AgentMixin<TBase extends Constructor<MongoDBProviderBase>>(Base:
           { description: { $regex: escaped, $options: 'i' } },
         ];
       }
-      const docs = await db
+      const cursor = db
         .collection(COLLECTIONS.agents)
         .find(filter)
-        .sort({ createdAt: -1 })
-        .toArray();
+        .sort({ createdAt: -1 });
+      if (filters?.offset && filters.offset > 0) cursor.skip(filters.offset);
+      if (filters?.limit && filters.limit > 0) cursor.limit(filters.limit);
+      const docs = await cursor.toArray();
       return docs.map((d) => ({ ...d, _id: d._id?.toString() })) as unknown as IAgent[];
     }
 

--- a/src/lib/database/mongodb/model.mixin.ts
+++ b/src/lib/database/mongodb/model.mixin.ts
@@ -135,6 +135,9 @@ export function ModelMixin<TBase extends Constructor<MongoDBProviderBase>>(Base:
       provider?: ModelProviderType;
       providerKey?: string;
       providerDriver?: string;
+      /** Page window. Omitted means every row, which is what unbounded lists cost. */
+      limit?: number;
+      offset?: number;
     }): Promise<IModel[]> {
       const db = this.getTenantDb();
       const query: Record<string, unknown> = {};
@@ -159,11 +162,13 @@ export function ModelMixin<TBase extends Constructor<MongoDBProviderBase>>(Base:
         query.providerDriver = filters.providerDriver;
       }
 
-      const models = await db
+      const cursor = db
         .collection<IModel>(COLLECTIONS.models)
         .find(query)
-        .sort({ createdAt: -1 })
-        .toArray();
+        .sort({ createdAt: -1 });
+      if (filters?.offset && filters.offset > 0) cursor.skip(filters.offset);
+      if (filters?.limit && filters.limit > 0) cursor.limit(filters.limit);
+      const models = await cursor.toArray();
 
       return models.map((model) => ({
         ...model,

--- a/src/lib/database/mongodb/prompt.mixin.ts
+++ b/src/lib/database/mongodb/prompt.mixin.ts
@@ -111,6 +111,9 @@ export function PromptMixin<TBase extends Constructor<MongoDBProviderBase>>(Base
     async listPrompts(filters?: {
       projectId?: string;
       search?: string;
+      /** Page window. Omitted means every row, which is what unbounded lists cost. */
+      limit?: number;
+      offset?: number;
     }): Promise<IPrompt[]> {
       const db = this.getTenantDb();
       const query: Filter<IPrompt> = {};
@@ -127,11 +130,13 @@ export function PromptMixin<TBase extends Constructor<MongoDBProviderBase>>(Base
         }
       }
 
-      const prompts = await db
+      const cursor = db
         .collection<IPrompt>(COLLECTIONS.prompts)
         .find(query)
-        .sort({ updatedAt: -1, createdAt: -1 })
-        .toArray();
+        .sort({ updatedAt: -1, createdAt: -1 });
+      if (filters?.offset && filters.offset > 0) cursor.skip(filters.offset);
+      if (filters?.limit && filters.limit > 0) cursor.limit(filters.limit);
+      const prompts = await cursor.toArray();
 
       return prompts.map((prompt) => ({
         ...prompt,

--- a/src/lib/database/mongodb/provider-record.mixin.ts
+++ b/src/lib/database/mongodb/provider-record.mixin.ts
@@ -271,5 +271,82 @@ export function ProviderRecordMixin<TBase extends Constructor<MongoDBProviderBas
         resetAt: result.resetAt,
       };
     }
+
+    async incrementRateLimits(
+      entries: Array<{ key: string; windowSeconds: number; amount: number }>,
+    ): Promise<Array<{ count: number; resetAt: Date }>> {
+      if (entries.length === 0) return [];
+      if (entries.length === 1) {
+        const only = entries[0];
+        return [await this.incrementRateLimit(only.key, only.windowSeconds, only.amount)];
+      }
+
+      type RateLimitRecord = {
+        _id: string;
+        count: number;
+        resetAt: Date;
+        isExpired?: boolean;
+      };
+
+      const db = this.getTenantDb();
+      const now = new Date();
+      const collection = db.collection<RateLimitRecord>(COLLECTIONS.rateLimits);
+
+      // Same check-and-set pipeline as the single-key path, issued as one
+      // bulkWrite so N counters cost one round trip instead of N.
+      await collection.bulkWrite(
+        entries.map(({ key, windowSeconds, amount }) => {
+          const resetAt = new Date(now.getTime() + windowSeconds * 1000);
+          return {
+            updateOne: {
+              filter: { _id: key } as Filter<RateLimitRecord>,
+              update: [
+                { $set: { isExpired: { $lt: ['$resetAt', now] } } },
+                {
+                  $set: {
+                    count: {
+                      $cond: {
+                        if: { $or: [{ $eq: ['$isExpired', true] }, { $not: ['$resetAt'] }] },
+                        then: amount,
+                        else: { $add: ['$count', amount] },
+                      },
+                    },
+                    resetAt: {
+                      $cond: {
+                        if: { $or: [{ $eq: ['$isExpired', true] }, { $not: ['$resetAt'] }] },
+                        then: resetAt,
+                        else: '$resetAt',
+                      },
+                    },
+                  },
+                },
+                { $unset: 'isExpired' },
+              ],
+              upsert: true,
+            },
+          };
+        }),
+        { ordered: false },
+      );
+
+      // Read the post-increment counts back in one query. A concurrent request
+      // may have incremented further in between, which can only report a count
+      // at or above our own — the safe direction for a limit check.
+      const keys = entries.map((e) => e.key);
+      const rows = await collection
+        .find({ _id: { $in: keys } } as Filter<RateLimitRecord>)
+        .toArray();
+      const byKey = new Map(rows.map((row) => [String(row._id), row]));
+
+      return entries.map(({ key, windowSeconds, amount }) => {
+        const row = byKey.get(key);
+        return row
+          ? { count: row.count, resetAt: row.resetAt }
+          // The row is written above, so a miss means it was swept between the
+          // write and the read. Report our own contribution rather than zero,
+          // which would read as "no usage" to the limit check.
+          : { count: amount, resetAt: new Date(now.getTime() + windowSeconds * 1000) };
+      });
+    }
   };
 }

--- a/src/lib/database/mongodb/rag.mixin.ts
+++ b/src/lib/database/mongodb/rag.mixin.ts
@@ -194,7 +194,13 @@ export function RagMixin<TBase extends Constructor<MongoDBProviderBase>>(Base: T
 
     async listRagDocuments(
       ragModuleKey: string,
-      filters?: { projectId?: string; status?: RagDocumentStatus; search?: string },
+      filters?: {
+        projectId?: string;
+        status?: RagDocumentStatus;
+        search?: string;
+        limit?: number;
+        offset?: number;
+      },
     ): Promise<IRagDocument[]> {
       const db = this.getTenantDb();
       // When projectId is provided, scope to that project.
@@ -207,20 +213,32 @@ export function RagMixin<TBase extends Constructor<MongoDBProviderBase>>(Base: T
       if (filters?.search) {
         query.fileName = { $regex: this.escapeRegex(filters.search), $options: 'i' };
       }
-      const docs = await db
+      const cursor = db
         .collection<IRagDocument>(COLLECTIONS.ragDocuments)
         .find(query as Filter<IRagDocument>)
-        .sort({ createdAt: -1 })
-        .toArray();
+        .sort({ createdAt: -1 });
+      if (filters?.offset && filters.offset > 0) cursor.skip(filters.offset);
+      if (filters?.limit && filters.limit > 0) cursor.limit(filters.limit);
+      const docs = await cursor.toArray();
       return docs.map((d) => ({ ...d, _id: d._id?.toString() }) as IRagDocument);
     }
 
-    async countRagDocuments(ragModuleKey: string, projectId?: string): Promise<number> {
+    async countRagDocuments(
+      ragModuleKey: string,
+      filters?: { projectId?: string; status?: RagDocumentStatus; search?: string },
+    ): Promise<number> {
       const db = this.getTenantDb();
-      const query: Record<string, unknown> = {
-        ragModuleKey,
-        ...this.buildProjectScopeFilter(projectId),
-      };
+      // Mirrors listRagDocuments exactly: an absent projectId means "every
+      // project", not "documents without one", or the total would disagree
+      // with the page it describes.
+      const query: Record<string, unknown> = { ragModuleKey };
+      if (filters?.projectId !== undefined) {
+        Object.assign(query, this.buildProjectScopeFilter(filters.projectId));
+      }
+      if (filters?.status) query.status = filters.status;
+      if (filters?.search) {
+        query.fileName = { $regex: this.escapeRegex(filters.search), $options: 'i' };
+      }
       return db
         .collection(COLLECTIONS.ragDocuments)
         // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/lib/database/mongodb/tool.mixin.ts
+++ b/src/lib/database/mongodb/tool.mixin.ts
@@ -82,6 +82,9 @@ export function ToolMixin<TBase extends Constructor<MongoDBProviderBase>>(Base: 
       type?: ToolSourceType;
       status?: ToolStatus;
       search?: string;
+      /** Page window. Omitted means every row, which is what unbounded lists cost. */
+      limit?: number;
+      offset?: number;
     }): Promise<ITool[]> {
       const db = this.getTenantDb();
       const filter: Record<string, unknown> = {};
@@ -95,11 +98,13 @@ export function ToolMixin<TBase extends Constructor<MongoDBProviderBase>>(Base: 
           { key: { $regex: filters.search, $options: 'i' } },
         ];
       }
-      const docs = await db
+      const cursor = db
         .collection(COLLECTIONS.tools)
         .find(filter)
-        .sort({ createdAt: -1 })
-        .toArray();
+        .sort({ createdAt: -1 });
+      if (filters?.offset && filters.offset > 0) cursor.skip(filters.offset);
+      if (filters?.limit && filters.limit > 0) cursor.limit(filters.limit);
+      const docs = await cursor.toArray();
       return docs.map((d) => ({ ...d, _id: d._id?.toString() })) as unknown as ITool[];
     }
 

--- a/src/lib/database/provider/contract.ts
+++ b/src/lib/database/provider/contract.ts
@@ -370,6 +370,9 @@ export interface DatabaseProvider extends EnterpriseDbMethods {
     provider?: ModelProviderType; // deprecated
     providerKey?: string;
     providerDriver?: string;
+    /** Page window. Omitting it returns every row. */
+    limit?: number;
+    offset?: number;
   }): Promise<IModel[]>;
   findModelById(id: string, projectId?: string): Promise<IModel | null>;
   findModelByKey(key: string, projectId?: string): Promise<IModel | null>;
@@ -380,7 +383,13 @@ export interface DatabaseProvider extends EnterpriseDbMethods {
   ): Promise<IPrompt>;
   updatePrompt(id: string, data: Partial<IPrompt>): Promise<IPrompt | null>;
   deletePrompt(id: string): Promise<boolean>;
-  listPrompts(filters?: { projectId?: string; search?: string }): Promise<IPrompt[]>;
+  listPrompts(filters?: {
+    projectId?: string;
+    search?: string;
+    /** Page window. Omitting it returns every row. */
+    limit?: number;
+    offset?: number;
+  }): Promise<IPrompt[]>;
   findPromptById(id: string, projectId?: string): Promise<IPrompt | null>;
   findPromptByKey(key: string, projectId?: string): Promise<IPrompt | null>;
 
@@ -634,6 +643,17 @@ export interface DatabaseProvider extends EnterpriseDbMethods {
     windowSeconds: number,
     amount: number,
   ): Promise<{ count: number; resetAt: Date }>;
+  /**
+   * Increment several rate-limit counters together, returning one result per
+   * entry in input order.
+   *
+   * One guarded request checks a counter per metric per window — up to 25 —
+   * and issuing those as 25 separate round trips let a single request occupy
+   * every connection in the pool.
+   */
+  incrementRateLimits(
+    entries: Array<{ key: string; windowSeconds: number; amount: number }>,
+  ): Promise<Array<{ count: number; resetAt: Date }>>;
 
   // Guardrail operations (tenant-specific)
   createGuardrail(
@@ -987,9 +1007,23 @@ export interface DatabaseProvider extends EnterpriseDbMethods {
   ): Promise<IRagDocument | null>;
   listRagDocuments(
     ragModuleKey: string,
-    filters?: { projectId?: string; status?: RagDocumentStatus; search?: string },
+    filters?: {
+      projectId?: string;
+      status?: RagDocumentStatus;
+      search?: string;
+      /** Rows to return. Omit for all of them — every row carries its source text. */
+      limit?: number;
+      offset?: number;
+    },
   ): Promise<IRagDocument[]>;
-  countRagDocuments(ragModuleKey: string, projectId?: string): Promise<number>;
+  /**
+   * Count the rows `listRagDocuments` would return for the same filters, so a
+   * paginated response can report an accurate total.
+   */
+  countRagDocuments(
+    ragModuleKey: string,
+    filters?: { projectId?: string; status?: RagDocumentStatus; search?: string },
+  ): Promise<number>;
 
   // ── RAG Chunk operations (tenant-specific) ──
   bulkInsertRagChunks(
@@ -1242,6 +1276,9 @@ export interface DatabaseProvider extends EnterpriseDbMethods {
     type?: ToolSourceType;
     status?: ToolStatus;
     search?: string;
+    /** Page window. Omitting it returns every row. */
+    limit?: number;
+    offset?: number;
   }): Promise<ITool[]>;
   countTools(projectId?: string): Promise<number>;
 
@@ -1285,6 +1322,9 @@ export interface DatabaseProvider extends EnterpriseDbMethods {
     projectId?: string;
     status?: AgentStatus;
     search?: string;
+    /** Page window. Omitting it returns every row. */
+    limit?: number;
+    offset?: number;
   }): Promise<IAgent[]>;
   countAgents(projectId?: string): Promise<number>;
 

--- a/src/lib/database/sqlite/agent.mixin.ts
+++ b/src/lib/database/sqlite/agent.mixin.ts
@@ -93,6 +93,9 @@ export function AgentMixin<TBase extends Constructor<SQLiteProviderBase>>(Base: 
       projectId?: string;
       status?: AgentStatus;
       search?: string;
+      /** Page window. Omitted means every row, which is what unbounded lists cost. */
+      limit?: number;
+      offset?: number;
     }): Promise<IAgent[]> {
       const db = this.getTenantDb();
       const conditions: string[] = [];
@@ -106,7 +109,22 @@ export function AgentMixin<TBase extends Constructor<SQLiteProviderBase>>(Base: 
       }
 
       const where = conditions.length ? `WHERE ${conditions.join(' AND ')}` : '';
-      const rows = db.prepare(`SELECT * FROM ${TABLES.agents} ${where} ORDER BY createdAt DESC`).all(params) as SqliteRow[];
+      // SQLite needs a LIMIT before it will honour an OFFSET; -1 means "all".
+      let pageSql = '';
+      if (filters?.limit && filters.limit > 0) {
+        pageSql = ' LIMIT @limit';
+        params.limit = filters.limit;
+      } else if (filters?.offset && filters.offset > 0) {
+        pageSql = ' LIMIT -1';
+      }
+      if (filters?.offset && filters.offset > 0) {
+        pageSql += ' OFFSET @offset';
+        params.offset = filters.offset;
+      }
+
+      const rows = db.prepare(
+        `SELECT * FROM ${TABLES.agents} ${where} ORDER BY createdAt DESC${pageSql}`,
+      ).all(params) as SqliteRow[];
       return rows.map((r) => this.mapAgent(r));
     }
 

--- a/src/lib/database/sqlite/model.mixin.ts
+++ b/src/lib/database/sqlite/model.mixin.ts
@@ -94,6 +94,9 @@ export function ModelMixin<TBase extends Constructor<SQLiteProviderBase>>(Base: 
       provider?: ModelProviderType;
       providerKey?: string;
       providerDriver?: string;
+      /** Page window. Omitted means every row, which is what unbounded lists cost. */
+      limit?: number;
+      offset?: number;
     }): Promise<IModel[]> {
       const db = this.getTenantDb();
       const clauses: string[] = [];
@@ -106,8 +109,22 @@ export function ModelMixin<TBase extends Constructor<SQLiteProviderBase>>(Base: 
       if (filters?.providerDriver) { clauses.push('providerDriver = @providerDriver'); params.providerDriver = filters.providerDriver; }
 
       const where = clauses.length > 0 ? `WHERE ${clauses.join(' AND ')}` : '';
-      const rows = db.prepare(`SELECT * FROM ${TABLES.models} ${where} ORDER BY createdAt DESC`)
-        .all(params) as SqliteRow[];
+      // SQLite needs a LIMIT before it will honour an OFFSET; -1 means "all".
+      let pageSql = '';
+      if (filters?.limit && filters.limit > 0) {
+        pageSql = ' LIMIT @limit';
+        params.limit = filters.limit;
+      } else if (filters?.offset && filters.offset > 0) {
+        pageSql = ' LIMIT -1';
+      }
+      if (filters?.offset && filters.offset > 0) {
+        pageSql += ' OFFSET @offset';
+        params.offset = filters.offset;
+      }
+
+      const rows = db.prepare(
+        `SELECT * FROM ${TABLES.models} ${where} ORDER BY createdAt DESC${pageSql}`,
+      ).all(params) as SqliteRow[];
       return rows.map((r) => this.mapModelRow(r));
     }
 

--- a/src/lib/database/sqlite/prompt.mixin.ts
+++ b/src/lib/database/sqlite/prompt.mixin.ts
@@ -84,7 +84,13 @@ export function PromptMixin<TBase extends Constructor<SQLiteProviderBase>>(Base:
       return row ? this.mapPromptRow(row) : null;
     }
 
-    async listPrompts(filters?: { projectId?: string; search?: string }): Promise<IPrompt[]> {
+    async listPrompts(filters?: {
+      projectId?: string;
+      search?: string;
+      /** Page window. Omitted means every row, which is what unbounded lists cost. */
+      limit?: number;
+      offset?: number;
+    }): Promise<IPrompt[]> {
       const db = this.getTenantDb();
       const clauses: string[] = [];
       const params: Record<string, unknown> = {};
@@ -97,8 +103,22 @@ export function PromptMixin<TBase extends Constructor<SQLiteProviderBase>>(Base:
       }
 
       const where = clauses.length > 0 ? `WHERE ${clauses.join(' AND ')}` : '';
-      const rows = db.prepare(`SELECT * FROM ${TABLES.prompts} ${where} ORDER BY updatedAt DESC, createdAt DESC`)
-        .all(params) as SqliteRow[];
+      // SQLite needs a LIMIT before it will honour an OFFSET; -1 means "all".
+      let pageSql = '';
+      if (filters?.limit && filters.limit > 0) {
+        pageSql = ' LIMIT @limit';
+        params.limit = filters.limit;
+      } else if (filters?.offset && filters.offset > 0) {
+        pageSql = ' LIMIT -1';
+      }
+      if (filters?.offset && filters.offset > 0) {
+        pageSql += ' OFFSET @offset';
+        params.offset = filters.offset;
+      }
+
+      const rows = db.prepare(
+        `SELECT * FROM ${TABLES.prompts} ${where} ORDER BY updatedAt DESC, createdAt DESC${pageSql}`,
+      ).all(params) as SqliteRow[];
       return rows.map((r) => this.mapPromptRow(r));
     }
 

--- a/src/lib/database/sqlite/provider-record.mixin.ts
+++ b/src/lib/database/sqlite/provider-record.mixin.ts
@@ -159,6 +159,19 @@ export function ProviderRecordMixin<TBase extends Constructor<SQLiteProviderBase
       return { count: updated.count, resetAt: new Date(updated.resetAt) };
     }
 
+    async incrementRateLimits(
+      entries: Array<{ key: string; windowSeconds: number; amount: number }>,
+    ): Promise<Array<{ count: number; resetAt: Date }>> {
+      // better-sqlite3 is in-process and synchronous, so there is no round trip
+      // to save here; the batch exists to satisfy the contract and to keep the
+      // whole set of counters inside one transaction.
+      const results: Array<{ count: number; resetAt: Date }> = [];
+      for (const { key, windowSeconds, amount } of entries) {
+        results.push(await this.incrementRateLimit(key, windowSeconds, amount));
+      }
+      return results;
+    }
+
     protected mapProviderRow(r: SqliteRow): IProviderRecord {
       return {
         _id: r.id as string,

--- a/src/lib/database/sqlite/rag.mixin.ts
+++ b/src/lib/database/sqlite/rag.mixin.ts
@@ -321,7 +321,13 @@ export function RagMixin<TBase extends Constructor<SQLiteProviderBase>>(Base: TB
 
     async listRagDocuments(
       ragModuleKey: string,
-      filters?: { projectId?: string; status?: RagDocumentStatus; search?: string },
+      filters?: {
+        projectId?: string;
+        status?: RagDocumentStatus;
+        search?: string;
+        limit?: number;
+        offset?: number;
+      },
     ): Promise<IRagDocument[]> {
       const db = this.getTenantDb();
       const clauses: string[] = ['ragModuleKey = @ragModuleKey'];
@@ -335,20 +341,44 @@ export function RagMixin<TBase extends Constructor<SQLiteProviderBase>>(Base: TB
       if (filters?.status) { clauses.push('status = @status'); params.status = filters.status; }
       if (filters?.search) { clauses.push('fileName LIKE @search'); params.search = this.likePattern(filters.search); }
 
+      // SQLite needs a LIMIT before it will honour an OFFSET; -1 means "all".
+      let pagination = '';
+      if (filters?.limit && filters.limit > 0) {
+        pagination = ' LIMIT @limit';
+        params.limit = filters.limit;
+      } else if (filters?.offset && filters.offset > 0) {
+        pagination = ' LIMIT -1';
+      }
+      if (filters?.offset && filters.offset > 0) {
+        pagination += ' OFFSET @offset';
+        params.offset = filters.offset;
+      }
+
       const rows = db.prepare(
-        `SELECT * FROM ${TABLES.ragDocuments} WHERE ${clauses.join(' AND ')} ORDER BY createdAt DESC`,
+        `SELECT * FROM ${TABLES.ragDocuments} WHERE ${clauses.join(' AND ')} `
+        + `ORDER BY createdAt DESC${pagination}`,
       ).all(params) as SqliteRow[];
       return rows.map((r) => this.mapDocRow(r));
     }
 
-    async countRagDocuments(ragModuleKey: string, projectId?: string): Promise<number> {
+    async countRagDocuments(
+      ragModuleKey: string,
+      filters?: { projectId?: string; status?: RagDocumentStatus; search?: string },
+    ): Promise<number> {
       const db = this.getTenantDb();
+      // Mirrors listRagDocuments exactly, so a paginated total describes the
+      // same rows as the page it accompanies.
       const clauses: string[] = ['ragModuleKey = @ragModuleKey'];
       const params: Record<string, unknown> = { ragModuleKey };
-      if (projectId) {
-        const scopeFilter = this.buildProjectScopeFilter(projectId);
+      if (filters?.projectId !== undefined) {
+        const scopeFilter = this.buildProjectScopeFilter(filters.projectId);
         clauses.push(scopeFilter.clause);
         Object.assign(params, scopeFilter.params);
+      }
+      if (filters?.status) { clauses.push('status = @status'); params.status = filters.status; }
+      if (filters?.search) {
+        clauses.push('fileName LIKE @search');
+        params.search = this.likePattern(filters.search);
       }
       const row = db.prepare(
         `SELECT COUNT(*) as cnt FROM ${TABLES.ragDocuments} WHERE ${clauses.join(' AND ')}`,

--- a/src/lib/database/sqlite/tool.mixin.ts
+++ b/src/lib/database/sqlite/tool.mixin.ts
@@ -112,6 +112,9 @@ export function ToolMixin<TBase extends Constructor<SQLiteProviderBase>>(Base: T
       type?: ToolSourceType;
       status?: ToolStatus;
       search?: string;
+      /** Page window. Omitted means every row, which is what unbounded lists cost. */
+      limit?: number;
+      offset?: number;
     }): Promise<ITool[]> {
       const db = this.getTenantDb();
       const clauses: string[] = [];
@@ -129,6 +132,18 @@ export function ToolMixin<TBase extends Constructor<SQLiteProviderBase>>(Base: T
       let sql = `SELECT * FROM ${TABLES.tools}`;
       if (clauses.length > 0) sql += ` WHERE ${clauses.join(' AND ')}`;
       sql += ' ORDER BY createdAt DESC';
+
+      // SQLite needs a LIMIT before it will honour an OFFSET; -1 means "all".
+      if (filters?.limit && filters.limit > 0) {
+        sql += ' LIMIT ?';
+        params.push(filters.limit);
+      } else if (filters?.offset && filters.offset > 0) {
+        sql += ' LIMIT -1';
+      }
+      if (filters?.offset && filters.offset > 0) {
+        sql += ' OFFSET ?';
+        params.push(filters.offset);
+      }
 
       const rows = db.prepare(sql).all(...params) as SqliteRow[];
       return rows.map((r) => this.mapToolRow(r));

--- a/src/lib/quota/quotaGuard.ts
+++ b/src/lib/quota/quotaGuard.ts
@@ -110,18 +110,16 @@ function mergeLimits(base: QuotaLimits, override: QuotaLimits): QuotaLimits {
   return merged;
 }
 
-async function incrementRateLimitCounter(
+async function incrementRateLimitCounters(
   context: QuotaContext,
-  key: string,
-  windowSeconds: number,
-  amount: number,
-): Promise<{ count: number; resetAt: Date }> {
+  entries: Array<{ key: string; windowSeconds: number; amount: number }>,
+): Promise<Array<{ count: number; resetAt: Date }>> {
   const provider = getConfig().rateLimit.provider;
 
   if (provider === 'mongodb') {
     const db = await getDatabase();
     await db.switchToTenant(context.tenantDbName);
-    return db.incrementRateLimit(key, windowSeconds, amount);
+    return db.incrementRateLimits(entries);
   }
 
   const cache = await getCache();
@@ -131,12 +129,15 @@ async function incrementRateLimitCounter(
     );
   }
 
-  return cache.incrementCounter(
-    `${context.tenantDbName}:${key}`,
-    windowSeconds,
-    amount,
+  return cache.incrementCounters(
+    entries.map((entry) => ({
+      key: `${context.tenantDbName}:${entry.key}`,
+      ttlSeconds: entry.windowSeconds,
+      amount: entry.amount,
+    })),
   );
 }
+
 
 /**
  * The tenant license + policy set behind an effective-limit resolution.
@@ -457,9 +458,27 @@ export async function checkRateLimit(
 
   const errors: string[] = [];
 
-  const checkWindow = async (
-    type: 'requests' | 'tokens' | 'vectors' | 'files' | 'storageBytes',
-    windowName: 'perSecond' | 'perMinute' | 'perHour' | 'perDay' | 'perMonth',
+  /**
+   * One counter to increment: a metric type in one window.
+   *
+   * Collected first and issued as a single batch. Sent one at a time these are
+   * up to 25 concurrent round trips per request, enough for one caller to hold
+   * every connection in the pool while its limits are checked.
+   */
+  interface PlannedWindow {
+    type: 'requests' | 'tokens' | 'vectors' | 'files' | 'storageBytes';
+    windowName: 'perSecond' | 'perMinute' | 'perHour' | 'perDay' | 'perMonth';
+    limit: number;
+    key: string;
+    windowSeconds: number;
+    amount: number;
+  }
+
+  const planned: PlannedWindow[] = [];
+
+  const checkWindow = (
+    type: PlannedWindow['type'],
+    windowName: PlannedWindow['windowName'],
     limit: number | undefined,
     incrementBy: number,
   ) => {
@@ -480,126 +499,84 @@ export async function checkRateLimit(
     else if (context.tokenId) keyParts.push(`token:${context.tokenId}`);
     else keyParts.push(`tenant:${context.tenantId}`);
 
-    const key = keyParts.join(':');
+    planned.push({
+      type,
+      windowName,
+      limit,
+      key: keyParts.join(':'),
+      windowSeconds,
+      amount: incrementBy,
+    });
+  };
 
+  if (rateLimit.requests) {
+    const r = rateLimit.requests;
+    checkWindow('requests', 'perSecond', r.perSecond, cost.requests || 0);
+    checkWindow('requests', 'perMinute', r.perMinute, cost.requests || 0);
+    checkWindow('requests', 'perHour', r.perHour, cost.requests || 0);
+    checkWindow('requests', 'perDay', r.perDay, cost.requests || 0);
+    checkWindow('requests', 'perMonth', r.perMonth, cost.requests || 0);
+  }
+
+  if (rateLimit.tokens) {
+    const t = rateLimit.tokens;
+    checkWindow('tokens', 'perSecond', t.perSecond, cost.tokens || 0);
+    checkWindow('tokens', 'perMinute', t.perMinute, cost.tokens || 0);
+    checkWindow('tokens', 'perHour', t.perHour, cost.tokens || 0);
+    checkWindow('tokens', 'perDay', t.perDay, cost.tokens || 0);
+    checkWindow('tokens', 'perMonth', t.perMonth, cost.tokens || 0);
+  }
+
+  if (rateLimit.vectors) {
+    const v = rateLimit.vectors;
+    checkWindow('vectors', 'perSecond', v.perSecond, cost.vectors || 0);
+    checkWindow('vectors', 'perMinute', v.perMinute, cost.vectors || 0);
+    checkWindow('vectors', 'perHour', v.perHour, cost.vectors || 0);
+    checkWindow('vectors', 'perDay', v.perDay, cost.vectors || 0);
+    checkWindow('vectors', 'perMonth', v.perMonth, cost.vectors || 0);
+  }
+
+  if (rateLimit.files) {
+    const f = rateLimit.files;
+    checkWindow('files', 'perSecond', f.perSecond, cost.files || 0);
+    checkWindow('files', 'perMinute', f.perMinute, cost.files || 0);
+    checkWindow('files', 'perHour', f.perHour, cost.files || 0);
+    checkWindow('files', 'perDay', f.perDay, cost.files || 0);
+    checkWindow('files', 'perMonth', f.perMonth, cost.files || 0);
+  }
+
+  if (rateLimit.storage) {
+    const s = rateLimit.storage;
+    checkWindow('storageBytes', 'perSecond', s.perSecond, cost.storageBytes || 0);
+    checkWindow('storageBytes', 'perMinute', s.perMinute, cost.storageBytes || 0);
+    checkWindow('storageBytes', 'perHour', s.perHour, cost.storageBytes || 0);
+    checkWindow('storageBytes', 'perDay', s.perDay, cost.storageBytes || 0);
+    checkWindow('storageBytes', 'perMonth', s.perMonth, cost.storageBytes || 0);
+  }
+
+  if (planned.length > 0) {
     try {
-      const { count } = await incrementRateLimitCounter(
-        context,
-        key,
-        windowSeconds,
-        incrementBy,
-      );
-      if (count > limit) {
-        errors.push(
-          `Rate limit exceeded for ${type} ${windowName} (${count}/${limit})`,
-        );
-      }
+      const counts = await incrementRateLimitCounters(context, planned);
+      counts.forEach(({ count }, index) => {
+        const window = planned[index];
+        if (count > window.limit) {
+          errors.push(
+            `Rate limit exceeded for ${window.type} ${window.windowName} `
+            + `(${count}/${window.limit})`,
+          );
+        }
+      });
     } catch (error) {
+      // The batch fails as a unit, where separate calls used to fail one
+      // counter at a time. Enforcement being unavailable is the same answer
+      // either way, and a partially-applied set of increments would leave the
+      // windows disagreeing about how much of this request was counted.
       logger.error('Rate limit check failed', {
         error: error instanceof Error ? error.message : String(error),
       });
       errors.push('Rate limit enforcement unavailable');
     }
-  };
-
-  const promises: Promise<void>[] = [];
-
-  if (rateLimit.requests) {
-    const r = rateLimit.requests;
-    promises.push(
-      checkWindow('requests', 'perSecond', r.perSecond, cost.requests || 0),
-    );
-    promises.push(
-      checkWindow('requests', 'perMinute', r.perMinute, cost.requests || 0),
-    );
-    promises.push(
-      checkWindow('requests', 'perHour', r.perHour, cost.requests || 0),
-    );
-    promises.push(
-      checkWindow('requests', 'perDay', r.perDay, cost.requests || 0),
-    );
-    promises.push(
-      checkWindow('requests', 'perMonth', r.perMonth, cost.requests || 0),
-    );
   }
-
-  if (rateLimit.tokens) {
-    const t = rateLimit.tokens;
-    promises.push(
-      checkWindow('tokens', 'perSecond', t.perSecond, cost.tokens || 0),
-    );
-    promises.push(
-      checkWindow('tokens', 'perMinute', t.perMinute, cost.tokens || 0),
-    );
-    promises.push(
-      checkWindow('tokens', 'perHour', t.perHour, cost.tokens || 0),
-    );
-    promises.push(
-      checkWindow('tokens', 'perDay', t.perDay, cost.tokens || 0),
-    );
-    promises.push(
-      checkWindow('tokens', 'perMonth', t.perMonth, cost.tokens || 0),
-    );
-  }
-
-  if (rateLimit.vectors) {
-    const v = rateLimit.vectors;
-    promises.push(
-      checkWindow('vectors', 'perSecond', v.perSecond, cost.vectors || 0),
-    );
-    promises.push(
-      checkWindow('vectors', 'perMinute', v.perMinute, cost.vectors || 0),
-    );
-    promises.push(
-      checkWindow('vectors', 'perHour', v.perHour, cost.vectors || 0),
-    );
-    promises.push(
-      checkWindow('vectors', 'perDay', v.perDay, cost.vectors || 0),
-    );
-    promises.push(
-      checkWindow('vectors', 'perMonth', v.perMonth, cost.vectors || 0),
-    );
-  }
-
-  if (rateLimit.files) {
-    const f = rateLimit.files;
-    promises.push(
-      checkWindow('files', 'perSecond', f.perSecond, cost.files || 0),
-    );
-    promises.push(
-      checkWindow('files', 'perMinute', f.perMinute, cost.files || 0),
-    );
-    promises.push(
-      checkWindow('files', 'perHour', f.perHour, cost.files || 0),
-    );
-    promises.push(
-      checkWindow('files', 'perDay', f.perDay, cost.files || 0),
-    );
-    promises.push(
-      checkWindow('files', 'perMonth', f.perMonth, cost.files || 0),
-    );
-  }
-
-  if (rateLimit.storage) {
-    const s = rateLimit.storage;
-    promises.push(
-      checkWindow('storageBytes', 'perSecond', s.perSecond, cost.storageBytes || 0),
-    );
-    promises.push(
-      checkWindow('storageBytes', 'perMinute', s.perMinute, cost.storageBytes || 0),
-    );
-    promises.push(
-      checkWindow('storageBytes', 'perHour', s.perHour, cost.storageBytes || 0),
-    );
-    promises.push(
-      checkWindow('storageBytes', 'perDay', s.perDay, cost.storageBytes || 0),
-    );
-    promises.push(
-      checkWindow('storageBytes', 'perMonth', s.perMonth, cost.storageBytes || 0),
-    );
-  }
-
-  await Promise.all(promises);
 
   if (errors.length > 0) {
     return { allowed: false, reason: errors[0], effectiveLimits };

--- a/src/lib/services/agents/agentService.ts
+++ b/src/lib/services/agents/agentService.ts
@@ -798,7 +798,7 @@ export async function getAgentByKey(
 
 export async function listAgents(
     tenantDbName: string,
-    filters?: { projectId?: string; status?: IAgent['status']; search?: string },
+    filters?: { projectId?: string; status?: IAgent['status']; search?: string; limit?: number; offset?: number },
 ): Promise<IAgent[]> {
     const db = await getDatabase();
     await db.switchToTenant(tenantDbName);

--- a/src/lib/services/analysis/service.ts
+++ b/src/lib/services/analysis/service.ts
@@ -16,6 +16,7 @@
 
 import slugify from 'slugify';
 import { getDatabase } from '@/lib/database';
+import { mapLimit } from '@/lib/core/concurrency';
 import type {
   IAnalysisDefinition,
   IAnalysisFieldDef,
@@ -44,19 +45,6 @@ const MAX_KEY_ATTEMPTS = 50;
 const MAX_RUN_CONVERSATIONS = Math.max(1, Number(process.env.ANALYSIS_MAX_RUN_CONVERSATIONS ?? 5000) || 5000);
 /** Parallel write-back updates. Bounded so a 5k-item run can't storm the DB. */
 const WRITE_BACK_CONCURRENCY = 20;
-
-/** Run tasks with a bounded number in flight, preserving input order. */
-async function mapLimit<T, R>(items: T[], limit: number, fn: (item: T) => Promise<R>): Promise<R[]> {
-  const results = new Array<R>(items.length);
-  let cursor = 0;
-  const workers = Array.from({ length: Math.min(limit, items.length) }, async () => {
-    for (let i = cursor++; i < items.length; i = cursor++) {
-      results[i] = await fn(items[i]);
-    }
-  });
-  await Promise.all(workers);
-  return results;
-}
 
 export type WithId<T> = Omit<T, '_id'> & { id: string };
 

--- a/src/lib/services/apiTokenAuth.ts
+++ b/src/lib/services/apiTokenAuth.ts
@@ -107,7 +107,7 @@ export async function requireApiTokenFromHeader(
   fireAndForget('token-last-used', async () => {
     const bgDb = await getDatabase();
     await bgDb.updateTokenLastUsedByHash(tokenHash);
-  });
+  }, { droppable: true });
 
   await db.switchToTenant(tenant.dbName);
 

--- a/src/lib/services/guardrail/guardrailService.ts
+++ b/src/lib/services/guardrail/guardrailService.ts
@@ -1,5 +1,8 @@
 import { getDatabase } from '@/lib/database';
 import type { IGuardrail, GuardrailType } from '@/lib/database';
+import { getCache } from '@/lib/core/cache';
+import { getConfig } from '@/lib/core/config';
+import { createLogger } from '@/lib/core/logger';
 import { fireAndForget } from '@/lib/core/asyncTask';
 import { recordUsageEvent } from '@/lib/services/usage/usageEvents';
 import { generateUniqueSlugKey } from './keyGeneration';
@@ -138,10 +141,17 @@ export async function updateGuardrail(
   const db = await getDatabase();
   await db.switchToTenant(tenantDbName);
 
+  // Read before writing: an update that renames the key or moves the guardrail
+  // between projects leaves a stale entry under the previous cache key.
+  const prior = await db.findGuardrailById(id);
+
   const updated = await db.updateGuardrail(id, {
     ...input,
     updatedBy,
   });
+
+  await invalidateGuardrailCache(tenantDbName, prior);
+  await invalidateGuardrailCache(tenantDbName, updated);
 
   if (!updated) return null;
   return serializeGuardrail(updated);
@@ -153,7 +163,10 @@ export async function deleteGuardrail(
 ): Promise<boolean> {
   const db = await getDatabase();
   await db.switchToTenant(tenantDbName);
-  return db.deleteGuardrail(id);
+  const existing = await db.findGuardrailById(id);
+  const deleted = await db.deleteGuardrail(id);
+  await invalidateGuardrailCache(tenantDbName, existing);
+  return deleted;
 }
 
 export async function getGuardrail(
@@ -165,6 +178,81 @@ export async function getGuardrail(
   const record = await db.findGuardrailById(id);
   if (!record) return null;
   return serializeGuardrail(record);
+}
+
+const cacheLog = createLogger('guardrail-cache');
+
+/*
+ * A guarded model resolves its guardrail on the request path — twice, when both
+ * an input and an output guardrail are configured — and the lookup was
+ * uncached, so the config was re-read from the database on every call.
+ */
+
+function guardrailCacheKey(tenantDbName: string, key: string, projectId?: string): string {
+  return `guardrail-cfg:${tenantDbName}:${key}:${projectId ?? ''}`;
+}
+
+/**
+ * Resolve a guardrail by key, through a short-lived cache.
+ *
+ * Returns the stored record, which callers treat as read-only: the memory cache
+ * provider hands back the object itself.
+ */
+async function loadGuardrailRecord(
+  tenantDbName: string,
+  key: string,
+  projectId?: string,
+): Promise<IGuardrail | null> {
+  const ttl = getConfig().guardrail.configCacheTtlSeconds;
+  const cacheKey = guardrailCacheKey(tenantDbName, key, projectId);
+
+  if (ttl > 0) {
+    try {
+      const cache = await getCache();
+      const cached = await cache.get<IGuardrail>(cacheKey);
+      if (cached) return cached;
+    } catch {
+      /* cache miss or unavailable — fall through to the database */
+    }
+  }
+
+  const db = await getDatabase();
+  await db.switchToTenant(tenantDbName);
+  const record = await db.findGuardrailByKey(key, projectId);
+
+  if (record && ttl > 0) {
+    try {
+      const cache = await getCache();
+      await cache.set(cacheKey, record, ttl);
+    } catch {
+      /* best-effort cache write */
+    }
+  }
+
+  return record;
+}
+
+/**
+ * Drop a guardrail's cached config so an edit applies to the next request.
+ *
+ * Best-effort, and only for a record whose project is known: a guardrail with
+ * no project is visible to every one of them and the cache is keyed per
+ * project, so those edits land on the TTL instead.
+ */
+async function invalidateGuardrailCache(
+  tenantDbName: string,
+  record: IGuardrail | null | undefined,
+): Promise<void> {
+  if (!record) return;
+  try {
+    const cache = await getCache();
+    await cache.del(guardrailCacheKey(tenantDbName, record.key, record.projectId));
+  } catch (error) {
+    cacheLog.warn('Failed to invalidate guardrail cache; entry expires on TTL', {
+      guardrailKey: record.key,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
 }
 
 export async function getGuardrailByKey(
@@ -281,7 +369,7 @@ export async function evaluateGuardrail(params: {
 
   const db = await getDatabase();
   await db.switchToTenant(tenantDbName);
-  const record = await db.findGuardrailByKey(guardrailKey, projectId);
+  const record = await loadGuardrailRecord(tenantDbName, guardrailKey, projectId);
 
   if (!record) {
     throw new Error(`Guardrail with key "${guardrailKey}" not found`);

--- a/src/lib/services/models/modelService.ts
+++ b/src/lib/services/models/modelService.ts
@@ -141,7 +141,7 @@ function ensureCurrency(
 export async function listModels(
   tenantDbName: string,
   projectId: string,
-  filters?: { category?: ModelCategory; providerKey?: string; providerDriver?: string },
+  filters?: { category?: ModelCategory; providerKey?: string; providerDriver?: string; limit?: number; offset?: number },
 ): Promise<IModel[]> {
   const db = await getDatabase();
   await db.switchToTenant(tenantDbName);

--- a/src/lib/services/prompts/promptService.ts
+++ b/src/lib/services/prompts/promptService.ts
@@ -184,6 +184,8 @@ export async function listPrompts(
 	const prompts = await db.listPrompts({
 		projectId,
 		search: options?.search,
+		limit: options?.limit,
+		offset: options?.offset,
 	});
 
 	return prompts.map((prompt) => serializePrompt(prompt));

--- a/src/lib/services/prompts/types.ts
+++ b/src/lib/services/prompts/types.ts
@@ -105,6 +105,9 @@ export interface PromptCompareView {
 
 export interface ListPromptsOptions {
 	search?: string;
+	/** Page window. Omitting it returns every prompt. */
+	limit?: number;
+	offset?: number;
 }
 
 export interface PromptCommentView {

--- a/src/lib/services/providers/providerService.ts
+++ b/src/lib/services/providers/providerService.ts
@@ -4,9 +4,87 @@ import {
   ProviderDomain,
 } from '@/lib/database';
 import { decryptObject, encryptObject } from '@/lib/utils/crypto';
+import { getCache } from '@/lib/core/cache';
+import { getConfig } from '@/lib/core/config';
 import { createLogger } from '@/lib/core/logger';
 
 const logger = createLogger('provider-service');
+
+/* ------------------------------------------------------------------ */
+/*  Provider record cache                                             */
+/* ------------------------------------------------------------------ */
+
+/*
+ * Every provider call re-read the provider row. The SDK client itself is
+ * pooled (`runtimePool`), but the record behind it was not, so one Knowledge
+ * Engine query — embedding, then vector store, then reranker — spent three
+ * uncached reads before doing any work, against a ten-connection pool.
+ *
+ * The cached value is the row as stored, which means `credentialsEnc` — the
+ * SAME ciphertext that sits in the database, sealed with
+ * PROVIDER_ENCRYPTION_SECRET, which is never cached. Decryption still happens
+ * per call and plaintext credentials are never written to the cache. An
+ * operator who would rather keep that ciphertext out of Redis entirely can set
+ * PROVIDER_RECORD_CACHE_TTL_SECONDS=0.
+ */
+
+function providerRecordCacheKeys(record: IProviderRecord, tenantDbName: string): string[] {
+  const keys = [`provider-rec:${tenantDbName}:id:${String(record._id)}`];
+  const projectIds = record.projectIds?.length ? record.projectIds : [undefined];
+  for (const projectId of projectIds) {
+    keys.push(
+      `provider-rec:${tenantDbName}:key:${record.tenantId}:${record.key}:${projectId ?? ''}`,
+    );
+  }
+  return keys;
+}
+
+async function readCachedProviderRecord(cacheKey: string): Promise<IProviderRecord | null> {
+  if (getConfig().providerRuntime.recordCacheTtlSeconds <= 0) return null;
+  try {
+    const cache = await getCache();
+    return (await cache.get<IProviderRecord>(cacheKey)) ?? null;
+  } catch {
+    return null; // cache miss or unavailable — the caller falls back to the database
+  }
+}
+
+async function writeCachedProviderRecord(
+  cacheKey: string,
+  record: IProviderRecord,
+): Promise<void> {
+  const ttl = getConfig().providerRuntime.recordCacheTtlSeconds;
+  if (ttl <= 0) return;
+  try {
+    const cache = await getCache();
+    await cache.set(cacheKey, record, ttl);
+  } catch {
+    /* best-effort cache write */
+  }
+}
+
+/**
+ * Drop every cached entry for a provider so a credential rotation, a status
+ * change or a project re-assignment takes effect on the next call rather than
+ * after the TTL.
+ */
+export async function invalidateProviderRecordCache(
+  tenantDbName: string,
+  record: IProviderRecord | null | undefined,
+): Promise<void> {
+  if (!record) return;
+  try {
+    const cache = await getCache();
+    await Promise.all(
+      providerRecordCacheKeys(record, tenantDbName).map((key) => cache.del(key)),
+    );
+  } catch (error) {
+    logger.warn('Failed to invalidate provider record cache; entries expire on TTL', {
+      providerKey: record.key,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
 
 export type ProviderStatus = IProviderRecord['status'];
 
@@ -145,6 +223,10 @@ export async function updateProviderConfig(
   payload: UpdateProviderConfigInput,
 ): Promise<ProviderConfigView | null> {
   const db = await withTenantDb(tenantDbName);
+  // Read once, up front: the credential merge below needs it, and so does the
+  // cache invalidation at the end — which must cover the projects the provider
+  // was assigned to BEFORE this update, not just after.
+  const priorRecord = await db.findProviderById(providerId);
   const updates: Partial<IProviderRecord> = {};
 
   if (payload.projectIds !== undefined) {
@@ -182,7 +264,7 @@ export async function updateProviderConfig(
     // '' because the backend never returns the secret, so a wholesale replace
     // would silently wipe the API key whenever an unrelated field (baseUrl,
     // region, …) is edited.
-    const existing = await db.findProviderById(providerId);
+    const existing = priorRecord;
     let current: Record<string, unknown> = {};
     if (existing?.credentialsEnc) {
       try {
@@ -214,6 +296,10 @@ export async function updateProviderConfig(
   }
 
   const updated = await db.updateProvider(providerId, updates);
+  // Invalidate against BOTH rows: an update that moves the provider between
+  // projects leaves a stale entry under the old project's key.
+  await invalidateProviderRecordCache(tenantDbName, priorRecord);
+  await invalidateProviderRecordCache(tenantDbName, updated);
   return updated ? sanitize(updated) : null;
 }
 
@@ -257,7 +343,12 @@ export async function deleteProviderConfig(
   providerId: string,
 ): Promise<boolean> {
   const db = await withTenantDb(tenantDbName);
-  return db.deleteProvider(providerId);
+  // Read before deleting: the cache is keyed by tenant/key/project, none of
+  // which can be derived from the id once the row is gone.
+  const existing = await db.findProviderById(providerId);
+  const deleted = await db.deleteProvider(providerId);
+  await invalidateProviderRecordCache(tenantDbName, existing);
+  return deleted;
 }
 
 export interface ProviderRuntimeData<TCredentials = Record<string, unknown>> {
@@ -274,17 +365,29 @@ export async function loadProviderRuntimeData<TCredentials = Record<string, unkn
     projectId?: string;
   },
 ): Promise<ProviderRuntimeData<TCredentials>> {
-  const db = await withTenantDb(tenantDbName);
-  let record: IProviderRecord | null = null;
+  const cacheKey = providerIdOrKey.id
+    ? `provider-rec:${tenantDbName}:id:${providerIdOrKey.id}`
+    : `provider-rec:${tenantDbName}:key:${providerIdOrKey.tenantId}:`
+      + `${providerIdOrKey.key}:${providerIdOrKey.projectId ?? ''}`;
 
-  if (providerIdOrKey.id) {
-    record = await db.findProviderById(providerIdOrKey.id);
-  } else if (providerIdOrKey.key) {
-    record = await db.findProviderByKey(
-      providerIdOrKey.tenantId,
-      providerIdOrKey.key,
-      providerIdOrKey.projectId,
-    );
+  let record = await readCachedProviderRecord(cacheKey);
+  const fromCache = record !== null;
+
+  const db = await withTenantDb(tenantDbName);
+
+  if (!record) {
+    if (providerIdOrKey.id) {
+      record = await db.findProviderById(providerIdOrKey.id);
+    } else if (providerIdOrKey.key) {
+      record = await db.findProviderByKey(
+        providerIdOrKey.tenantId,
+        providerIdOrKey.key,
+        providerIdOrKey.projectId,
+      );
+    }
+    // Only successful lookups are cached. A miss falls through to the
+    // diagnostic branch below, which is an error path and not worth caching.
+    if (record) await writeCachedProviderRecord(cacheKey, record);
   }
 
   if (!record) {
@@ -313,6 +416,12 @@ export async function loadProviderRuntimeData<TCredentials = Record<string, unkn
   try {
     credentials = decryptObject<TCredentials>(record.credentialsEnc);
   } catch (error) {
+    // A cached row is the first suspect when decryption suddenly fails: the
+    // credentials may have been rotated a moment ago. Drop it so the retry —
+    // and the legacy-recovery path below — work against the stored row.
+    if (fromCache) {
+      await invalidateProviderRecordCache(tenantDbName, record);
+    }
     // Legacy auto-heal: an earlier version of the GPU-fleet auto-register
     // path persisted credentialsEnc as PLAINTEXT JSON instead of running it
     // through encryptObject. Those rows fail decrypt with the Node AES-GCM

--- a/src/lib/services/rag/ragReindexService.ts
+++ b/src/lib/services/rag/ragReindexService.ts
@@ -103,7 +103,7 @@ export async function startRagReindex(
     status: 'queued',
     reason: request.reason ?? 'manual',
     attempt: 1,
-    totalDocuments: await db.countRagDocuments(request.ragModuleKey, projectId),
+    totalDocuments: await db.countRagDocuments(request.ragModuleKey, { projectId }),
     processedDocuments: 0,
     failedDocuments: 0,
     batchSize: request.batchSize ?? 1,

--- a/src/lib/services/rag/ragService.ts
+++ b/src/lib/services/rag/ragService.ts
@@ -27,6 +27,8 @@ import { runReranker } from '@/lib/services/reranker';
 import { recordUsageEvent } from '@/lib/services/usage/usageEvents';
 import { fireAndForget } from '@/lib/core/asyncTask';
 import { chunkConfigRequiresReindex, chunkText, resolveParentWindow, type ChunkContext } from './chunking';
+import { getCache } from '@/lib/core/cache';
+import { mapLimit } from '@/lib/core/concurrency';
 import { publishRagIngestJob } from './ragIngestJob';
 import {
   discardDocumentSource,
@@ -711,10 +713,21 @@ function withoutInlineSource(document: RagDocument): RagDocument {
   return trimmed;
 }
 
-export async function listRagDocuments(
+/** Rows `listRagDocuments` would return for the same filters, ignoring paging. */
+export async function countRagDocuments(
   tenantDbName: string,
   ragModuleKey: string,
   filters?: { projectId?: string; search?: string },
+): Promise<number> {
+  const db = await getDatabase();
+  await db.switchToTenant(tenantDbName);
+  return db.countRagDocuments(ragModuleKey, filters);
+}
+
+export async function listRagDocuments(
+  tenantDbName: string,
+  ragModuleKey: string,
+  filters?: { projectId?: string; search?: string; limit?: number; offset?: number },
 ): Promise<RagDocument[]> {
   const db = await getDatabase();
   await db.switchToTenant(tenantDbName);
@@ -1038,6 +1051,86 @@ export async function ingestFile(
   });
 }
 
+/* ── Parent-window source loading ─────────────────────────────────── */
+
+/** Documents whose source may be loaded for one query's parent windows. */
+const PARENT_SOURCE_MAX_DOCUMENTS = Math.max(
+  1,
+  Number(process.env.RAG_PARENT_SOURCE_MAX_DOCUMENTS ?? 25) || 25,
+);
+
+/** Source loads in flight at once. Each is a DB read or an object download. */
+const PARENT_SOURCE_CONCURRENCY = Math.max(
+  1,
+  Number(process.env.RAG_PARENT_SOURCE_CONCURRENCY ?? 4) || 4,
+);
+
+/** Seconds a loaded source is reused. 0 disables the cache. */
+const PARENT_SOURCE_CACHE_TTL_SECONDS = Math.max(
+  0,
+  Number(process.env.RAG_PARENT_SOURCE_CACHE_TTL_SECONDS ?? 60) || 0,
+);
+
+/**
+ * Largest source kept in the cache.
+ *
+ * The memory cache provider has no size ceiling of its own, so caching every
+ * source would trade a read-amplification problem for a memory one. Anything
+ * larger is still expanded, it is just re-read each time.
+ */
+const PARENT_SOURCE_CACHE_MAX_CHARS = Math.max(
+  0,
+  Number(process.env.RAG_PARENT_SOURCE_CACHE_MAX_CHARS ?? 65_536) || 0,
+);
+
+interface ParentSource {
+  text: string;
+  windowSize: number;
+}
+
+function parentSourceCacheKey(tenantDbName: string, documentId: string): string {
+  return `rag-parent-src:${tenantDbName}:${documentId}`;
+}
+
+/**
+ * A re-ingest within the TTL can serve the previous text for up to that long.
+ * The window is an enrichment around a chunk the vector store already matched,
+ * so a briefly stale one costs context quality, never correctness.
+ */
+async function readCachedParentSource(
+  tenantDbName: string,
+  documentId: string,
+): Promise<ParentSource | null> {
+  if (PARENT_SOURCE_CACHE_TTL_SECONDS <= 0) return null;
+  try {
+    const cache = await getCache();
+    return (await cache.get<ParentSource>(
+      parentSourceCacheKey(tenantDbName, documentId),
+    )) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+async function writeCachedParentSource(
+  tenantDbName: string,
+  documentId: string,
+  source: ParentSource,
+): Promise<void> {
+  if (PARENT_SOURCE_CACHE_TTL_SECONDS <= 0) return;
+  if (source.text.length > PARENT_SOURCE_CACHE_MAX_CHARS) return;
+  try {
+    const cache = await getCache();
+    await cache.set(
+      parentSourceCacheKey(tenantDbName, documentId),
+      source,
+      PARENT_SOURCE_CACHE_TTL_SECONDS,
+    );
+  } catch {
+    /* best-effort cache write */
+  }
+}
+
 /* ── Query (embed → vector search) ───────────────────────────────────── */
 
 /**
@@ -1067,23 +1160,45 @@ async function applyParentWindows(params: {
   const moduleWindowSize = ragModule.chunkConfig.parentWindowSize;
   if (!moduleWindowSize || moduleWindowSize <= 0 || matches.length === 0) return matches;
 
-  const documentIds = [...new Set(
+  const allDocumentIds = [...new Set(
     matches.map((m) => m.documentId).filter((id): id is string => Boolean(id)),
   )];
 
+  // Expansion reads a whole document per match — up to INLINE_SOURCE_MAX_CHARS
+  // from the row itself, or a full object download for anything larger. Left
+  // unbounded that is one query pulling megabytes of text into heap, so cap the
+  // documents, and say so rather than silently returning narrower context.
+  const documentIds = allDocumentIds.slice(0, PARENT_SOURCE_MAX_DOCUMENTS);
+  if (documentIds.length < allDocumentIds.length) {
+    logger.warn('Parent window expansion capped; remaining matches keep their chunk text', {
+      ragModuleKey: ragModule.key,
+      expanded: documentIds.length,
+      requested: allDocumentIds.length,
+    });
+  }
+
   const sources = new Map<string, { text: string; windowSize: number }>();
-  await Promise.all(documentIds.map(async (documentId) => {
+  await mapLimit(documentIds, PARENT_SOURCE_CONCURRENCY, async (documentId) => {
+    const cached = await readCachedParentSource(params.tenantDbName, documentId);
+    if (cached) {
+      sources.set(documentId, cached);
+      return;
+    }
+
     const document = await db.findRagDocumentById(documentId);
     if (!document) return;
     const text = await loadSourceText(
       params.tenantDbName, params.tenantId, params.projectId, document,
     );
     if (!text) return;
-    sources.set(documentId, {
+
+    const source = {
       text,
       windowSize: chunkConfigFor(ragModule, document).parentWindowSize ?? moduleWindowSize,
-    });
-  }));
+    };
+    sources.set(documentId, source);
+    await writeCachedParentSource(params.tenantDbName, documentId, source);
+  });
 
   if (sources.size === 0) {
     logger.warn('Parent windows are configured but no document source could be read', {

--- a/src/lib/services/tools/toolService.ts
+++ b/src/lib/services/tools/toolService.ts
@@ -386,6 +386,8 @@ export async function listTools(
     type?: ITool['type'];
     status?: ITool['status'];
     search?: string;
+    limit?: number;
+    offset?: number;
   },
 ): Promise<ITool[]> {
   const db = await getDatabase();

--- a/src/server/api/plugins/client-agents.ts
+++ b/src/server/api/plugins/client-agents.ts
@@ -1,6 +1,7 @@
 import type { FastifyPluginAsync } from 'fastify';
 import type { AgentStatus, IAgent, IAgentConfig } from '@/lib/database';
 import { createLogger } from '@/lib/core/logger';
+import { overfetchLimit, paginationMeta, readPagination, takePage } from '@/lib/api/pagination';
 import {
   createAgentRecord,
   createConversation,
@@ -199,12 +200,19 @@ export const clientAgentsApiPlugin: FastifyPluginAsync = async (app) => {
     try {
       const ctx = await getApiTokenContextForRequest(request);
       const query = (request.query ?? {}) as { status?: AgentStatus };
-      const agents = await listAgents(ctx.tenantDbName, {
+      // Paged: a tenant's agent list grows with use, and returning it whole
+      // put the whole collection on the wire on every call.
+      const page = readPagination(request.query);
+      const fetched = await listAgents(ctx.tenantDbName, {
         ...(query.status ? { status: query.status } : {}),
         projectId: ctx.projectId,
+        limit: overfetchLimit(page),
+        offset: page.offset,
       });
+      const { items: agents, hasMore } = takePage(fetched, page);
 
       return reply.code(200).send({
+        pagination: paginationMeta(page, { hasMore }),
         agents: agents.map((agent) => ({
           config: {
             maxTokens: agent.config.maxTokens,

--- a/src/server/api/plugins/client-prompts.ts
+++ b/src/server/api/plugins/client-prompts.ts
@@ -1,6 +1,7 @@
 import type { FastifyPluginAsync } from 'fastify';
 import Mustache from 'mustache';
 import { createLogger } from '@/lib/core/logger';
+import { overfetchLimit, paginationMeta, readPagination, takePage } from '@/lib/api/pagination';
 import {
   activatePromptDeployment,
   comparePromptVersions,
@@ -35,11 +36,18 @@ export const clientPromptsApiPlugin: FastifyPluginAsync = async (app) => {
     try {
       const ctx = await getApiTokenContextForRequest(request);
       const query = (request.query ?? {}) as { search?: string };
-      const prompts = await listPrompts(ctx.tenantDbName, ctx.projectId, {
+      const page = readPagination(request.query);
+      const fetched = await listPrompts(ctx.tenantDbName, ctx.projectId, {
         search: query.search,
+        limit: overfetchLimit(page),
+        offset: page.offset,
       });
+      const { items: prompts, hasMore } = takePage(fetched, page);
 
-      return reply.code(200).send({ prompts });
+      return reply.code(200).send({
+        prompts,
+        pagination: paginationMeta(page, { hasMore }),
+      });
     } catch (error) {
       logger.error('List client prompts error', { error });
       return reply.code(500).send({

--- a/src/server/api/plugins/client-rag.ts
+++ b/src/server/api/plugins/client-rag.ts
@@ -2,6 +2,7 @@ import { Buffer } from 'node:buffer';
 import type { FastifyPluginAsync } from 'fastify';
 import type { IRagChunkConfig } from '@/lib/database';
 import { createLogger } from '@/lib/core/logger';
+import { paginationMeta, readPagination } from '@/lib/api/pagination';
 import {
   createRagModule,
   deleteRagDocument,
@@ -9,6 +10,7 @@ import {
   getRagModule,
   ingestDocument,
   ingestFile,
+  countRagDocuments,
   listRagDocuments,
   listRagModules,
   queryRag,
@@ -183,8 +185,17 @@ export const clientRagApiPlugin: FastifyPluginAsync = async (app) => {
     try {
       const ctx = await getApiTokenContextForRequest(request);
       const { key } = request.params as { key: string };
-      const documents = await listRagDocuments(ctx.tenantDbName, key, {});
-      return reply.code(200).send({ documents });
+      // A module's corpus grows with every ingest and each row carries its
+      // source text, so this returns a page rather than the whole collection.
+      const page = readPagination(request.query);
+      const [documents, total] = await Promise.all([
+        listRagDocuments(ctx.tenantDbName, key, page),
+        countRagDocuments(ctx.tenantDbName, key),
+      ]);
+      return reply.code(200).send({
+        documents,
+        pagination: paginationMeta(page, { total }),
+      });
     } catch (error) {
       logger.error('List client RAG documents error', { error });
       return reply.code(500).send({

--- a/src/server/api/plugins/client-tools.ts
+++ b/src/server/api/plugins/client-tools.ts
@@ -2,6 +2,7 @@ import type { FastifyPluginAsync } from 'fastify';
 import type { IToolAuthConfig } from '@/lib/database';
 import type { SpecFormatHint } from '@/lib/services/specImport';
 import { createLogger } from '@/lib/core/logger';
+import { overfetchLimit, paginationMeta, readPagination, takePage } from '@/lib/api/pagination';
 import {
   createTool,
   deleteTool,
@@ -27,13 +28,18 @@ export const clientToolsApiPlugin: FastifyPluginAsync = async (app) => {
     try {
       const ctx = await getApiTokenContextForRequest(request);
       const query = (request.query ?? {}) as { status?: 'active' | 'disabled'; type?: 'mcp' | 'openapi' };
-      const tools = await listTools(ctx.tenantDbName, {
+      const page = readPagination(request.query);
+      const fetched = await listTools(ctx.tenantDbName, {
         projectId: ctx.projectId,
         ...(query.status ? { status: query.status } : {}),
         ...(query.type ? { type: query.type } : {}),
+        limit: overfetchLimit(page),
+        offset: page.offset,
       });
+      const { items: tools, hasMore } = takePage(fetched, page);
 
       return reply.code(200).send({
+        pagination: paginationMeta(page, { hasMore }),
         tools: tools.map((tool) => ({
           actions: tool.actions.map((action) => ({
             description: action.description,

--- a/src/server/api/plugins/client-tracing.ts
+++ b/src/server/api/plugins/client-tracing.ts
@@ -816,7 +816,7 @@ export const clientTracingApiPlugin: FastifyPluginAsync = async (app) => {
             events: insertedEvents,
           });
         }
-      });
+      }, { droppable: true });
 
       return reply.code(200).send({
         eventsStored: mapped.events.length,
@@ -1077,7 +1077,7 @@ export const clientTracingApiPlugin: FastifyPluginAsync = async (app) => {
           events: createdEvents,
           previousEvents,
         });
-      });
+      }, { droppable: true });
 
       return reply.code(200).send({
         eventsStored: events.length,
@@ -1221,7 +1221,7 @@ export const clientTracingApiPlugin: FastifyPluginAsync = async (app) => {
             actorType: attribution.actorType,
           });
         }
-      });
+      }, { droppable: true });
 
       return reply.code(200).send({
         sessionId,
@@ -1357,7 +1357,7 @@ export const clientTracingApiPlugin: FastifyPluginAsync = async (app) => {
           reasoningTokens: diagnostics.reasoningTokens,
           toolsUsed: collectEventToolNames(event),
         }, ctx.projectId);
-      });
+      }, { droppable: true });
 
       return reply.code(200).send({
         eventId: event.id,
@@ -1460,7 +1460,7 @@ export const clientTracingApiPlugin: FastifyPluginAsync = async (app) => {
           totalInputTokens: getSummaryNumber(mergedSummary, 'totalInputTokens'),
           totalOutputTokens: getSummaryNumber(mergedSummary, 'totalOutputTokens'),
         }, ctx.projectId);
-      });
+      }, { droppable: true });
 
       return reply.code(200).send({
         durationMs,

--- a/src/server/api/plugins/rag.ts
+++ b/src/server/api/plugins/rag.ts
@@ -1,6 +1,7 @@
 import { Buffer } from 'node:buffer';
 import type { FastifyPluginAsync, FastifyReply } from 'fastify';
 import { createLogger } from '@/lib/core/logger';
+import { paginationMeta, readPagination } from '@/lib/api/pagination';
 import type { IRagChunkConfig, IRagDocument, IRagModule, IUser } from '@/lib/database';
 import {
   aggregateRagQueryScoreDistribution,
@@ -12,6 +13,7 @@ import {
   getRagModule,
   ingestDocument,
   ingestFile,
+  countRagDocuments,
   listRagDocuments,
   listRagModules,
   listRagQueryLogs,
@@ -428,12 +430,25 @@ export const ragApiPlugin: FastifyPluginAsync = async (app) => {
       const { projectId, session } = await requireProjectContextForRequest(request);
       const { key } = request.params as { key: string };
       const query = (request.query ?? {}) as { search?: string };
-      const documents = await listRagDocuments(session.tenantDbName, key, {
-        projectId,
-        search: query.search,
-      });
+      // Each row carries its source text, so an unpaged list of a large
+      // module's corpus is megabytes of response and heap.
+      const page = readPagination(request.query);
+      const [documents, total] = await Promise.all([
+        listRagDocuments(session.tenantDbName, key, {
+          projectId,
+          search: query.search,
+          ...page,
+        }),
+        countRagDocuments(session.tenantDbName, key, {
+          projectId,
+          search: query.search,
+        }),
+      ]);
 
-      return reply.code(200).send({ documents });
+      return reply.code(200).send({
+        documents,
+        pagination: paginationMeta(page, { total }),
+      });
     } catch (error) {
       logger.error('List RAG documents error', { error });
       return sendProjectContextError(reply, error)


### PR DESCRIPTION
## Summary

A second pass over the load path, this time on what a request actually touches on its way through the gateway — Model Hub, Knowledge Engine, and the work each of them queues behind the response. Every item here is a place with **no ceiling** rather than a wrong one: a lookup repeated per call, a fan-out sized by user data, a backlog that grows with the request rate, a list that returns a whole collection.

**Stacked on #237** — it shares files with that branch (`quotaGuard`, `ragService`), so basing it on `main` would only manufacture conflicts. Review after #237; it retargets to `main` cleanly once that merges.

## Changes

- **Provider rows are cached** (`PROVIDER_RECORD_CACHE_TTL_SECONDS`, default 60). The SDK client was already pooled, but the row describing it was re-read on every call — one Knowledge Engine query (embedding → vector store → reranker) spent three uncached reads before doing any work. What's cached is the row **as stored**: `credentialsEnc` stays sealed under `PROVIDER_ENCRYPTION_SECRET`, decryption stays per call, plaintext credentials are never cached (test asserts this). Provider create/update/delete invalidate every affected project key; TTL `0` keeps the ciphertext out of the cache backend entirely.

- **Guardrail configs are cached** (`GUARDRAIL_CONFIG_CACHE_TTL_SECONDS`, default 30). A guarded model resolved its guardrail on the request path — twice when both an input and an output guardrail are set — and went to the database each time. Guardrail edits invalidate.

- **Parent-window retrieval is bounded** — the sharpest one. Expansion reads a whole document per matched chunk (up to `INLINE_SOURCE_MAX_CHARS` = 250k inline, or a full object download beyond that), and did so for every match of every query: no cap, unbounded `Promise.all`, no reuse. A `topK`-20 query spanning 20 documents pulled megabytes of text into heap to compute windows it had computed a second earlier. Now capped (`RAG_PARENT_SOURCE_MAX_DOCUMENTS`, 25), bounded in flight (`…_CONCURRENCY`, 4), and cached (`…_CACHE_TTL_SECONDS`, 60; only sources under `…_CACHE_MAX_CHARS` are cached, so the fix doesn't trade read amplification for a memory problem). When the cap truncates it **logs** — the remaining matches keep their chunk text rather than silently returning narrower context.

- **Background work is queued, not started on arrival.** Every usage write, audit row and trace payload became a live promise in an unbounded `Set`: the backlog grew with the request rate, competed with foreground queries for the same 10-connection pool, and held trace bodies (up to `TRACING_MAX_BODY_SIZE_MB`) in heap until it drained. Now a bounded number of runners (`ASYNC_TASK_MAX_CONCURRENT`, 32) drains a queue. Shedding is opt-in per call site: telemetry (trace ingest, `token-last-used`) is `droppable` and sheds oldest-first past `ASYNC_TASK_MAX_QUEUED`; **usage, billing and audit writes are always kept** — losing them corrupts records the product bills and answers audits from.

- **Rate-limit counters are written as one batch.** A guarded request touches a counter per metric per window — up to 25 — and issuing them separately let one caller hold every pool connection while its own limits were checked. New `incrementRateLimits` / `incrementCounters` on both contracts: MongoDB does one `bulkWrite` + one read-back, Redis one pipeline, the in-process providers keep looping (no round trip there to save). Behaviour note: the batch now fails as a unit where individual counters used to fail one at a time — "enforcement unavailable" is the same answer either way, and a partially-applied set would leave the windows disagreeing about how much of the request was counted.

- **Pagination on the list endpoints that grow with usage.** Knowledge Engine documents (client + dashboard), agents, tools and prompts returned whole collections; they now take `limit`/`offset` through a shared helper (default 100, max 500) and return `pagination` metadata. Where a count query filters identically to its list it reports `total` — `countRagDocuments` was realigned to match `listRagDocuments` for exactly this reason, since a total derived from different filters is worse than none. Elsewhere it reads one row past the window (`takePage`), which is cheaper and cannot drift.

**Deliberately not paged:** `/client/v1/models` serves the OpenAI-compatible discovery list, which SDK clients expect whole. Batches already had a bounded default (50, max 500). The remaining list endpoints (projects, members, license, providers, budgets, automations) are admin-managed and bounded by configuration rather than usage — say the word and I'll extend the same helper to them.

⚠️ **Behaviour change:** the four paged endpoints now default to 100 rows where they previously returned everything. `pagination.hasMore`/`total` make the truncation visible, and both are documented in `openapi.yaml`.

## Validation

- [x] `npm run lint` — 0 errors (164 pre-existing warnings)
- [x] `npm run test` — 3694 passed, 0 failures. 5 test *files* fail to start because `mongodb-memory-server` cannot download its binary in this sandbox (403/502 from `fastdl.mongodb.org`); identical on a clean checkout, and the `[sqlite]` halves of the same parity suites pass, which is what exercises the new SQLite pagination.
- [x] `npm run build`
- [x] `npm run docs:build`
- [x] `npm run test:endpoints` — 217 uncovered / 137 new, byte-identical to the base branch.

31 new tests: the provider and guardrail caches (including that nothing decrypted is cached), the background queue's ceiling, shedding order and never-shed guarantee, the batched counters (one call, correct rejection, fail-closed, provider routing), the parent-window cap, and the pagination helpers. The shared test setup now clears the core cache between cases — request-path caches outlive a single test in one process, and one case's fixtures must not answer the next one's reads.

## Release Notes

- [x] Docs updated when behavior changed — `.env.example` (11 new settings), `openapi.yaml` (pagination params on four endpoints)
- [x] Security-sensitive changes reviewed — the provider cache stores only the sealed credential blob, never plaintext; a decrypt failure drops the cached row before retrying so a rotation cannot be masked by a stale entry
- [ ] License or policy files updated if repo-facing behavior changed — not applicable

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ltao83ZEHPKrpAQZv3n5z1)_