### PR TITLE
fix(ci): grant App dispatch write access

### DIFF
--- a/.github/workflows/build-community.yml
+++ b/.github/workflows/build-community.yml
@@ -60,6 +60,8 @@ jobs:
           private-key: ${{ secrets.RELEASE_AUTOMATION_PRIVATE_KEY }}
           owner: Cognipeer
           repositories: console-ee
+          permission-contents: write
+          permission-metadata: read
 
       - name: Update Console Enterprise compatibility pin
         env:


### PR DESCRIPTION
## Summary
- request `Contents: write` for the release automation App token used by `repository_dispatch`
- keep the Community-to-Console-EE dispatch PAT-free

## Why
The App token could be created, but the current Community scope requested only read access to Console EE contents. The dispatch job completed without a corresponding Console EE sync run.

## Validation
- workflow YAML parsed
- diff check passed

After merging, resend the existing v1.2.47 Community release event; no Community rebuild is required.