### PR TITLE
fix(models): drop reasoning_effort when a call carries function tools

### DIFF
--- a/src/__tests__/unit/model-request-parameters.test.ts
+++ b/src/__tests__/unit/model-request-parameters.test.ts
@@ -322,6 +322,70 @@ describe('automatic detection — the drop_params equivalent', () => {
   });
 });
 
+describe('reasoning_effort + function tools — upstream 400s the combination', () => {
+  // gpt-5.6-terra confirmed: "Function tools with reasoning_effort are not
+  // supported ... To use function tools, use /v1/responses or set
+  // reasoning_effort to 'none'." The console does not proxy /v1/responses, so
+  // the gateway has to drop reasoning_effort itself whenever tools are present.
+  it('is unaffected without tools', () => {
+    expect(detectUnsupportedParams('openai', 'gpt-5.6-luna', false).params)
+      .not.toContain('reasoning_effort');
+  });
+
+  it('is dropped once the call carries tools', () => {
+    expect(detectUnsupportedParams('openai', 'gpt-5.6-luna', true).params)
+      .toEqual(expect.arrayContaining(['reasoning', 'reasoning_effort']));
+  });
+
+  it('keeps reasoning_effort out of the constructed model when tools are present', () => {
+    const config = resolveModelInvocationConfig(
+      { settings: {}, modelId: 'gpt-5.6-luna', providerDriver: 'openai' },
+      {
+        messages: [],
+        reasoning_effort: 'high',
+        tools: [{ type: 'function', function: { name: 'search' } }],
+      },
+    );
+
+    expect(config.modelSettings.reasoning).toBeUndefined();
+    expect(config.unsupportedParams).toEqual(expect.arrayContaining(['reasoning', 'reasoning_effort']));
+  });
+
+  it('still applies reasoning_effort on a tool-free call', () => {
+    const config = resolveModelInvocationConfig(
+      { settings: {}, modelId: 'gpt-5.6-luna', providerDriver: 'openai' },
+      { messages: [], reasoning_effort: 'high' },
+    );
+
+    expect(config.modelSettings.reasoning).toEqual({ effort: 'high' });
+  });
+
+  it('drops it end-to-end once bound to a real gpt-5 model id', () => {
+    constructed.length = 0;
+    const runtime = OpenAiCompatibleModelProviderContract.createRuntime({
+      tenantId: 't1',
+      providerKey: 'p1',
+      credentials: { apiKey: 'sk-test' },
+      settings: { baseUrl: 'https://api.openai.com/v1' },
+      metadata: {},
+      logger: console,
+    } as never) as ModelProviderRuntime;
+
+    const { modelSettings } = resolveModelInvocationConfig(
+      { settings: {}, modelId: 'gpt-5.6-luna', providerDriver: 'openai-compatible' },
+      {
+        messages: [],
+        reasoning_effort: 'high',
+        tools: [{ type: 'function', function: { name: 'search' } }],
+      },
+    );
+
+    runtime.createChatModel!({ modelId: 'gpt-5.6-luna', category: 'llm', modelSettings });
+
+    expect(constructed[0].reasoning).toBeUndefined();
+  });
+});
+
 describe('buildPassthroughBody — what a caller may add to the upstream body', () => {
   const settings = (extra: Record<string, unknown> = {}) => ({
     requestDefaults: { chat_template_kwargs: { enable_thinking: false, tool_prompt: 'x' } },

--- a/src/app/dashboard/models/[id]/edit/page.tsx
+++ b/src/app/dashboard/models/[id]/edit/page.tsx
@@ -630,6 +630,9 @@ export default function EditModelPage() {
                   {...form.getInputProps('modelId')}
                 />
               </Grid.Col>
+            </Grid>
+
+            <Grid>
               <Grid.Col span={{ base: 12, md: 6 }}>
                 <TextInput
                   label={tWizard('fields.currency.label')}
@@ -657,7 +660,7 @@ export default function EditModelPage() {
                     min={0}
                     value={form.values.pricing.inputTokenPer1M}
                     onChange={(value) => form.setFieldValue('pricing.inputTokenPer1M', Number(value) || 0)}
-                    thousandSeparator="," 
+                    thousandSeparator=","
                   />
                 </Grid.Col>
                 <Grid.Col span={{ base: 12, md: 4 }}>
@@ -666,7 +669,7 @@ export default function EditModelPage() {
                     min={0}
                     value={form.values.pricing.outputTokenPer1M}
                     onChange={(value) => form.setFieldValue('pricing.outputTokenPer1M', Number(value) || 0)}
-                    thousandSeparator="," 
+                    thousandSeparator=","
                   />
                 </Grid.Col>
                 <Grid.Col span={{ base: 12, md: 4 }}>
@@ -675,7 +678,7 @@ export default function EditModelPage() {
                     min={0}
                     value={form.values.pricing.cachedTokenPer1M}
                     onChange={(value) => form.setFieldValue('pricing.cachedTokenPer1M', Number(value) || 0)}
-                    thousandSeparator="," 
+                    thousandSeparator=","
                   />
                 </Grid.Col>
               </Grid>

--- a/src/lib/providers/unsupportedParams.ts
+++ b/src/lib/providers/unsupportedParams.ts
@@ -31,8 +31,17 @@ export interface UnsupportedParamRule {
   drivers: readonly string[];
   /** Matched against the upstream model id (not the Model Hub key). */
   match: RegExp;
-  /** Wire names the model rejects. */
+  /** Wire names the model rejects outright, regardless of the rest of the request. */
   params: readonly string[];
+  /**
+   * Wire names the model only rejects when the request also carries function
+   * tools (`tools`/`tool_choice`) — e.g. OpenAI's newer reasoning models 400 on
+   * `reasoning`/`reasoning_effort` together with tools on `/v1/chat/completions`
+   * ("use /v1/responses, or set reasoning_effort to 'none'"). Kept separate from
+   * `params` because the parameter works fine — and callers rely on it — for a
+   * tool-free request.
+   */
+  paramsWithTools?: readonly string[];
   /** Shown in the UI next to the detected parameters. */
   reason: string;
 }
@@ -62,7 +71,12 @@ export const UNSUPPORTED_PARAM_RULES: readonly UnsupportedParamRule[] = [
     // `gpt-5-chat` is the non-reasoning variant and keeps the normal knobs.
     match: /^gpt-5(?!-chat)/,
     params: ['temperature', 'top_p', 'max_tokens'],
-    reason: 'GPT-5 family: only the default temperature and top_p are accepted, and max_tokens was replaced by max_completion_tokens',
+    // Confirmed on gpt-5.6-terra: /v1/chat/completions 400s with "Function tools
+    // with reasoning_effort are not supported ... To use function tools, use
+    // /v1/responses or set reasoning_effort to 'none'." The console does not proxy
+    // /v1/responses, so the only safe move on this endpoint is to drop it.
+    paramsWithTools: ['reasoning', 'reasoning_effort'],
+    reason: 'GPT-5 family: only the default temperature and top_p are accepted, max_tokens was replaced by max_completion_tokens, and reasoning_effort cannot be combined with function tools on /v1/chat/completions (upstream requires /v1/responses, or reasoning_effort:"none")',
   },
 ];
 
@@ -80,10 +94,14 @@ const EMPTY: DetectedUnsupportedParams = { params: [] };
 /**
  * Parameters the given model is known to reject. Returns an empty list — never
  * throws — for any driver or model the registry says nothing about.
+ *
+ * `hasTools` folds in a rule's `paramsWithTools` — pass `true` only when this
+ * particular call carries function tools, since those params are otherwise fine.
  */
 export function detectUnsupportedParams(
   driver: string | undefined,
   modelId: string | undefined,
+  hasTools = false,
 ): DetectedUnsupportedParams {
   if (!driver || !modelId) return EMPTY;
 
@@ -93,7 +111,11 @@ export function detectUnsupportedParams(
 
   if (!rule) return EMPTY;
 
-  return { params: [...rule.params], reason: rule.reason, ruleId: rule.id };
+  const params = hasTools && rule.paramsWithTools
+    ? [...rule.params, ...rule.paramsWithTools]
+    : [...rule.params];
+
+  return { params, reason: rule.reason, ruleId: rule.id };
 }
 
 /**
@@ -106,10 +128,11 @@ export function resolveUnsupportedParamNames(input: {
   modelId?: string;
   manual?: unknown;
   autoDetect?: unknown;
+  hasTools?: boolean;
 }): { params: string[]; detected: DetectedUnsupportedParams } {
   const detected = input.autoDetect === false
     ? EMPTY
-    : detectUnsupportedParams(input.driver, input.modelId);
+    : detectUnsupportedParams(input.driver, input.modelId, input.hasTools);
 
   const manual = Array.isArray(input.manual)
     ? input.manual.filter((entry): entry is string => typeof entry === 'string')

--- a/src/lib/services/models/inferenceService.ts
+++ b/src/lib/services/models/inferenceService.ts
@@ -737,6 +737,7 @@ export function resolveModelInvocationConfig(
   unsupportedParams: string[];
 } {
   const settings = asRecord(model.settings);
+  const hasTools = Array.isArray(body.tools) && body.tools.length > 0;
 
   // Resolved here as well as in the contract layer, because the passthrough body
   // is assembled here and must not smuggle back a parameter the provider is
@@ -746,18 +747,24 @@ export function resolveModelInvocationConfig(
     modelId: model.modelId,
     manual: settings.unsupportedParams,
     autoDetect: settings.autoDropUnsupportedParams,
+    hasTools,
   });
+  const blockedLower = new Set(unsupportedParams.map((name) => name.toLowerCase()));
 
   const overrides = buildOverrides(body);
   const modelSettings = buildChatModelSettings(model.settings, overrides);
-  const extraBody = buildPassthroughBody(
-    model.settings,
-    body,
-    new Set(unsupportedParams.map((name) => name.toLowerCase())),
-  );
+  const extraBody = buildPassthroughBody(model.settings, body, blockedLower);
 
   if (extraBody) {
     modelSettings.extraBody = extraBody;
+  }
+
+  // `reasoning`/`reasoning_effort` is a call-level field the constructor
+  // wiring (openAiChatOverrides) always forwards, so — unlike the other
+  // unsupported params, which get filtered in the contract layer — it has to
+  // be dropped here, before it ever lands in modelSettings.
+  if (blockedLower.has('reasoning') || blockedLower.has('reasoning_effort')) {
+    delete modelSettings.reasoning;
   }
 
   // Stripping silently changes sampling behaviour, so leave a trace of which


### PR DESCRIPTION
## Summary
- gpt-5.6-terra 400s on `/v1/chat/completions` when `reasoning_effort` is combined with function tools ("use `/v1/responses`, or set `reasoning_effort` to `'none'`"). The console doesn't proxy `/v1/responses`, so this drops `reasoning`/`reasoning_effort` from the outgoing request whenever `tools` is present, via the existing unsupported-params mechanism (new `paramsWithTools` rule field).
- Tool-free calls are unaffected — `reasoning_effort` still applies normally.

## Test plan
- [x] `npx vitest run src/__tests__/unit/model-request-parameters.test.ts` — 38/38 passing (5 new cases covering the tools/no-tools split, end-to-end runtime construction)

🤖 Generated with [Claude Code](https://claude.com/claude-code)