### PR TITLE
Add on-prem single-database mode for MongoDB

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,10 @@ SQLITE_DATA_DIR=./data/sqlite                      # SQLite data directory
 # MONGODB_CONNECT_TIMEOUT_MS=10000                  # Connection timeout (ms)
 # MONGODB_SOCKET_TIMEOUT_MS=45000                   # Socket timeout (ms)
 # MONGODB_SERVER_SELECTION_TIMEOUT_MS=30000          # Server selection timeout (ms)
+# MONGODB_SINGLE_DATABASE=                          # true|false. Keep tenant collections in MAIN_DB_NAME instead of a
+#                                                    # separate tenant_{slug} database. Defaults to true when
+#                                                    # DEPLOYMENT_MODE=onprem (below), false otherwise. On-prem deployments
+#                                                    # are single-organization, so this is safe; a second tenant is refused.
 
 # ---- Authentication ------------------------------------------
 JWT_SECRET=                                        # (required) JWT signing secret — min 32 random chars (e.g. `openssl rand -hex 32`)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,14 @@ services:
       - SUPPORT_BASE_URL=${SUPPORT_BASE_URL:-}
       - SUPPORT_CRM_API_URL=${SUPPORT_CRM_API_URL:-}
       - SUPPORT_HANDOFF_SECRET=${SUPPORT_HANDOFF_SECRET:-}
+      # On-prem, single-organization bootstrap: set REGISTRATION_MODE=disabled
+      # in your environment/.env and fill these to create the one organization
+      # + owner user on first boot instead of leaving public signup open.
+      - REGISTRATION_MODE=${REGISTRATION_MODE:-open}
+      - BOOTSTRAP_ORG_NAME=${BOOTSTRAP_ORG_NAME:-}
+      - BOOTSTRAP_ADMIN_EMAIL=${BOOTSTRAP_ADMIN_EMAIL:-}
+      - BOOTSTRAP_ADMIN_PASSWORD=${BOOTSTRAP_ADMIN_PASSWORD:-}
+      - BOOTSTRAP_ADMIN_NAME=${BOOTSTRAP_ADMIN_NAME:-Administrator}
     volumes:
       - app-data:/app/data
     restart: unless-stopped
@@ -31,6 +39,9 @@ services:
 
   # ── Optional: MongoDB (uncomment to use MongoDB instead of SQLite) ──
   # Requires: DB_PROVIDER=mongodb and MONGODB_URI=mongodb://mongo:27017
+  # On-prem (DEPLOYMENT_MODE=onprem, the default above) tenant data is kept in
+  # the same physical database as MAIN_DB_NAME — no separate tenant_{slug}
+  # database is created. Override with MONGODB_SINGLE_DATABASE=false to opt out.
   #
   # mongo:
   #   image: mongo:7

--- a/src/lib/core/config.ts
+++ b/src/lib/core/config.ts
@@ -71,6 +71,16 @@ export interface AppConfig {
     connectTimeoutMs: number;
     socketTimeoutMs: number;
     serverSelectionTimeoutMs: number;
+    /**
+     * When true, tenant-scoped MongoDB operations are bound to the main
+     * database instead of a separate `tenant_{slug}` database. On-prem
+     * deployments are single-organization by construction (REGISTRATION_MODE
+     * disabled + BOOTSTRAP_* envs), so collapsing main+tenant collections into
+     * one physical database removes an extra database to provision/back up
+     * without any cross-tenant risk. Defaults on for onprem+mongodb; override
+     * with MONGODB_SINGLE_DATABASE for edge cases.
+     */
+    singleDatabase: boolean;
   };
 
   auth: {
@@ -359,6 +369,11 @@ function buildConfig(source: ConfigSource): AppConfig {
       connectTimeoutMs: int(source, 'MONGODB_CONNECT_TIMEOUT_MS', 10000),
       socketTimeoutMs: int(source, 'MONGODB_SOCKET_TIMEOUT_MS', 45000),
       serverSelectionTimeoutMs: int(source, 'MONGODB_SERVER_SELECTION_TIMEOUT_MS', 30000),
+      singleDatabase: bool(
+        source,
+        'MONGODB_SINGLE_DATABASE',
+        deploymentMode === 'onprem' && databaseProvider === 'mongodb',
+      ),
     },
 
     auth: {

--- a/src/lib/database/index.ts
+++ b/src/lib/database/index.ts
@@ -70,16 +70,21 @@ export async function getDatabase(): Promise<DatabaseProvider> {
       throw new Error('MONGODB_URI environment variable is not set');
     }
 
-    const provider = new MongoDBProvider(cfg.database.uri, cfg.database.mainDbName, {
-      minPoolSize: cfg.database.minPoolSize,
-      maxPoolSize: cfg.database.maxPoolSize,
-      connectTimeoutMS: cfg.database.connectTimeoutMs,
-      socketTimeoutMS: cfg.database.socketTimeoutMs,
-      serverSelectionTimeoutMS: cfg.database.serverSelectionTimeoutMs,
-    });
+    const provider = new MongoDBProvider(
+      cfg.database.uri,
+      cfg.database.mainDbName,
+      {
+        minPoolSize: cfg.database.minPoolSize,
+        maxPoolSize: cfg.database.maxPoolSize,
+        connectTimeoutMS: cfg.database.connectTimeoutMs,
+        socketTimeoutMS: cfg.database.socketTimeoutMs,
+        serverSelectionTimeoutMS: cfg.database.serverSelectionTimeoutMs,
+      },
+      cfg.database.singleDatabase,
+    );
     await provider.connect();
     dbProvider = provider;
-    log.info('MongoDB connected successfully');
+    log.info('MongoDB connected successfully', { singleDatabase: cfg.database.singleDatabase });
 
     // Register health check
     registerHealthCheck('mongodb', async () => {

--- a/src/lib/database/mongodb/base.ts
+++ b/src/lib/database/mongodb/base.ts
@@ -140,15 +140,25 @@ export class MongoDBProviderBase {
   protected readonly uri: string;
   protected readonly mainDbName: string;
   protected readonly clientOptions?: MongoClientOptions;
+  /**
+   * On-prem single-database mode: tenant operations bind to the main DB
+   * instead of a separate `tenant_{slug}` database. See `switchToTenant` /
+   * `runWithTenant`. Collection names never collide between `MAIN_DB_INDEXES`
+   * and `TENANT_DB_INDEXES` (indexManifest.ts), so this is safe as long as
+   * there is exactly one tenant — enforced in `TenantMixin.createTenant`.
+   */
+  protected readonly singleDatabase: boolean;
 
   constructor(
     uri: string,
     mainDbName: string = 'console_main',
     clientOptions?: MongoClientOptions,
+    singleDatabase: boolean = false,
   ) {
     this.uri = uri;
     this.mainDbName = mainDbName;
     this.clientOptions = clientOptions;
+    this.singleDatabase = singleDatabase;
   }
 
   // ── Connection lifecycle ─────────────────────────────────────────────
@@ -191,7 +201,10 @@ export class MongoDBProviderBase {
     if (!this.client) {
       throw new Error('Database client not connected. Call connect() first.');
     }
-    const tenantDb = this.client.db(tenantDbName);
+    // Single-database mode: the tenant handle IS the main DB. `tenantDbName`
+    // is kept only as the logical label (assertTenantContext, audit/logging) —
+    // it no longer names a distinct physical database.
+    const tenantDb = this.singleDatabase ? this.getMainDb() : this.client.db(tenantDbName);
     // First touch of this tenant DB in this process ensures its indexes once,
     // in the background. Memoized per process, so this is a cheap Set check on
     // every subsequent request — no per-request index work.
@@ -217,7 +230,8 @@ export class MongoDBProviderBase {
     if (!this.client) {
       throw new Error('Database client not connected. Call connect() first.');
     }
-    const tenantDb = this.client.db(tenantDbName);
+    // See switchToTenant: single-database mode binds the main DB handle.
+    const tenantDb = this.singleDatabase ? this.getMainDb() : this.client.db(tenantDbName);
     void ensureTenantDbIndexes(tenantDb, tenantDbName);
     return this.tenantContext.run(tenantDb, () =>
       this.tenantNameContext.run(tenantDbName, () => fn()),

--- a/src/lib/database/mongodb/tenant.mixin.ts
+++ b/src/lib/database/mongodb/tenant.mixin.ts
@@ -87,6 +87,20 @@ export function TenantMixin<TBase extends Constructor<MongoDBProviderBase>>(Base
       tenantData: Omit<ITenant, '_id' | 'createdAt' | 'updatedAt'>,
     ): Promise<ITenant> {
       const db = this.getMainDb();
+
+      if (this.singleDatabase) {
+        // In single-database mode there is no per-tenant physical database to
+        // isolate a second tenant's data — tenant-scoped collections carry no
+        // per-row tenant discriminator, so a second tenant would silently
+        // share (and corrupt) the first tenant's rows. Refuse instead.
+        const existingCount = await db.collection(COLLECTIONS.tenants).countDocuments();
+        if (existingCount > 0) {
+          throw new Error(
+            'Cannot create a second tenant: MONGODB_SINGLE_DATABASE mode supports exactly one tenant per deployment.',
+          );
+        }
+      }
+
       const now = new Date();
 
       const result = await db.collection(COLLECTIONS.tenants).insertOne({


### PR DESCRIPTION
## Summary

On-prem deployments are single-organization by construction (`REGISTRATION_MODE=disabled` + `BOOTSTRAP_*` bootstrap). Today, when `DB_PROVIDER=mongodb`, every tenant still gets its own physical `tenant_{slug}` database alongside `MAIN_DB_NAME` — an extra database to provision and back up for a deployment that will only ever have one tenant. This adds a single-database mode that collapses tenant collections into the main database for on-prem Mongo installs, following the same `DEPLOYMENT_MODE`-driven pattern already used elsewhere in the config (and the equivalent single-database approach in our Pulse product).

## Changes

- `src/lib/core/config.ts`: new `database.singleDatabase` flag — defaults to `true` when `DEPLOYMENT_MODE=onprem` and `DB_PROVIDER=mongodb`, overridable via `MONGODB_SINGLE_DATABASE`.
- `src/lib/database/mongodb/base.ts`: `switchToTenant()` / `runWithTenant()` bind the main DB handle instead of opening a separate `client.db(tenantDbName)` when single-database mode is on. The logical tenant name is unchanged (still used for `assertTenantContext`, logging, indexes) — only the physical `Db` object changes. No call-site changes needed anywhere else: confirmed `MAIN_DB_INDEXES`/`TENANT_DB_INDEXES` (`indexManifest.ts`) never share a collection name, so main and tenant collections coexist safely in one physical database.
- `src/lib/database/mongodb/tenant.mixin.ts`: `createTenant()` refuses to create a second tenant when single-database mode is active — tenant-scoped collections carry no per-row tenant discriminator today (isolation was always by physical database), so a second tenant would silently mix data with the first.
- `src/lib/database/index.ts`: passes the new flag into the `MongoDBProvider` constructor.
- `docker-compose.yml` / `.env.example`: document and wire `MONGODB_SINGLE_DATABASE`, `REGISTRATION_MODE`, and `BOOTSTRAP_ORG_NAME`/`BOOTSTRAP_ADMIN_EMAIL`/`BOOTSTRAP_ADMIN_PASSWORD`/`BOOTSTRAP_ADMIN_NAME` for local on-prem setups.

Companion change in `console-ee`'s Helm chart wires the same envs (plus fixes a related gap where the chart's MongoDB-backed default silently fell back to `DEPLOYMENT_MODE=saas`).

## Validation

- [ ] `npm run lint`
- [ ] `npm run test`
- [ ] `npm run build`
- [ ] `npm run docs:build`

Not run in this session — `node_modules` wasn't installed in the working environment. Changes were reviewed manually: verified no other constructor call sites break (only one other `new MongoDBProvider(...)`, in `db-parity.helper.ts`, uses the 3-arg form and picks up the new parameter's default), and traced all `switchToTenant`/`runWithTenantScope` call sites to confirm none need updating since they operate on the same public API surface. Please run the full validation suite before merging.

## Release Notes

- [x] Docs updated when behavior changed (`.env.example`, `docker-compose.yml`)
- [x] Security-sensitive changes reviewed (single-tenant guard against cross-tenant data mixing)
- [ ] License or policy files updated if repo-facing behavior changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BJZJ8oqG2BfSaGvhqeXinb

---
_Generated by [Claude Code](https://claude.ai/code/session_01BJZJ8oqG2BfSaGvhqeXinb)_