### PR TITLE
Document durable targets, flows and signed-in profiles

### DIFF
--- a/docs/api/browser.md
+++ b/docs/api/browser.md
@@ -107,10 +107,37 @@ GET /api/client/v1/browser/sessions/:sessionKey/snapshot
 - `POST /api/client/v1/browser/sessions/:sessionKey/screenshot`
 - `POST /api/client/v1/browser/sessions/:sessionKey/pdf`
 
+### Find Text / Diagnostics / Export Profile
+
+- `GET /api/client/v1/browser/sessions/:sessionKey/find?text=…&limit=…` — locate visible text and get a **durable target** for each hit, cheaper than a full snapshot.
+- `GET /api/client/v1/browser/sessions/:sessionKey/diagnostics` — console messages, failed requests and the last dialog the session saw.
+- `GET /api/client/v1/browser/sessions/:sessionKey/profile` — export this session's cookies + origin storage, ready to attach as a browser profile.
+
 ### Close / Delete Session
 
 - `DELETE /api/client/v1/browser/sessions/:sessionKey`
 - `DELETE /api/client/v1/browser/sessions/by-id/:sessionId`
+
+## Signed-In Profiles
+
+- `PUT /api/client/v1/browser/browsers/:idOrKey/profile` — attach a Playwright `storageState` so new sessions start authenticated. Body is either the raw export or `{ "storageState": …, "fileName": "profile.json" }`. Encrypted at rest; the response is a summary only and the payload is never readable back.
+- `DELETE /api/client/v1/browser/browsers/:idOrKey/profile`
+
+## Browser Flows
+
+A flow is a recorded, replayable step list — discovery once, deterministic execution afterwards.
+
+- `POST /api/client/v1/browser/flows` — create (steps may be supplied directly)
+- `GET /api/client/v1/browser/flows` — list, filterable by `status`, `browserId`, `search`
+- `GET|PATCH|DELETE /api/client/v1/browser/flows/:idOrKey`
+- `POST /api/client/v1/browser/flows/record` — turn a driven session into a flow
+- `POST /api/client/v1/browser/flows/:idOrKey/run` — replay it and wait for the result
+- `GET /api/client/v1/browser/flow-runs` — run history, filterable by `flowId` and `status`
+- `GET /api/client/v1/browser/flow-runs/:runId`
+
+A step's action uses the same schema as a live action, with one added rule: **a stored `ref` is rejected**. A ref is valid only for the snapshot that produced it, so a persisted one resolves to nothing on the next run and burns the step's whole timeout finding that out. Use `role` + `name`, `testId`, `label`, `placeholder`, `text` or `selector`.
+
+A failed run still returns `200` with `run.status: "failed"` — the request succeeded and the caller gets a complete, inspectable answer including `failedStepIndex` and per-step results.
 
 ## Per-Browser MCP
 
@@ -145,17 +172,17 @@ Supported methods:
 
 The browser MCP server exposes the Browser Use-compatible tools:
 
-- `browser_navigate`
-- `browser_click`
-- `browser_hover`
-- `browser_type`
-- `browser_press`
-- `browser_wait`
-- `browser_snapshot`
-- `browser_extract`
-- `browser_screenshot`
-- `browser_pdf` (renders the current page to PDF)
+- `browser_navigate`, `browser_history` (back / forward / reload)
+- `browser_click`, `browser_hover`, `browser_type`, `browser_press`
+- `browser_select`, `browser_check`, `browser_upload`, `browser_scroll`
+- `browser_wait`, `browser_tabs`
+- `browser_snapshot` (accessibility tree with `[ref=…]` markers), `browser_find`, `browser_extract`
+- `browser_diagnostics` (console, failed requests, last dialog)
+- `browser_screenshot`, `browser_pdf`
+- `browser_list_flows`, `browser_run_flow`
 - `browser_close`
+
+The list is derived from the same definitions the `Browser Use` system tool binds, so the MCP and agent surfaces cannot drift apart.
 
 ## Relationship To Console Agents
 
@@ -164,5 +191,7 @@ Standalone browser agent management has been removed. If you want a Console-mana
 1. create or reuse a browser profile,
 2. attach the `Browser Use` system tool to the agent in Console,
 3. invoke that agent through the normal agents / responses surface.
+
+The agent addresses elements by the `ref` values in `browser_snapshot`'s output. Those are valid only until the next snapshot — every action result also returns `resolvedTarget`, the durable `role`/`name` form, which is what a flow step stores. Where a flow already exists for the task, `browser_run_flow` replays it without a model in the loop.
 
 For external runtimes or custom orchestrators, use the browser session API directly or connect through the per-browser MCP endpoint.

--- a/docs/guide/browser.md
+++ b/docs/guide/browser.md
@@ -14,9 +14,119 @@ The landing page lists browser profiles with their active/disabled and live-sess
 
 - **Browser profile** — long-lived container with defaults for session config, the artifact bucket where screenshots/PDFs land, and a default model (used by extract/LLM-driven actions). Persisted in `browsers`.
 - **Session** — a live Playwright context. Created from a profile, carries its own status (`starting | ready | closed | error`), receives actions, and records every event (navigation, click, extract, screenshot) to `browser_session_events`. Auto-closes after `idleTimeoutMs`.
-- **Action** — a single operation against a session: `goto`, `click`, `hover`, `type`, `press`, `wait`, `snapshot`, `extract`, `screenshot`, `close`. The full schema lives in `browserActionSchema`.
-- **Extract** — selector + mode (`text | html | attribute`) optionally piped through the profile's default model for structured extraction.
+- **Action** — a single operation against a session: `goto`, `click`, `hover`, `type`, `press`, `select`, `check`, `upload`, `drag`, `scroll`, `wait`, `tab`, `back`/`forward`/`reload`. The full schema lives in `browserActionSchema`.
+- **Target** — how an action names the element it acts on. See [Addressing elements](#addressing-elements); this is the difference between an automation that works once and one that keeps working.
+- **Flow** — a recorded, replayable step list. See [Flows](#flows).
+- **Extract** — a target + mode (`text | html | attr | value`), optionally over every match.
 - **Artifacts** — screenshots and PDFs are stored in the configured file bucket; the response carries the bucket key.
+
+## Addressing elements
+
+An action can name its element two ways, and only one of them survives being
+saved.
+
+`browser_snapshot` returns the page's accessibility tree with `[ref=e4]`
+markers. A **ref** is the cheapest, least ambiguous handle for the turn you
+are in — and it is valid only until the next snapshot, because the browser
+renumbers them every time. Stored in a flow, a ref looks like a working
+target and then spends the step's entire timeout resolving to nothing.
+
+Everything else is **durable**: it describes the element the way a person
+would, so it still resolves after a re-render and usually after a deploy.
+
+| Field | Use when |
+|---|---|
+| `testId` | the app sets `data-testid` — the most stable target there is |
+| `role` + `name` | almost always: `{ "role": "button", "name": "Sign in" }` |
+| `label` | a form field with a `<label>` |
+| `placeholder` | an input with placeholder text and no label |
+| `text` | a link or element identified by its visible text |
+| `selector` | last resort — CSS encodes markup nobody promised to keep |
+| `nth` | disambiguates when the chosen strategy matches several elements |
+| `frame` | CSS selector of an iframe to look inside |
+
+Every action result carries **`resolvedTarget`**: the durable description of
+whatever the action actually hit. That is what you save.
+
+```jsonc
+// Request — a live agent uses the ref it just saw
+{ "type": "click", "ref": "e12" }
+
+// Response — the durable form, safe to keep
+{ "ok": true, "targetStrategy": "ref",
+  "resolvedTarget": { "role": "button", "name": "Sign in" } }
+```
+
+A stale ref does not stall: when a durable target is supplied alongside it,
+the ref is probed briefly and then abandoned in favour of the durable one.
+
+## Flows
+
+Driving a browser with a model is **discovery** — it reads the page,
+guesses, backtracks, and bills tokens for every step. Replaying a flow is
+**execution**: no model, no guessing, the same steps every time.
+
+A flow is an ordered list of steps with durable targets, declared inputs, and
+per-step retry policy. Record one from a session you already drove — by hand
+in the live preview, or with an agent:
+
+```bash
+curl -X POST /api/client/v1/browser/flows/record \
+  -d '{ "sessionId": "…", "name": "Submit expense", "status": "active" }'
+```
+
+Recording substitutes durable targets for refs, and turns **every typed value
+into a declared input** rather than a literal — the recorder cannot tell a
+search term from a password, and only one of those mistakes is recoverable.
+Steps reference them as <span v-pre>`{{input.name}}`</span>.
+
+Replay it with different values, as often as you like:
+
+```bash
+curl -X POST /api/client/v1/browser/flows/<key>/run \
+  -d '{ "inputs": { "reference": "EXP-2002", "amount": "999" } }'
+```
+
+The response is the run record: per-step status and attempt count, whatever
+`captureAs` collected, and — on a failure — the index of the step that broke
+plus a screenshot of the page it gave up on.
+
+Step policy:
+
+| Field | Effect |
+|---|---|
+| `policy.retries` | attempts beyond the first; the delay doubles |
+| `policy.timeoutMs` | per-step bound, overriding the session default |
+| `policy.optional` | a failing step is recorded and skipped instead of aborting |
+| `when` | skip the step unless the expression is truthy |
+| `captureAs` | store the step's output for later steps and the run's outputs |
+
+A run **aborts at the first non-optional failure**: a half-finished form is
+usually worse than an untouched one.
+
+Agents reach flows through `browser_list_flows` and `browser_run_flow` —
+check for an existing flow before working a task out step by step.
+
+Flows live at **Operate → Browser → Flows**.
+
+## Signed-in profiles
+
+An unattended run should not push credentials through a login form every
+time. A browser profile can carry a Playwright `storageState` — cookies plus
+origin storage — so every session it opens starts already authenticated:
+
+```bash
+curl -X PUT /api/client/v1/browser/browsers/<idOrKey>/profile \
+  -d '{ "storageState": <contents of profile.json> }'
+```
+
+Get that file either from Playwright (`context.storageState()`) or from a
+session you signed into by hand — the session list has a **save as profile**
+action, and `GET …/sessions/<key>/profile` returns the same JSON.
+
+The payload is encrypted at rest and is **never readable back**; the API
+returns only a summary (cookie count, origins, earliest expiry) so the
+dashboard can warn you before a profile goes stale.
 
 ## Quick start
 
@@ -53,10 +163,16 @@ The live screenshot endpoint (`GET …/screenshot/live`) returns an inline PNG/J
 Every profile exposes its own MCP server at `/api/client/v1/browser/:browserKey/mcp/*`. The toolset mirrors the action API but follows the Model Context Protocol:
 
 ```
-browser_navigate · browser_click · browser_hover · browser_type ·
-browser_press · browser_wait · browser_snapshot · browser_extract ·
-browser_screenshot · browser_close
+browser_navigate · browser_history · browser_click · browser_hover ·
+browser_type · browser_press · browser_select · browser_check ·
+browser_upload · browser_scroll · browser_wait · browser_tabs ·
+browser_snapshot · browser_find · browser_extract · browser_diagnostics ·
+browser_screenshot · browser_pdf · browser_list_flows · browser_run_flow ·
+browser_close
 ```
+
+The list is derived from the same tool definitions the `Browser Use` system
+tool binds, so the two surfaces cannot drift apart.
 
 Open the SSE stream first:
 


### PR DESCRIPTION
The browser docs still listed ten tools, described actions as selector-or-ref, and said nothing about flows — wrong about the part that decides whether an automation keeps working.

Adds to the guide and API reference:
- **Addressing elements** — the ref/durable split, a table of target strategies, and why a stored ref is worse than no target.
- **Flows** — recording, replaying with inputs, step policy (`retries`, `optional`, `when`, `captureAs`), and what a failed run reports.
- **Signed-in profiles** — attaching a `storageState` so unattended runs start authenticated.
- The corrected 21-tool MCP list, plus the new session endpoints (`find`, `diagnostics`, `profile`).

`npm run docs:build` passes. (Note: `{{input.name}}` needs `v-pre` — VitePress runs pages through Vue, which interpolates it even inside inline code.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016AWZPd7wXxE3PzPH1iNaFJ