### PR TITLE
Resolve Playwright without a bare require in the browser test guard

### DIFF
--- a/src/__tests__/helpers/browserAvailability.ts
+++ b/src/__tests__/helpers/browserAvailability.ts
@@ -14,23 +14,31 @@
  * coverage is real where it counts.
  */
 
+import { existsSync } from 'node:fs';
+import { createRequire } from 'node:module';
+
 let cached: boolean | undefined;
 
 export function chromiumAvailable(): boolean {
   if (cached !== undefined) return cached;
+
   try {
-    // `executablePath()` resolves the browser Playwright would launch and
-    // throws when the download is missing — cheaper and more accurate than
-    // probing the cache directory ourselves.
+    // Resolved lazily and synchronously: this is called in a `describe.skipIf`
+    // predicate, which runs during collection and cannot await. `playwright`
+    // is a CommonJS package, so a created require is the honest way in.
+    const require = createRequire(import.meta.url);
     const { chromium } = require('playwright') as {
       chromium: { executablePath(): string };
     };
-    const path = chromium.executablePath();
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    cached = Boolean(path) && (require('node:fs') as typeof import('node:fs')).existsSync(path);
+    // `executablePath()` names the browser Playwright would launch and throws
+    // when the download is missing — more accurate than probing the cache
+    // directory ourselves.
+    const executable = chromium.executablePath();
+    cached = Boolean(executable) && existsSync(executable);
   } catch {
     cached = false;
   }
+
   if (!cached) {
     console.warn(
       '[browser tests] Skipped: no Chromium available. Run `npx playwright install chromium` to run them.',


### PR DESCRIPTION
`npm run lint` forbids `require()` style imports, so the browser-availability guard from #265 failed CI's Lint step.

`playwright` is CommonJS and the guard runs inside a `describe.skipIf` predicate — evaluated during collection, so it cannot await. `createRequire(import.meta.url)` is the honest way to reach a CJS package synchronously from an ES module.

Verified locally: 0 lint errors, typecheck clean, 21 browser engine tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016AWZPd7wXxE3PzPH1iNaFJ