### PR TITLE
docs: redirect GitHub Pages site to docs.cognipeer.com

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,14 +1,17 @@
-name: Deploy Documentation
+name: Deploy Documentation Redirect
+
+# The documentation for this package now lives at docs.cognipeer.com.
+# This workflow publishes a two-file redirect site in place of the old
+# VitePress build: GitHub Pages serves 404.html for any unmatched path,
+# so deep links are forwarded, not just the homepage.
 
 on:
   push:
     branches:
       - main
     paths:
-      - 'docs/**'
+      - 'docs-redirect/**'
       - '.github/workflows/deploy-docs.yml'
-      - 'package.json'
-      - 'package-lock.json'
   workflow_dispatch:
 
 permissions:
@@ -21,42 +24,23 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: npm
-
-      - name: Setup Pages
-        uses: actions/configure-pages@v4
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Build with VitePress
-        run: npm run docs:build
-
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: docs/.vitepress/dist
-
   deploy:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    needs: build
     runs-on: ubuntu-latest
-    name: Deploy
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+
+      - name: Upload redirect site
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs-redirect
+
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ See [openapi.yaml](openapi.yaml) for the full API specification.
 If you are building an application against Cognipeer Console, prefer the official TypeScript/JavaScript SDK:
 
 - SDK repo: [console-sdk](https://github.com/Cognipeer/console-sdk)
-- SDK docs: [cognipeer.github.io/console-sdk](https://cognipeer.github.io/console-sdk/)
+- SDK docs: [docs.cognipeer.com/console-sdk](https://docs.cognipeer.com/console-sdk/)
 
 Use this repository and its docs for platform setup, deployment, providers, tenancy, auth, and raw HTTP API semantics.
 

--- a/docs-redirect/404.html
+++ b/docs-redirect/404.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Documentation has moved</title>
+<meta name="robots" content="noindex">
+<link rel="canonical" href="https://docs.cognipeer.com/console/">
+<script>
+(function () {
+  var base = "/console/";
+  var path = location.pathname;
+  var p = path.indexOf(base) === 0 ? path.slice(base.length) : "";
+  p = p.replace(/^\/+/, "").replace(/\.html$/, "");
+  var target = (function(){if(/^api\//.test(p)) return 'console/developer/api/' + p.slice(4);if(/^how-to\//.test(p)) return 'console/guide/how-to/' + p.slice(7);if(/^releases\//.test(p)) return 'release-notes/console/' + p.slice(9);if(/^contributing/.test(p)) return 'console/developer/contributing';if(/^guide\/(architecture|sdk-integration|core-)/.test(p)) return 'console/developer/' + p.slice(6);if(/^guide\//.test(p)) return 'console/guide/' + p.slice(6);return 'console/' + p;})();
+  location.replace("https://docs.cognipeer.com/" + target + location.hash);
+})();
+</script>
+<p>This documentation now lives at <a href="https://docs.cognipeer.com/console/">docs.cognipeer.com</a>.</p>

--- a/docs-redirect/index.html
+++ b/docs-redirect/index.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Documentation has moved</title>
+<meta name="robots" content="noindex">
+<link rel="canonical" href="https://docs.cognipeer.com/console/">
+<script>
+(function () {
+  var base = "/console/";
+  var path = location.pathname;
+  var p = path.indexOf(base) === 0 ? path.slice(base.length) : "";
+  p = p.replace(/^\/+/, "").replace(/\.html$/, "");
+  var target = (function(){if(/^api\//.test(p)) return 'console/developer/api/' + p.slice(4);if(/^how-to\//.test(p)) return 'console/guide/how-to/' + p.slice(7);if(/^releases\//.test(p)) return 'release-notes/console/' + p.slice(9);if(/^contributing/.test(p)) return 'console/developer/contributing';if(/^guide\/(architecture|sdk-integration|core-)/.test(p)) return 'console/developer/' + p.slice(6);if(/^guide\//.test(p)) return 'console/guide/' + p.slice(6);return 'console/' + p;})();
+  location.replace("https://docs.cognipeer.com/" + target + location.hash);
+})();
+</script>
+<p>This documentation now lives at <a href="https://docs.cognipeer.com/console/">docs.cognipeer.com</a>.</p>


### PR DESCRIPTION
The docs for every Cognipeer product and package now live at docs.cognipeer.com.

This replaces the repo GitHub Pages site with a redirect so existing links keep working. GitHub Pages serves 404.html for any unmatched path, so deep links forward too, not just the homepage.

- docs-redirect/ holds the two-file redirect site
- deploy-docs.yml publishes it instead of building VitePress
- README links point at the new location
- The pre-migration commit is tagged docs-archive

The docs/ tree is left in place; its content is copied into the hub, so edit it there.

Opened as a PR rather than pushed to main because this repo had unrelated work in flight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V16gWNPn72UZX9G8ZGeK4z