### PR TITLE
docs: add optional Parallel Search MCP setup

### DIFF
--- a/docs/api/mcp.md
+++ b/docs/api/mcp.md
@@ -4,6 +4,38 @@ Connect to external MCP (Model Context Protocol) servers and execute tools throu
 
 ## Direct Tool Execution
 
+### Optional Parallel Search MCP setup
+
+Parallel Search MCP can be added as a separate, optional remote server alongside existing servers such as Tavily. In the dashboard, create a new MCP server with these settings:
+
+| Field | Value |
+|-------|-------|
+| Source type | Remote |
+| Name | `parallel-search` |
+| Key | `parallel-search` |
+| MCP server URL | `https://search.parallel.ai/mcp` |
+| Upstream transport | Streamable HTTP (`streamable-http`) |
+| Upstream authentication | None |
+
+The default Parallel endpoint requires no upstream API key, but this does not remove Cognipeer gateway authentication. Calls to `/api/client/v1/mcp/parallel-search/*` still require the gateway `Authorization` header shown below and remain subject to the gateway's existing security and access controls. Adding the server and invoking its tools are explicit user choices; this setup does not change any provider or default.
+
+When Parallel tools are used, user-provided search objectives, search queries, and requested URLs are sent to Parallel. See the [Parallel Search MCP documentation](https://docs.parallel.ai/integrations/mcp/search-mcp) for details.
+
+For example, after adding the server, invoke `web_search` through the authenticated gateway:
+
+```bash
+curl -X POST https://gateway.example.com/api/client/v1/mcp/parallel-search/execute \
+  -H "Authorization: Bearer cpeer_your_token" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "tool": "web_search",
+    "arguments": {
+      "objective": "Find the latest official Model Context Protocol specification updates.",
+      "search_queries": ["site:modelcontextprotocol.io specification updates"]
+    }
+  }'
+```
+
 ### List Server Tools
 
 ```


### PR DESCRIPTION
## Summary

Document an optional Parallel Search MCP setup using Cognipeer Console's existing remote MCP source flow. The setup is explicitly opt-in, uses Parallel's no-key upstream endpoint, and continues to require Cognipeer gateway authorization for gateway requests.

## Changes

- Add dashboard settings for a separate `parallel-search` remote MCP server using Streamable HTTP with no upstream authentication.
- Add an authenticated gateway `web_search` example with both `objective` and `search_queries`.
- Preserve existing providers, configuration, security controls, and defaults.
- Disclose that user-provided search objectives, search queries, and requested URLs are sent to Parallel when its tools are explicitly used.

## Validation

- [x] `git diff --check`

## Release Notes

- [x] Docs updated when behavior changed
- [ ] Security-sensitive changes reviewed
- [ ] License or policy files updated if repo-facing behavior changed

Disclosure: I work at Parallel.ai, which operates this MCP endpoint.