### PR TITLE
ci: authenticate release dispatch with GitHub App

### DIFF
--- a/.github/workflows/build-community.yml
+++ b/.github/workflows/build-community.yml
@@ -52,16 +52,25 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Create release automation token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.RELEASE_AUTOMATION_APP_ID }}
+          private-key: ${{ secrets.RELEASE_AUTOMATION_PRIVATE_KEY }}
+          owner: Cognipeer
+          repositories: console-ee
+
       - name: Update Console Enterprise compatibility pin
         env:
-          DISPATCH_TOKEN: ${{ secrets.CONSOLE_EE_DISPATCH_PAT }}
+          DISPATCH_TOKEN: ${{ steps.app-token.outputs.token }}
           COMMUNITY_TAG: ${{ github.ref_name }}
           COMMUNITY_SHA: ${{ needs.build.outputs.commit_sha }}
         run: |
           set -euo pipefail
 
           if [[ -z "${DISPATCH_TOKEN}" ]]; then
-            echo "::error::CONSOLE_EE_DISPATCH_PAT is not configured."
+            echo "::error::GitHub release automation App token is not available."
             exit 1
           fi
 

--- a/.github/workflows/build-deploy.yaml
+++ b/.github/workflows/build-deploy.yaml
@@ -78,15 +78,5 @@
 #             ${{ steps.ecr.outputs.registry }}/${{ secrets.LOCAL_FIRST_REPOSITORY }}:${{ steps.vars.outputs.tag }}
 #             ${{ secrets.LOGIN_SERVER }}/${{ secrets.LOCAL_SECOND_REPOSITORY }}:${{ steps.vars.outputs.tag }}
 
-#   notify:
-#     runs-on: ubuntu-latest
-#     needs: build
-#     steps:
-#       - name: Fire repository_dispatch
-#         run: |
-#           curl --fail-with-body -X POST \
-#             -H "Authorization: Bearer ${{ secrets.REPO_PAT_TO_DEPLOY }}" \
-#             -H "Accept: application/vnd.github+json" \
-#             -H "Content-Type: application/json" \
-#             https://api.github.com/repos/${{secrets.TENANT_REPO_ADDRESS}}/dispatches \
-#             -d "{\"event_type\":\"app-released\",\"client_payload\":{\"image_tag\":\"${{ needs.build.outputs.image_tag }}\",\"source_ref\":\"${GITHUB_REF_NAME}\"}}"
+# The legacy workflow is disabled. Active release workflows use GitHub App
+# installation tokens for cross-repository operations.


### PR DESCRIPTION
## Summary
- replace the Community-to-Console-EE PAT dispatch with a short-lived GitHub App installation token
- keep GHCR publishing on the built-in workflow token
- remove the stale commented PAT dispatch example

## Required organization secrets
- `RELEASE_AUTOMATION_APP_ID`
- `RELEASE_AUTOMATION_PRIVATE_KEY`

The App must be installed on `Cognipeer/console-ee` with contents read/write and metadata read permissions.