### PR TITLE
fix: align internal trace types for release build

### DIFF
--- a/src/lib/services/agents/agentService.ts
+++ b/src/lib/services/agents/agentService.ts
@@ -109,6 +109,8 @@ type InternalTraceEvent = TraceSessionFile['events'][number] & {
     toolName?: string;
     usage?: Record<string, unknown>;
     metadata?: Record<string, unknown> & { usage?: Record<string, unknown> };
+    finishReason?: string;
+    reasoningTokens?: number;
     sections?: unknown[];
     data?: { sections?: unknown[] };
     modelNames?: string[];
@@ -118,6 +120,7 @@ type InternalTraceEvent = TraceSessionFile['events'][number] & {
 
 type InternalTraceSession = Omit<TraceSessionFile, 'events'> & {
     events: InternalTraceEvent[];
+    metadata?: Record<string, string>;
 };
 
 type CreateConsoleSdkAgentInput = {


### PR DESCRIPTION
## Summary
- declare optional internal trace diagnostics used by the agent sink
- keep session metadata compatible with the tracing database contract

## Validation
- `npx tsc --noEmit`
- enterprise overlay `npx tsc --noEmit`
- enterprise `npm run build`