### PR TITLE
feat(cost): add Forecast sub-nav entry

### DIFF
--- a/src/components/layout/launcher/ServiceSubNav.tsx
+++ b/src/components/layout/launcher/ServiceSubNav.tsx
@@ -46,6 +46,7 @@ import {
   IconStackPush,
   IconTimeline,
   IconTool,
+  IconTrendingUp,
   IconVector,
   IconVolume,
   IconWorld,
@@ -279,6 +280,7 @@ export const SUBNAV_CONFIG: Record<string, SubNavItem[]> = {
           !p.startsWith('/dashboard/cost/agents') &&
           !p.startsWith('/dashboard/cost/pricing') &&
           !p.startsWith('/dashboard/cost/reports') &&
+          !p.startsWith('/dashboard/cost/forecast') &&
           !p.startsWith('/dashboard/cost/recommendations') &&
           !p.startsWith('/dashboard/cost/analysis') &&
           !p.startsWith('/dashboard/cost/prescriptions') &&
@@ -337,6 +339,13 @@ export const SUBNAV_CONFIG: Record<string, SubNavItem[]> = {
       href: '/dashboard/cost/reports',
       icon: IconReportAnalytics,
       matcher: (p) => p.startsWith('/dashboard/cost/reports'),
+    },
+    {
+      id: 'forecast',
+      label: 'Forecast',
+      href: '/dashboard/cost/forecast',
+      icon: IconTrendingUp,
+      matcher: (p) => p.startsWith('/dashboard/cost/forecast'),
     },
   ],
   vector: [


### PR DESCRIPTION
## Summary
- Adds a "Forecast" item under Cost & Optimization in the dashboard sub-nav, linking to `/dashboard/cost/forecast`.
- Excludes the new path from the "Model costs" default sub-nav matcher, matching the existing pattern for every other cost sub-page.

Pairs with Cognipeer/console-ee#feat/cost-forecast (the actual forecast page + API, which lives in the EE overlay).

## Test plan
- [x] `tsc --noEmit` clean on the merged overlay+community tree
- [ ] Manual: confirm "Forecast" appears under Cost & Optimization and routes correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H5HPzNcveP1buArrZ5cUeJ