### PR TITLE
Run the browser integration suites in CI, and skip them without Chromium

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,14 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # The browser integration suites drive a real Chromium — they exist to
+      # catch the class of defect that passes a mocked test and fails in
+      # production (a Playwright option silently ignored, a locator that
+      # resolves to nothing). Without the binary they skip themselves, which
+      # would quietly remove that coverage from CI.
+      - name: Install Chromium for browser tests
+        run: npx playwright install --with-deps chromium
+
       - name: Lint
         run: npm run lint
 

--- a/src/__tests__/helpers/browserAvailability.ts
+++ b/src/__tests__/helpers/browserAvailability.ts
@@ -1,0 +1,40 @@
+/**
+ * Is a real Chromium available to run browser integration tests against?
+ *
+ * The browser suites are integration tests on purpose — the defects they
+ * exist to catch (a Playwright option that is silently ignored, a locator
+ * that resolves to nothing, a recorded target that stops working on the next
+ * page load) all pass a mocked test and fail in production. That means they
+ * need a browser binary, which CI installs explicitly and a developer's
+ * checkout may not have.
+ *
+ * Missing browsers SKIP rather than fail: a developer who has not run
+ * `npx playwright install chromium` should see a clear skip, not 34 red
+ * tests that say nothing about their change. CI installs the binary, so the
+ * coverage is real where it counts.
+ */
+
+let cached: boolean | undefined;
+
+export function chromiumAvailable(): boolean {
+  if (cached !== undefined) return cached;
+  try {
+    // `executablePath()` resolves the browser Playwright would launch and
+    // throws when the download is missing — cheaper and more accurate than
+    // probing the cache directory ourselves.
+    const { chromium } = require('playwright') as {
+      chromium: { executablePath(): string };
+    };
+    const path = chromium.executablePath();
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    cached = Boolean(path) && (require('node:fs') as typeof import('node:fs')).existsSync(path);
+  } catch {
+    cached = false;
+  }
+  if (!cached) {
+    console.warn(
+      '[browser tests] Skipped: no Chromium available. Run `npx playwright install chromium` to run them.',
+    );
+  }
+  return cached;
+}

--- a/src/__tests__/integration/browser-client-api.test.ts
+++ b/src/__tests__/integration/browser-client-api.test.ts
@@ -32,6 +32,7 @@ process.env.BROWSER_BLOCK_PRIVATE_NETWORK = 'false';
 import { reloadConfig } from '@/lib/core/config';
 import { disconnectDatabase, getDatabase } from '@/lib/database';
 import { browserManager } from '@/lib/services/browser/browserManager';
+import { chromiumAvailable } from '../helpers/browserAvailability';
 import { createApiTokenSecret, hashApiToken } from '@/lib/services/apiTokens/tokenHashing';
 import { fastifyApiPlugin } from '@/server/api/plugin';
 import { bootstrapApplication } from '@/server/bootstrap';
@@ -149,7 +150,7 @@ afterAll(async () => {
   rmSync(tmpRoot, { force: true, recursive: true });
 });
 
-describe('client API', () => {
+describe.skipIf(!chromiumAvailable())('client API', () => {
   let browserId = '';
   let sessionKey = '';
   let sessionId = '';

--- a/src/__tests__/integration/browser-engine.test.ts
+++ b/src/__tests__/integration/browser-engine.test.ts
@@ -22,6 +22,7 @@ import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
 process.env.BROWSER_BLOCK_PRIVATE_NETWORK = 'false';
 
 import { browserManager } from '@/lib/services/browser/browserManager';
+import { chromiumAvailable } from '../helpers/browserAvailability';
 
 const PAGE = `<!doctype html>
 <html><body>
@@ -105,7 +106,7 @@ afterAll(async () => {
   await new Promise<void>((resolve) => server.close(() => resolve()));
 });
 
-describe('aria snapshot', () => {
+describe.skipIf(!chromiumAvailable())('aria snapshot', () => {
   it('emits element references the model can address', async () => {
     const key = await open();
     const snapshot = await browserManager.captureAriaSnapshot(key);
@@ -135,7 +136,7 @@ describe('aria snapshot', () => {
   }, 60_000);
 });
 
-describe('target strategies', () => {
+describe.skipIf(!chromiumAvailable())('target strategies', () => {
   it('addresses an element by role and name', async () => {
     const key = await open();
     const result = await browserManager.runAction(key, {
@@ -191,7 +192,7 @@ describe('target strategies', () => {
   }, 60_000);
 });
 
-describe('replay across sessions', () => {
+describe.skipIf(!chromiumAvailable())('replay across sessions', () => {
   it('re-uses a descriptor captured in an earlier session', async () => {
     const discovery = await open();
     const snapshot = await browserManager.captureAriaSnapshot(discovery);
@@ -214,7 +215,7 @@ describe('replay across sessions', () => {
   }, 60_000);
 });
 
-describe('form controls', () => {
+describe.skipIf(!chromiumAvailable())('form controls', () => {
   it('types, selects, checks and reads back the result', async () => {
     const key = await open();
 
@@ -243,7 +244,7 @@ describe('form controls', () => {
   }, 60_000);
 });
 
-describe('scrolling', () => {
+describe.skipIf(!chromiumAvailable())('scrolling', () => {
   it('scrolls the window by an offset', async () => {
     const key = await open();
     const result = await browserManager.runAction(key, { type: 'scroll', y: 800 });
@@ -264,7 +265,7 @@ describe('scrolling', () => {
   }, 60_000);
 });
 
-describe('navigation history', () => {
+describe.skipIf(!chromiumAvailable())('navigation history', () => {
   it('goes back and forward', async () => {
     const key = await open();
     await browserManager.runAction(key, { type: 'goto', url: `${baseUrl}second` });
@@ -274,7 +275,7 @@ describe('navigation history', () => {
   }, 60_000);
 });
 
-describe('tabs', () => {
+describe.skipIf(!chromiumAvailable())('tabs', () => {
   it('adopts a popup opened by the page and can switch back', async () => {
     const key = await open();
     await browserManager.runAction(key, { type: 'click', role: 'link', name: 'Open second' });
@@ -301,7 +302,7 @@ describe('tabs', () => {
   }, 60_000);
 });
 
-describe('observation', () => {
+describe.skipIf(!chromiumAvailable())('observation', () => {
   it('finds visible text and hands back a reusable target', async () => {
     const key = await open();
     const found = await browserManager.findText(key, 'Sign in');
@@ -340,7 +341,7 @@ describe('observation', () => {
   }, 60_000);
 });
 
-describe('extraction', () => {
+describe.skipIf(!chromiumAvailable())('extraction', () => {
   it('reads text, attributes, input values and multiple matches', async () => {
     const key = await open();
     expect((await browserManager.extract(key, { role: 'heading', name: 'Console Test App' })).values[0])
@@ -356,7 +357,7 @@ describe('extraction', () => {
   }, 60_000);
 });
 
-describe('egress policy', () => {
+describe.skipIf(!chromiumAvailable())('egress policy', () => {
   it('blocks a host outside the allow list', async () => {
     const { sessionKey } = await browserManager.openSession({
       tenantId: 'test-tenant',
@@ -378,7 +379,7 @@ describe('egress policy', () => {
   }, 60_000);
 });
 
-describe('storage state', () => {
+describe.skipIf(!chromiumAvailable())('storage state', () => {
   it('exports cookies and origin storage for a later session', async () => {
     const key = await open();
     const state = await browserManager.exportStorageState(key);

--- a/src/__tests__/integration/browser-flow-e2e.test.ts
+++ b/src/__tests__/integration/browser-flow-e2e.test.ts
@@ -28,6 +28,7 @@ process.env.BROWSER_BLOCK_PRIVATE_NETWORK = 'false';
 import { reloadConfig } from '@/lib/core/config';
 import { disconnectDatabase, getDatabase } from '@/lib/database';
 import { browserManager } from '@/lib/services/browser/browserManager';
+import { chromiumAvailable } from '../helpers/browserAvailability';
 import {
   createBrowser,
   setBrowserStorageState,
@@ -154,7 +155,7 @@ async function driveDiscoverySession(): Promise<{ sessionId: string; sessionKey:
   return { sessionId: session.id, sessionKey: key };
 }
 
-describe('record', () => {
+describe.skipIf(!chromiumAvailable())('record', () => {
   it('turns a ref-driven session into a flow with no refs left in it', async () => {
     const { sessionId, sessionKey } = await driveDiscoverySession();
     await closeBrowserSession(ctx, sessionKey);
@@ -207,7 +208,7 @@ describe('record', () => {
   }, 60_000);
 });
 
-describe('replay', () => {
+describe.skipIf(!chromiumAvailable())('replay', () => {
   it('runs a recorded flow in a fresh session and binds its inputs', async () => {
     const { sessionId, sessionKey } = await driveDiscoverySession();
     await closeBrowserSession(ctx, sessionKey);
@@ -384,7 +385,7 @@ describe('replay', () => {
   }, 120_000);
 });
 
-describe('browser profile', () => {
+describe.skipIf(!chromiumAvailable())('browser profile', () => {
   it('stores a storageState encrypted and reports only a summary', async () => {
     const summary = await setBrowserStorageState(ctx, browserId, {
       storageState: {


### PR DESCRIPTION
The three browser suites added in #264 drive a real Chromium. CI had no browser binary, so all 34 tests failed there while passing locally — the worst of both outcomes: a red `main`, and no actual coverage.

- Install `chromium` in CI so the tests do their job.
- Gate the suites on a browser being present, so a checkout that has not run `npx playwright install chromium` skips them with a message instead of reporting 34 failures that say nothing about the change in hand.

Verified locally: 43 tests pass with a browser present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016AWZPd7wXxE3PzPH1iNaFJ