### PR TITLE
Add model replica pools and the OpenAI Assistants API dialect

### DIFF
--- a/src/__tests__/unit/client-assistants.test.ts
+++ b/src/__tests__/unit/client-assistants.test.ts
@@ -1,0 +1,234 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { IAgentConversation } from '@/lib/database';
+
+// Hoisted: `toolBindingsFromAssistantBody`'s file_search branch resolves the
+// module through `getDatabase()`, which — unmocked — would try a real tenant
+// connection this test has none of, and hang. `switchToTenant` and every
+// other DB call the rest of this suite touches are stubbed no-ops; only
+// `findRagModuleByKey` carries a real (fake) answer.
+vi.mock('@/lib/database', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/database')>();
+  return {
+    ...actual,
+    getDatabase: vi.fn().mockResolvedValue({
+      switchToTenant: vi.fn(),
+      findRagModuleByKey: vi.fn().mockImplementation((key: string) =>
+        Promise.resolve(key === 'docs-v1' ? { key: 'docs-v1' } : null)),
+    }),
+  };
+});
+
+import {
+  agentKeyFromAssistantId,
+  agentToAssistant,
+  assistantId,
+  AssistantRequestError,
+  conversationIdFromThreadId,
+  extractMessageText,
+  mergedMessages,
+  messageId,
+  threadId,
+  toDate,
+  toMessageObject,
+  toolBindingsFromAssistantBody,
+} from '@/server/api/plugins/client-assistants';
+
+describe('id scheme', () => {
+  it('round-trips assistant, thread and message ids', () => {
+    expect(agentKeyFromAssistantId(assistantId('support-bot'))).toBe('support-bot');
+    expect(conversationIdFromThreadId(threadId('conv-1'))).toBe('conv-1');
+    expect(messageId('conv-1', 0)).toBe('msg_conv-1_0');
+  });
+
+  it('passes an id straight through when it lacks the expected prefix', () => {
+    // Defensive, not a feature: a caller handing back a bare key still resolves.
+    expect(agentKeyFromAssistantId('support-bot')).toBe('support-bot');
+    expect(conversationIdFromThreadId('conv-1')).toBe('conv-1');
+  });
+});
+
+describe('toDate', () => {
+  it('passes a real Date through unchanged', () => {
+    const d = new Date('2026-01-01T00:00:00.000Z');
+    expect(toDate(d)).toBe(d);
+  });
+
+  it('coerces the ISO string SQLite round-trips a persisted timestamp as', () => {
+    // Regression: `agent.mixin.ts`'s `mapConversation` reads `messages` back
+    // with a plain JSON.parse (no reviver), so a persisted message's
+    // `timestamp` — typed `Date` — is actually a string once it has round-
+    // tripped through storage. A raw `.getTime()` on it throws, which is
+    // exactly what listing a thread's messages did after its first run until
+    // this coercion was added.
+    const coerced = toDate('2026-01-01T00:00:00.000Z');
+    expect(coerced).toBeInstanceOf(Date);
+    expect(coerced.getTime()).toBe(new Date('2026-01-01T00:00:00.000Z').getTime());
+  });
+});
+
+const conversation = (overrides: Partial<IAgentConversation> = {}): IAgentConversation => ({
+  _id: 'conv-1',
+  tenantId: 't1',
+  projectId: 'p1',
+  agentKey: 'support-bot',
+  messages: [],
+  createdBy: 'u1',
+  ...overrides,
+}) as IAgentConversation;
+
+describe('mergedMessages — id stability across the pending → persisted promotion', () => {
+  it('places pending messages after persisted ones', () => {
+    const merged = mergedMessages(conversation({
+      messages: [{ role: 'user', content: 'hi', timestamp: new Date('2026-01-01T00:00:00Z') }],
+      metadata: {
+        assistantsApi: {
+          pendingMessages: [{ id: 'p1', role: 'user', content: 'again', created_at: 1735776000 }],
+        },
+      },
+    }));
+    expect(merged.map((m) => [m.role, m.content, m.pending])).toEqual([
+      ['user', 'hi', false],
+      ['user', 'again', true],
+    ]);
+  });
+
+  it('keeps a message at the SAME index once its run promotes it to persisted', () => {
+    // Before the run: one persisted turn, one pending user message at index 1.
+    const before = mergedMessages(conversation({
+      messages: [
+        { role: 'user', content: 'turn 1', timestamp: new Date('2026-01-01T00:00:00Z') },
+        { role: 'assistant', content: 'reply 1', timestamp: new Date('2026-01-01T00:00:01Z') },
+      ],
+      metadata: {
+        assistantsApi: { pendingMessages: [{ id: 'p1', role: 'user', content: 'turn 2', created_at: 1735776002 }] },
+      },
+    }));
+    expect(before[2]).toMatchObject({ role: 'user', content: 'turn 2', pending: true });
+
+    // After the run: `executeAgentChat` appended the (user, assistant) pair
+    // itself and the pending queue was cleared — the exact transition
+    // `runThread` performs.
+    const after = mergedMessages(conversation({
+      messages: [
+        { role: 'user', content: 'turn 1', timestamp: new Date('2026-01-01T00:00:00Z') },
+        { role: 'assistant', content: 'reply 1', timestamp: new Date('2026-01-01T00:00:01Z') },
+        { role: 'user', content: 'turn 2', timestamp: '2026-01-01T00:00:02.000Z' as unknown as Date },
+        { role: 'assistant', content: 'reply 2', timestamp: '2026-01-01T00:00:03.000Z' as unknown as Date },
+      ],
+      metadata: { assistantsApi: { pendingMessages: [] } },
+    }));
+    expect(after[2]).toMatchObject({ role: 'user', content: 'turn 2', pending: false });
+    expect(after[3]).toMatchObject({ role: 'assistant', content: 'reply 2', pending: false });
+  });
+});
+
+describe('toMessageObject', () => {
+  it('stamps assistant_id only on assistant turns', () => {
+    const userMsg = toMessageObject('conv-1', 'asst_x', 0, {
+      role: 'user', content: 'hi', timestamp: new Date(),
+    });
+    const asstMsg = toMessageObject('conv-1', 'asst_x', 1, {
+      role: 'assistant', content: 'hello', timestamp: new Date(),
+    });
+    expect(userMsg.assistant_id).toBeNull();
+    expect(asstMsg.assistant_id).toBe('asst_x');
+    expect(userMsg.content[0]).toEqual({ type: 'text', text: { value: 'hi', annotations: [] } });
+  });
+});
+
+describe('extractMessageText', () => {
+  it('accepts a plain string', () => {
+    expect(extractMessageText('  hi  ')).toBe('hi');
+  });
+
+  it('accepts an OpenAI-shaped text content part', () => {
+    expect(extractMessageText([{ type: 'text', text: { value: 'hi' } }])).toBe('hi');
+    expect(extractMessageText([{ type: 'text', text: 'hi' }])).toBe('hi');
+  });
+
+  it('rejects empty and unrecognized input', () => {
+    expect(extractMessageText('   ')).toBeNull();
+    expect(extractMessageText(42)).toBeNull();
+    expect(extractMessageText([{ type: 'image_url' }])).toBeNull();
+  });
+});
+
+describe('agentToAssistant', () => {
+  it('maps an IAgent onto the Assistant wire shape', () => {
+    const out = agentToAssistant({
+      _id: 'a1',
+      tenantId: 't1',
+      projectId: 'p1',
+      key: 'support-bot',
+      name: 'Support Bot',
+      config: { modelKey: 'gpt-4o-mini', systemPrompt: 'Be terse.', toolBindings: [] },
+      status: 'active',
+      createdBy: 'u1',
+      createdAt: new Date('2026-01-01T00:00:00Z'),
+    } as never);
+    expect(out).toMatchObject({
+      id: 'asst_support-bot',
+      object: 'assistant',
+      model: 'gpt-4o-mini',
+      instructions: 'Be terse.',
+      tools: [],
+    });
+  });
+
+  it('projects a knowledge module onto tool_resources.file_search', () => {
+    const out = agentToAssistant({
+      key: 'kb-bot',
+      name: 'KB Bot',
+      config: { modelKey: 'gpt-4o-mini', knowledgeEngineKey: 'docs-v1' },
+      createdBy: 'u1',
+    } as never);
+    expect(out.tool_resources).toEqual({ file_search: { vector_store_ids: ['docs-v1'] } });
+  });
+});
+
+describe('toolBindingsFromAssistantBody', () => {
+  // These four map exactly onto the live 400s exercised against the real
+  // server (function / code_interpreter / file_search-with-no-module /
+  // file_search-with-unknown-module); re-asserted here as unit tests so a
+  // future refactor of the validation function fails fast without a live run.
+  it('rejects a client-executed "function" tool', async () => {
+    await expect(
+      toolBindingsFromAssistantBody('tdb', 'p1', { tools: [{ type: 'function', function: { name: 'foo' } }] }),
+    ).rejects.toThrow(AssistantRequestError);
+  });
+
+  it('rejects "code_interpreter" — no backing runtime yet', async () => {
+    await expect(
+      toolBindingsFromAssistantBody('tdb', 'p1', { tools: [{ type: 'code_interpreter' }] }),
+    ).rejects.toThrow(AssistantRequestError);
+  });
+
+  it('rejects "file_search" with no vector_store_ids', async () => {
+    await expect(
+      toolBindingsFromAssistantBody('tdb', 'p1', { tools: [{ type: 'file_search' }] }),
+    ).rejects.toThrow(/vector_store_ids/);
+  });
+
+  it('accepts "file_search" naming a real Knowledge Engine module', async () => {
+    const result = await toolBindingsFromAssistantBody('tdb', 'p1', {
+      tools: [{ type: 'file_search' }],
+      tool_resources: { file_search: { vector_store_ids: ['docs-v1'] } },
+    });
+    expect(result.knowledgeEngineKey).toBe('docs-v1');
+  });
+
+  it('accepts the console_tool extension for the built-in tool/MCP/system catalog', async () => {
+    const result = await toolBindingsFromAssistantBody('tdb', 'p1', {
+      tools: [{ type: 'console_tool', tool: { source: 'system', sourceKey: 'browser_use', toolNames: ['browser_use'] } }],
+    });
+    expect(result.toolBindings).toEqual([
+      { source: 'system', sourceKey: 'browser_use', toolNames: ['browser_use'] },
+    ]);
+  });
+
+  it('rejects an unrecognized tool type rather than dropping it silently', async () => {
+    await expect(
+      toolBindingsFromAssistantBody('tdb', 'p1', { tools: [{ type: 'retrieval' }] }),
+    ).rejects.toThrow(AssistantRequestError);
+  });
+});

--- a/src/__tests__/unit/replica-pool.test.ts
+++ b/src/__tests__/unit/replica-pool.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import type { IModel } from '@/lib/database';
+import { resetAllCircuits } from '@/lib/core/resilience';
+import {
+  listReplicas,
+  modelForReplica,
+  replicaOrder,
+  shouldTryNextReplica,
+} from '@/lib/services/models/replicaPool';
+import { UpstreamRequestError } from '@/lib/providers/contracts/upstreamError';
+
+const model = (overrides: Partial<IModel> = {}) => ({
+  _id: 'm1',
+  tenantId: 't1',
+  projectId: 'p1',
+  name: 'GPT-4o',
+  key: 'gpt-4o',
+  providerKey: 'azure-west',
+  providerDriver: 'azure',
+  category: 'llm' as const,
+  modelId: 'gpt-4o',
+  settings: { temperature: 0.2 },
+  pricing: { inputTokenPer1M: 1, outputTokenPer1M: 2 },
+  ...overrides,
+}) as unknown as IModel;
+
+beforeEach(() => resetAllCircuits());
+
+describe('listReplicas', () => {
+  it('treats an unpooled model as a pool of one built from its own provider', () => {
+    expect(listReplicas(model())).toEqual([
+      { index: 0, providerKey: 'azure-west', modelId: 'gpt-4o', weight: 1 },
+    ]);
+  });
+
+  it('falls back to the model id for a replica that only names a provider', () => {
+    const pooled = model({ replicas: [{ providerKey: 'azure-north', modelId: '' }] });
+    expect(listReplicas(pooled)[0]).toMatchObject({ providerKey: 'azure-north', modelId: 'gpt-4o' });
+  });
+
+  it('drains a disabled replica without deleting it', () => {
+    const pooled = model({
+      replicas: [
+        { providerKey: 'a', modelId: 'x' },
+        { providerKey: 'b', modelId: 'y', enabled: false },
+      ],
+    });
+    expect(listReplicas(pooled).map((r) => r.providerKey)).toEqual(['a']);
+  });
+
+  it('falls back to the model itself when every replica is disabled', () => {
+    const pooled = model({ replicas: [{ providerKey: 'a', modelId: 'x', enabled: false }] });
+    expect(listReplicas(pooled)).toHaveLength(1);
+    expect(listReplicas(pooled)[0].providerKey).toBe('azure-west');
+  });
+});
+
+describe('replicaOrder', () => {
+  const pooled = model({
+    replicas: [
+      { providerKey: 'a', modelId: 'x', weight: 3 },
+      { providerKey: 'b', modelId: 'y', weight: 1 },
+    ],
+  });
+
+  it('returns every replica, so the pool doubles as a fallback chain', () => {
+    const order = replicaOrder(pooled, 'chat', () => 0.99);
+    expect(order.map((r) => r.providerKey).sort()).toEqual(['a', 'b']);
+  });
+
+  it('respects weight when picking the first attempt', () => {
+    // Draws at the low end of the ticket range land on the heaviest replica.
+    expect(replicaOrder(pooled, 'chat', () => 0.01)[0].providerKey).toBe('a');
+  });
+
+  it('is a no-op for a single replica', () => {
+    expect(replicaOrder(model(), 'chat')).toHaveLength(1);
+  });
+});
+
+describe('modelForReplica', () => {
+  it('swaps provider and model id, and merges the replica settings over the model', () => {
+    const swapped = modelForReplica(model(), {
+      index: 1,
+      providerKey: 'bedrock-eu',
+      modelId: 'openai.gpt-oss-120b-1:0',
+      weight: 1,
+      settings: { azureApiVersion: '2025-04-01-preview' },
+    });
+
+    expect(swapped.providerKey).toBe('bedrock-eu');
+    expect(swapped.modelId).toBe('openai.gpt-oss-120b-1:0');
+    expect(swapped.settings).toEqual({ temperature: 0.2, azureApiVersion: '2025-04-01-preview' });
+    // Identity, pricing and category are the MODEL's and must not vary by replica.
+    expect(swapped.key).toBe('gpt-4o');
+    expect(swapped.pricing).toEqual(model().pricing);
+  });
+
+  it('returns the same object when the replica is the model itself', () => {
+    const base = model();
+    expect(modelForReplica(base, { index: 0, providerKey: 'azure-west', modelId: 'gpt-4o', weight: 1 }))
+      .toBe(base);
+  });
+});
+
+describe('shouldTryNextReplica', () => {
+  it('moves on for capacity and availability faults', () => {
+    expect(shouldTryNextReplica(new UpstreamRequestError('rate limited', 429))).toBe(true);
+    expect(shouldTryNextReplica(new UpstreamRequestError('bad gateway', 502))).toBe(true);
+    expect(shouldTryNextReplica(new Error('Circuit breaker is open for "chat:a:b"'))).toBe(true);
+    expect(shouldTryNextReplica(new Error('fetch failed'))).toBe(true);
+  });
+
+  it('does NOT move on for the caller\'s own mistakes', () => {
+    // A 400 fails identically on every replica; retrying multiplies the bill,
+    // and a 401 would walk through several sets of provider credentials.
+    expect(shouldTryNextReplica(new UpstreamRequestError('bad request', 400))).toBe(false);
+    expect(shouldTryNextReplica(new UpstreamRequestError('unauthorized', 401))).toBe(false);
+    expect(shouldTryNextReplica(new UpstreamRequestError('not found', 404))).toBe(false);
+  });
+
+  it('reads a status nested under error / response / cause', () => {
+    expect(shouldTryNextReplica({ response: { status: 503 } })).toBe(true);
+    expect(shouldTryNextReplica({ cause: { error: { status: 400 } } })).toBe(false);
+  });
+});

--- a/src/app/dashboard/models/[id]/page.tsx
+++ b/src/app/dashboard/models/[id]/page.tsx
@@ -42,6 +42,7 @@ import {
   IconPlayerPlay,
   IconRefresh,
   IconSettings,
+  IconStack2,
   IconTimeline,
   IconTrash,
 } from '@tabler/icons-react';
@@ -53,6 +54,7 @@ import TtsPlayground from '@/components/playground/TtsPlayground';
 import OcrPlayground from '@/components/playground/OcrPlayground';
 import ImagePlayground from '@/components/playground/ImagePlayground';
 import EmbeddingPlayground from '@/components/playground/EmbeddingPlayground';
+import ReplicaPoolPanel from '@/components/models/ReplicaPoolPanel';
 import PageContainer from '@/components/common/ui/PageContainer';
 import TabsBar from '@/components/common/ui/TabsBar';
 import StatusBadge from '@/components/common/ui/StatusBadge';
@@ -124,6 +126,13 @@ interface ModelDetailDto {
    * are then ignored rather than merged. An empty array is a real state
    * ("attached to nothing") and must not be confused with an absent one.
    */
+  replicas?: Array<{
+    providerKey: string;
+    modelId: string;
+    weight?: number;
+    enabled?: boolean;
+    label?: string;
+  }>;
   guardrails?: GuardrailBindingRow[];
   /** @deprecated Read only as the fallback when `guardrails` is absent. */
   inputGuardrailKey?: string;
@@ -301,7 +310,7 @@ function relativeDate(iso?: string) {
   return d.toLocaleDateString();
 }
 
-type DetailTab = 'overview' | 'playground' | 'routing' | 'configure' | 'logs' | 'usage';
+type DetailTab = 'overview' | 'playground' | 'routing' | 'replicas' | 'configure' | 'logs' | 'usage';
 
 interface ParsedToolCall {
   id?: string;
@@ -704,6 +713,11 @@ export default function ModelDetailPage() {
     ...(isDynamic
       ? [{ id: 'routing' as const, label: 'Routing', icon: <IconArrowsSplit size={14} stroke={1.7} /> }]
       : []),
+    // Pooling is wired on the chat path, so the tab appears where it does
+    // something. A Dynamic LLM owns no provider of its own to pool.
+    ...(!isDynamic && model.category === 'llm'
+      ? [{ id: 'replicas' as const, label: 'Replicas', icon: <IconStack2 size={14} stroke={1.7} /> }]
+      : []),
     { id: 'configure', label: 'Configure', icon: <IconSettings size={14} stroke={1.7} /> },
     { id: 'logs', label: 'Logs', icon: <IconTimeline size={14} stroke={1.7} /> },
     { id: 'usage', label: 'Usage', icon: <IconBook size={14} stroke={1.7} /> },
@@ -934,6 +948,17 @@ export default function ModelDetailPage() {
 
       {tab === 'playground' && model.category === 'tts' ? (
         <TtsPlayground modelKey={model.key} />
+      ) : null}
+
+      {tab === 'replicas' ? (
+        <ReplicaPoolPanel
+          modelId={String(model._id)}
+          modelKey={model.key}
+          ownProviderKey={model.providerKey ?? ''}
+          ownModelId={model.modelId}
+          providers={providers.map((provider) => ({ key: provider.key, label: provider.label }))}
+          initialReplicas={model.replicas}
+        />
       ) : null}
 
       {tab === 'playground' && model.category === 'image' ? (

--- a/src/components/models/ReplicaPoolPanel.tsx
+++ b/src/components/models/ReplicaPoolPanel.tsx
@@ -1,0 +1,229 @@
+'use client';
+
+import { useState } from 'react';
+import {
+  ActionIcon,
+  Alert,
+  Badge,
+  Button,
+  Group,
+  NumberInput,
+  Paper,
+  Select,
+  Stack,
+  Switch,
+  Table,
+  Text,
+  TextInput,
+} from '@mantine/core';
+import { notifications } from '@mantine/notifications';
+import {
+  IconAlertTriangle,
+  IconDeviceFloppy,
+  IconPlus,
+  IconStack2,
+  IconTrash,
+} from '@tabler/icons-react';
+
+export interface ReplicaDraft {
+  providerKey: string;
+  modelId: string;
+  weight?: number;
+  enabled?: boolean;
+  label?: string;
+}
+
+interface ReplicaPoolPanelProps {
+  modelId: string;
+  modelKey: string;
+  /** The model's own provider/upstream id — replica zero when no pool exists. */
+  ownProviderKey: string;
+  ownModelId: string;
+  providers: Array<{ key: string; label?: string }>;
+  initialReplicas?: ReplicaDraft[];
+  onSaved?: (replicas: ReplicaDraft[]) => void;
+}
+
+export default function ReplicaPoolPanel({
+  modelId,
+  modelKey,
+  ownProviderKey,
+  ownModelId,
+  providers,
+  initialReplicas,
+  onSaved,
+}: ReplicaPoolPanelProps) {
+  const [replicas, setReplicas] = useState<ReplicaDraft[]>(initialReplicas ?? []);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const pooled = replicas.length > 0;
+
+  const update = (index: number, patch: Partial<ReplicaDraft>) => {
+    setReplicas((current) => current.map((entry, i) => (i === index ? { ...entry, ...patch } : entry)));
+  };
+
+  const add = () => {
+    setReplicas((current) => [
+      ...current,
+      // The first replica seeds from the model's own deployment, so turning a
+      // single model into a pool never silently drops the upstream it had.
+      current.length === 0
+        ? { providerKey: ownProviderKey, modelId: ownModelId, weight: 1, enabled: true }
+        : { providerKey: providers[0]?.key ?? '', modelId: ownModelId, weight: 1, enabled: true },
+    ]);
+  };
+
+  const save = async () => {
+    setSaving(true);
+    setError(null);
+    try {
+      const response = await fetch(`/api/models/${modelId}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ replicas }),
+      });
+      const payload = await response.json().catch(() => ({}));
+      if (!response.ok) throw new Error(payload.error || `Save failed (${response.status})`);
+      notifications.show({
+        color: 'teal',
+        title: pooled ? 'Pool saved' : 'Pool cleared',
+        message: pooled
+          ? `${modelKey} now serves from ${replicas.filter((r) => r.enabled !== false).length} replica(s).`
+          : `${modelKey} is back to a single deployment.`,
+      });
+      onSaved?.(replicas);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Save failed';
+      setError(message);
+      notifications.show({ color: 'red', title: 'Could not save the pool', message });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Stack gap="md">
+      <Paper withBorder radius="md" p="md">
+        <Stack gap="sm">
+          <Group gap="xs" justify="space-between">
+            <Group gap="xs">
+              <IconStack2 size={18} />
+              <Text fw={600}>Replicas</Text>
+              <Badge variant="light" color={pooled ? 'teal' : 'gray'}>
+                {pooled ? `${replicas.length} in pool` : 'single deployment'}
+              </Badge>
+            </Group>
+            <Group gap="xs">
+              <Button
+                variant="default"
+                size="xs"
+                leftSection={<IconPlus size={14} />}
+                onClick={add}
+              >
+                Add replica
+              </Button>
+              <Button
+                size="xs"
+                loading={saving}
+                leftSection={<IconDeviceFloppy size={14} />}
+                onClick={() => void save()}
+              >
+                Save
+              </Button>
+            </Group>
+          </Group>
+
+          <Text size="sm" c="dimmed">
+            Interchangeable deployments of this same model. Traffic is split by weight across the
+            healthy ones, and a request that hits a deployment which is rate-limited, down or
+            cooling off is retried on the next — so callers keep asking for{' '}
+            <Text span fw={600}>{modelKey}</Text> and never learn which one answered. Routing to a
+            different model is a Dynamic LLM, not a pool.
+          </Text>
+
+          {replicas.length === 0 ? (
+            <Text size="sm" c="dimmed">
+              No pool. Every request goes to{' '}
+              <Text span fw={600}>{ownProviderKey}</Text> · <Text span fw={600}>{ownModelId}</Text>.
+            </Text>
+          ) : (
+            <Table striped withTableBorder>
+              <Table.Thead>
+                <Table.Tr>
+                  <Table.Th>Provider</Table.Th>
+                  <Table.Th>Upstream model / deployment</Table.Th>
+                  <Table.Th w={110}>Weight</Table.Th>
+                  <Table.Th w={100}>Enabled</Table.Th>
+                  <Table.Th w={44} />
+                </Table.Tr>
+              </Table.Thead>
+              <Table.Tbody>
+                {replicas.map((replica, index) => (
+                  <Table.Tr key={`${replica.providerKey}-${index}`}>
+                    <Table.Td>
+                      <Select
+                        size="xs"
+                        data={providers.map((p) => ({ value: p.key, label: p.label || p.key }))}
+                        value={replica.providerKey}
+                        onChange={(value) => update(index, { providerKey: value ?? '' })}
+                        searchable
+                      />
+                    </Table.Td>
+                    <Table.Td>
+                      <TextInput
+                        size="xs"
+                        placeholder={ownModelId}
+                        value={replica.modelId}
+                        onChange={(e) => update(index, { modelId: e.currentTarget.value })}
+                      />
+                    </Table.Td>
+                    <Table.Td>
+                      <NumberInput
+                        size="xs"
+                        min={1}
+                        value={replica.weight ?? 1}
+                        onChange={(value) => update(index, { weight: Number(value) || 1 })}
+                      />
+                    </Table.Td>
+                    <Table.Td>
+                      <Switch
+                        size="sm"
+                        checked={replica.enabled !== false}
+                        onChange={(e) => update(index, { enabled: e.currentTarget.checked })}
+                        aria-label={`Enable replica ${index + 1}`}
+                      />
+                    </Table.Td>
+                    <Table.Td>
+                      <ActionIcon
+                        variant="subtle"
+                        color="red"
+                        aria-label={`Remove replica ${index + 1}`}
+                        onClick={() => setReplicas((c) => c.filter((_, i) => i !== index))}
+                      >
+                        <IconTrash size={15} />
+                      </ActionIcon>
+                    </Table.Td>
+                  </Table.Tr>
+                ))}
+              </Table.Tbody>
+            </Table>
+          )}
+        </Stack>
+      </Paper>
+
+      {error ? (
+        <Alert color="red" icon={<IconAlertTriangle size={16} />} title="Could not save the pool">
+          {error}
+        </Alert>
+      ) : null}
+
+      <Alert color="gray" variant="light" title="What a pool does not change">
+        Pricing, capabilities, guardrail bindings, quota and the semantic cache stay on the model —
+        every replica is the same model, so splitting them would fork the bill and the cache.
+        Failover covers opening the call; once a streamed answer has started it runs to the end on
+        the deployment that began it. Pooling applies to chat completions.
+      </Alert>
+    </Stack>
+  );
+}

--- a/src/lib/database/index.ts
+++ b/src/lib/database/index.ts
@@ -176,6 +176,7 @@ export type {
   IAgentTracingSession,
   IAgentTracingEvent,
   IModel,
+  IModelReplica,
   IModelUsageLog,
   ModelUsageStatus,
   IModelUsageAggregate,

--- a/src/lib/database/provider/types.base.ts
+++ b/src/lib/database/provider/types.base.ts
@@ -470,6 +470,29 @@ export interface IModelPricing {
 // child model — by rules (signal thresholds) or by a decider model — and
 // recurses through `handleChatCompletion` against the chosen key.
 
+/**
+ * One deployment behind a pooled model.
+ *
+ * `settings` is merged OVER the model's own settings for calls that land here,
+ * which is what makes a pool able to span providers whose knobs differ — an
+ * Azure replica needing its own `azureApiVersion`, say. Everything that must
+ * stay identical across replicas (pricing, capability profile, cache key,
+ * guardrail bindings, quota attribution) deliberately lives on the model and
+ * has no per-replica form.
+ */
+export interface IModelReplica {
+  providerKey: string;
+  /** Upstream model id at THIS provider — a deployment name on Azure. */
+  modelId: string;
+  /** Relative share of traffic among healthy replicas. Defaults to 1. */
+  weight?: number;
+  /** Defaults to true. A disabled replica is drained without being deleted. */
+  enabled?: boolean;
+  /** Per-replica overrides merged over `IModel.settings`. */
+  settings?: Record<string, unknown>;
+  label?: string;
+}
+
 export type DynamicRoutingStrategy = 'rule-based' | 'model-based';
 
 /** Signals computed from the chat request, available to rule conditions. */
@@ -754,6 +777,20 @@ export interface IModel {
   settings: Record<string, unknown>;
   pricing: IModelPricing;
   semanticCache?: ISemanticCacheConfig;
+  /**
+   * Interchangeable deployments of THIS SAME model, for capacity and
+   * resilience. Every replica must be the same model — same pricing, same
+   * capabilities, same answers — because the caller asked for this model and
+   * cannot tell which replica served it. Routing to a DIFFERENT model is what
+   * Dynamic LLM does (`dynamic` below), and the two compose: a Dynamic route
+   * picks a model key, and that model may itself be pooled.
+   *
+   * ABSENT means "one replica", built from the `providerKey`/`modelId` on this
+   * record — so every existing model keeps working with no migration, and the
+   * top-level pair stays the identity of the model rather than becoming
+   * vestigial.
+   */
+  replicas?: IModelReplica[];
   /**
    * Multi-guardrail binding. AUTHORITATIVE when present: the two deprecated
    * single-slot keys below are then ignored, not merged — see

--- a/src/lib/database/sqlite/base.ts
+++ b/src/lib/database/sqlite/base.ts
@@ -814,6 +814,7 @@ export class SQLiteProviderBase {
     // The AGENT side needs no migration: its bindings live in IAgentConfig and
     // ride the existing `config` JSON column on both backends.
     this.ensureTableColumn(db, TABLES.models, 'guardrails', 'guardrails TEXT');
+    this.ensureTableColumn(db, TABLES.models, 'replicas', 'replicas TEXT');
     // Evaluation log: without these, all five hooks collapse into the two
     // legacy `target` values and a tool.pre block is indistinguishable from an
     // output.pre redaction in the audit trail. riskScore has no other home.

--- a/src/lib/database/sqlite/model.mixin.ts
+++ b/src/lib/database/sqlite/model.mixin.ts
@@ -3,6 +3,7 @@
  */
 
 import type {
+  IModelReplica,
   IGuardrailBinding,
   IModel, IModelUsageLog, IModelUsageAggregate,
   ModelCategory, ModelProviderType,
@@ -24,10 +25,10 @@ export function ModelMixin<TBase extends Constructor<SQLiteProviderBase>>(Base: 
         INSERT INTO ${TABLES.models}
         (id, tenantId, projectId, name, description, key, providerKey, providerDriver, provider,
          category, modelId, isMultimodal, supportsToolCalls, settings, pricing, semanticCache,
-         inputGuardrailKey, outputGuardrailKey, guardrails, metadata, createdBy, updatedBy, createdAt, updatedAt)
+         inputGuardrailKey, outputGuardrailKey, guardrails, replicas, metadata, createdBy, updatedBy, createdAt, updatedAt)
         VALUES (@id, @tenantId, @projectId, @name, @description, @key, @providerKey, @providerDriver, @provider,
          @category, @modelId, @isMultimodal, @supportsToolCalls, @settings, @pricing, @semanticCache,
-         @inputGuardrailKey, @outputGuardrailKey, @guardrails, @metadata, @createdBy, @updatedBy, @createdAt, @updatedAt)
+         @inputGuardrailKey, @outputGuardrailKey, @guardrails, @replicas, @metadata, @createdBy, @updatedBy, @createdAt, @updatedAt)
       `).run({
         id,
         tenantId: model.tenantId,
@@ -51,6 +52,7 @@ export function ModelMixin<TBase extends Constructor<SQLiteProviderBase>>(Base: 
         // operator saying "bound to nothing", NULL is "never authored" and is
         // what makes resolveBindings fall back to the two legacy keys above.
         guardrails: model.guardrails ? this.toJson(model.guardrails) : null,
+        replicas: model.replicas ? this.toJson(model.replicas) : null,
         metadata: this.toJson(model.metadata ?? {}),
         createdBy: model.createdBy ?? null,
         updatedBy: model.updatedBy ?? null,
@@ -84,6 +86,7 @@ export function ModelMixin<TBase extends Constructor<SQLiteProviderBase>>(Base: 
       // real operator action and must not be rewritten to the "never authored"
       // NULL, which would resurrect the deprecated legacy keys.
       if (data.guardrails !== undefined) { sets.push('guardrails = @guardrails'); params.guardrails = data.guardrails ? this.toJson(data.guardrails) : null; }
+      if (data.replicas !== undefined) { sets.push('replicas = @replicas'); params.replicas = data.replicas ? this.toJson(data.replicas) : null; }
       if (data.metadata !== undefined) { sets.push('metadata = @metadata'); params.metadata = this.toJson(data.metadata); }
       if (data.updatedBy !== undefined) { sets.push('updatedBy = @updatedBy'); params.updatedBy = data.updatedBy; }
       if (data.projectId !== undefined) { sets.push('projectId = @projectId'); params.projectId = data.projectId; }
@@ -361,6 +364,13 @@ export function ModelMixin<TBase extends Constructor<SQLiteProviderBase>>(Base: 
         // null rather than to the fallback.
         guardrails: ((): IGuardrailBinding[] | undefined => {
           const parsed = this.parseJson<IGuardrailBinding[] | null>(r.guardrails, null);
+          return Array.isArray(parsed) ? parsed : undefined;
+        })(),
+        // Same undefined-vs-[] care as `guardrails`: an empty array here would
+        // mean "pooled, with nowhere to send traffic", which is not what a
+        // pre-pool row is saying.
+        replicas: ((): IModelReplica[] | undefined => {
+          const parsed = this.parseJson<IModelReplica[] | null>(r.replicas, null);
           return Array.isArray(parsed) ? parsed : undefined;
         })(),
         metadata: this.parseJson(r.metadata, {}),

--- a/src/lib/database/sqlite/schema.ts
+++ b/src/lib/database/sqlite/schema.ts
@@ -558,6 +558,11 @@ export const TENANT_SCHEMA_SQL = `
     -- undefined, and resolveBindings reads undefined as "fall back to the two
     -- legacy columns" but [] as "authored, bound to nothing".
     guardrails TEXT,
+    -- Replica pool (IModelReplica[]) as ONE JSON blob, same reasoning as the
+    -- guardrails column above. NULL means no pool: the model's own
+    -- providerKey/modelId are then its single replica, which is what every row
+    -- written before pools existed says.
+    replicas TEXT,
     metadata TEXT DEFAULT '{}',
     createdBy TEXT,
     updatedBy TEXT,

--- a/src/lib/services/models/inferenceService.ts
+++ b/src/lib/services/models/inferenceService.ts
@@ -19,6 +19,12 @@ import type {
 } from '@/lib/providers';
 import { resolveUnsupportedParamNames } from '@/lib/providers/unsupportedParams';
 import { createInlineReasoningSplitter } from '@/lib/shared/inlineReasoning';
+import {
+  modelForReplica,
+  replicaOrder,
+  shouldTryNextReplica,
+  type ResolvedReplica,
+} from './replicaPool';
 import { repairJsonContent } from '@/lib/shared/jsonExtraction';
 import { InvalidRequestError } from '@/lib/providers/contracts/upstreamError';
 import { getModelByKey } from './modelService';
@@ -1104,6 +1110,80 @@ export function resolveModelInvocationConfig(
 }
 
 /**
+ * Runs one call across a model's replica pool.
+ *
+ * Each replica is a full attempt: its own parameter resolution (drivers differ,
+ * so the set of parameters an upstream rejects differs with them), its own
+ * runtime, and its own circuit breaker. A capacity or availability fault moves
+ * to the next replica; the caller's own mistakes do not travel, because a 400
+ * fails identically everywhere and retrying it only multiplies the bill.
+ *
+ * `attempt` is handed the model AS THAT REPLICA — `providerKey`, `modelId` and
+ * merged `settings` already swapped — so nothing downstream has to know a pool
+ * exists.
+ */
+/**
+ * The replica detail carried on a usage row. Absent for an unpooled model, so
+ * existing rows and dashboards are untouched until someone adds a replica.
+ */
+function replicaTrace(
+  model: IModel,
+  replica: ResolvedReplica,
+  failed: readonly ResolvedReplica[] = [],
+): Record<string, unknown> | undefined {
+  const pooled = Array.isArray(model.replicas) && model.replicas.length > 0;
+  if (!pooled) return undefined;
+  return {
+    replica: {
+      index: replica.index,
+      providerKey: replica.providerKey,
+      modelId: replica.modelId,
+      ...(replica.label ? { label: replica.label } : {}),
+      ...(failed.length > 0
+        ? { failedOver: failed.map((entry) => `${entry.providerKey}:${entry.modelId}`) }
+        : {}),
+    },
+  };
+}
+
+async function runAcrossReplicas<T>(
+  model: IModel,
+  prefix: 'chat' | 'chat-stream',
+  attempt: (activeModel: IModel, replica: ResolvedReplica) => Promise<T>,
+): Promise<{ value: T; replica: ResolvedReplica; failed: ResolvedReplica[] }> {
+  const order = replicaOrder(model, prefix);
+  const failed: ResolvedReplica[] = [];
+  let lastError: unknown;
+
+  for (let i = 0; i < order.length; i += 1) {
+    const replica = order[i];
+    try {
+      const value = await attempt(modelForReplica(model, replica), replica);
+      if (failed.length > 0) {
+        logger.info('Replica failover succeeded', {
+          modelKey: model.key,
+          served: `${replica.providerKey}:${replica.modelId}`,
+          skipped: failed.map((entry) => `${entry.providerKey}:${entry.modelId}`),
+        });
+      }
+      return { value, replica, failed };
+    } catch (error) {
+      lastError = error;
+      const isLast = i === order.length - 1;
+      if (isLast || !shouldTryNextReplica(error)) throw error;
+      failed.push(replica);
+      logger.warn('Replica failed, trying the next one', {
+        modelKey: model.key,
+        replica: `${replica.providerKey}:${replica.modelId}`,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  throw lastError;
+}
+
+/**
  * Circuit-breaker key for a chat call.
  *
  * Scoped to the MODEL, not just the provider. One Model Hub entry can be broken
@@ -1508,21 +1588,38 @@ export async function handleChatCompletion(params: {
     }
   }
 
-  const { runtime } = await buildModelRuntime(
-    tenantDbName,
-    model.tenantId,
-    model.providerKey,
-    projectId,
-  );
-
-  if (!runtime.createChatModel) {
-    throw new Error('Model provider does not support chat completions');
-  }
-
   const messagesInput = body.messages as Parameters<typeof toLangChainMessages>[0];
   const messages = toLangChainMessages(messagesInput);
-  const { modelSettings, callOptions, overrides } = invocation;
-  const outputTokenLimit = resolveOutputTokenLimit(overrides, modelSettings);
+
+  /**
+   * Everything needed to place ONE call, resolved for the replica that will
+   * serve it.
+   *
+   * This runs per replica rather than once per request because the parts that
+   * depend on the upstream genuinely differ between them: the parameter
+   * registry is keyed on driver AND model id, so a pool spanning Azure and
+   * Bedrock strips (and forces) different fields on each leg, and the runtime
+   * is built from the replica's own provider credentials.
+   *
+   * What is deliberately NOT in here: the cache variant key and the quota
+   * context, both resolved once from the model above. A pool must not fork the
+   * cache or split a budget — every replica is the same model.
+   */
+  const prepareCall = async (activeModel: IModel) => {
+    const { runtime } = await buildModelRuntime(
+      tenantDbName,
+      activeModel.tenantId,
+      activeModel.providerKey,
+      projectId,
+    );
+
+    if (!runtime.createChatModel) {
+      throw new InvalidRequestError('Model provider does not support chat completions');
+    }
+
+    const call = resolveModelInvocationConfig(activeModel, body);
+    const { modelSettings, callOptions, overrides } = call;
+    const outputTokenLimit = resolveOutputTokenLimit(overrides, modelSettings);
   // A streamed request that carries tools used to be answered by a single
   // `invoke()` replayed as one SSE frame. The reason was real at the time —
   // the collapsed `tool_calls` on a streamed chunk arrive with empty arguments
@@ -1533,63 +1630,83 @@ export async function handleChatCompletion(params: {
   // tools) and from Onyx, i.e. exactly the clients that reported streaming not
   // working. Tools are the normal case, not the exception; the escape hatch
   // stays per-model for an upstream that really cannot stream them.
-  const disableProviderStreaming = Boolean(
-    stream
-    && modelSettings.disableStreamingWithTools === true
-    && Array.isArray(overrides.tools)
-    && overrides.tools.length > 0,
-  );
-  const includeStreamUsage =
-    asRecord(overrides.stream_options).include_usage === true;
+    const disableProviderStreaming = Boolean(
+      stream
+      && modelSettings.disableStreamingWithTools === true
+      && Array.isArray(overrides.tools)
+      && overrides.tools.length > 0,
+    );
+    const includeStreamUsage =
+      asRecord(overrides.stream_options).include_usage === true;
 
-  if (disableProviderStreaming) {
-    delete callOptions.stream_options;
-  }
-
-  const chatModel = ensureChatRunnable(await runtime.createChatModel({
-    modelId: model.modelId,
-    category: model.category,
-    modelSettings,
-    options: {
-      streaming: Boolean(stream),
-      disableStreaming: disableProviderStreaming,
-      // `withResilience` owns retry and circuit-breaking on this path, so the
-      // provider SDK must not retry underneath it.
-      maxRetries: 0,
-    },
-  }));
-
-  if (stream) {
-    if (!disableProviderStreaming && typeof chatModel.stream !== 'function') {
-      throw new Error('Model provider does not support streaming responses');
+    if (disableProviderStreaming) {
+      delete callOptions.stream_options;
     }
 
+    const chatModel = ensureChatRunnable(await runtime.createChatModel({
+      modelId: activeModel.modelId,
+      category: activeModel.category,
+      modelSettings,
+      options: {
+        streaming: Boolean(stream),
+        disableStreaming: disableProviderStreaming,
+        // `withResilience` owns retry and circuit-breaking on this path, so the
+        // provider SDK must not retry underneath it.
+        maxRetries: 0,
+      },
+    }));
+
+    return {
+      chatModel,
+      modelSettings,
+      callOptions,
+      overrides,
+      outputTokenLimit,
+      disableProviderStreaming,
+      includeStreamUsage,
+    };
+  };
+
+  if (stream) {
     // A disconnected client used to leave the provider generating (and billing)
     // until it finished on its own. Cancelling the readable — which Fastify does
     // when the response socket closes — now aborts the upstream call.
     const abortController = new AbortController();
-    const streamCallOptions = { ...callOptions, signal: abortController.signal };
 
-    let asyncIterator: AsyncIterable<AIMessageChunk>;
-    if (disableProviderStreaming) {
-      const eagerMessage = await withResilience(
-        (signal) => chatModel.invoke(messages, { ...callOptions, signal }),
-        { key: chatResilienceKey('chat', model) },
-      );
-      asyncIterator = (async function* () {
-        yield new AIMessageChunk({
-          content: eagerMessage.content,
-          additional_kwargs: eagerMessage.additional_kwargs,
-          response_metadata: eagerMessage.response_metadata,
-          id: eagerMessage.id,
-          name: eagerMessage.name,
-          usage_metadata: eagerMessage.usage_metadata,
-          tool_calls: eagerMessage.tool_calls,
-          invalid_tool_calls: eagerMessage.invalid_tool_calls,
-        });
-      })();
-    } else {
-      asyncIterator = await withResilience(
+    // FAILOVER ENDS HERE. Opening the stream is the last moment a different
+    // replica can serve this request: once a byte has reached the client, the
+    // answer is half-written and retrying elsewhere would splice two different
+    // completions together. So the pool covers connection and handshake
+    // failures, and a mid-stream fault stays a mid-stream fault.
+    const opened = await runAcrossReplicas(model, 'chat-stream', async (activeModel) => {
+      const prepared = await prepareCall(activeModel);
+      if (!prepared.disableProviderStreaming && typeof prepared.chatModel.stream !== 'function') {
+        throw new InvalidRequestError('Model provider does not support streaming responses');
+      }
+
+      const streamCallOptions = { ...prepared.callOptions, signal: abortController.signal };
+
+      if (prepared.disableProviderStreaming) {
+        const eagerMessage = await withResilience(
+          (signal) => prepared.chatModel.invoke(messages, { ...prepared.callOptions, signal }),
+          { key: chatResilienceKey('chat', activeModel) },
+        );
+        const iterator: AsyncIterable<AIMessageChunk> = (async function* () {
+          yield new AIMessageChunk({
+            content: eagerMessage.content,
+            additional_kwargs: eagerMessage.additional_kwargs,
+            response_metadata: eagerMessage.response_metadata,
+            id: eagerMessage.id,
+            name: eagerMessage.name,
+            usage_metadata: eagerMessage.usage_metadata,
+            tool_calls: eagerMessage.tool_calls,
+            invalid_tool_calls: eagerMessage.invalid_tool_calls,
+          });
+        })();
+        return { activeModel, prepared, asyncIterator: iterator };
+      }
+
+      const iterator = await withResilience(
         (signal) => {
           // The stream already aborts on client disconnect; chain the gateway's
           // timeout into the same controller so a provider that never opens the
@@ -1599,11 +1716,17 @@ export async function handleChatCompletion(params: {
             () => abortController.abort(signal.reason),
             { once: true },
           );
-          return chatModel.stream!(messages, streamCallOptions) as Promise<AsyncIterable<AIMessageChunk>>;
+          return prepared.chatModel.stream!(messages, streamCallOptions) as Promise<AsyncIterable<AIMessageChunk>>;
         },
-        { key: chatResilienceKey('chat-stream', model) },
+        { key: chatResilienceKey('chat-stream', activeModel) },
       );
-    }
+      return { activeModel, prepared, asyncIterator: iterator };
+    });
+
+    const servingReplica = opened.replica;
+    const asyncIterator = opened.value.asyncIterator;
+    const { overrides, outputTokenLimit, includeStreamUsage } = opened.value.prepared;
+
     const startedAt = Date.now();
     const completionId = newCompletionId();
     const completionCreated = Math.floor(Date.now() / 1000);
@@ -1861,6 +1984,7 @@ export async function handleChatCompletion(params: {
                 overrides,
                 stream: true,
                 ...describeRequestContract(body),
+                ...replicaTrace(model, servingReplica, opened.failed),
               }),
               providerResponse: sanitizeForLogging({
                 guardrail_blocked: true,
@@ -2079,6 +2203,7 @@ export async function handleChatCompletion(params: {
                 overrides,
                 stream: true,
                 ...describeRequestContract(body),
+                ...replicaTrace(model, servingReplica, opened.failed),
               }),
               providerResponse: sanitizeForLogging(providerResponse),
               errorMessage: outputLimitError?.message,
@@ -2146,6 +2271,7 @@ export async function handleChatCompletion(params: {
                 overrides,
                 stream: true,
                 ...describeRequestContract(body),
+                ...replicaTrace(model, servingReplica, opened.failed),
               }),
               providerResponse: sanitizeForLogging({ error: errorMessage }),
               errorMessage,
@@ -2173,13 +2299,24 @@ export async function handleChatCompletion(params: {
     return { stream: readable, requestId, streamHeaders };
   }
 
-  const aiMessage = await withResilience(
-    (signal) => chatModel.invoke(messages, { ...callOptions, signal }),
-    { key: chatResilienceKey('chat', model) },
-  );
+  const completed = await runAcrossReplicas(model, 'chat', async (candidate) => {
+    const prepared = await prepareCall(candidate);
+    const message = await withResilience(
+      (signal) => prepared.chatModel.invoke(messages, { ...prepared.callOptions, signal }),
+      { key: chatResilienceKey('chat', candidate) },
+    );
+    return { candidate, prepared, message };
+  });
+
+  const servingReplica = completed.replica;
+  const failedReplicas = completed.failed;
+  const { overrides, outputTokenLimit } = completed.value.prepared;
+  const aiMessage = completed.value.message;
 
   const latencyMs = Date.now() - start;
   const response = toOpenAIChatResponse(aiMessage, {
+    // The MODEL's id, never the replica's: the caller asked for this model and
+    // must not be able to tell which deployment answered.
     model: model.modelId,
     stream: false,
   });
@@ -2233,6 +2370,7 @@ export async function handleChatCompletion(params: {
         overrides,
         stream: false,
         ...describeRequestContract(body),
+        ...replicaTrace(model, servingReplica, failedReplicas),
       }),
       providerResponse: sanitizeForLogging(response),
       latencyMs,

--- a/src/lib/services/models/replicaPool.ts
+++ b/src/lib/services/models/replicaPool.ts
@@ -1,0 +1,176 @@
+/**
+ * Replica pools: interchangeable deployments of the SAME model.
+ *
+ * The distinction that shapes everything here — a pool answers "which copy of
+ * this model?", Dynamic LLM answers "which model?". A pool must therefore be
+ * INVISIBLE: same price, same capability profile, same cache key, one usage
+ * row. Only the deployment actually dialled differs, and that is recorded as a
+ * detail of the call rather than as a routing decision.
+ *
+ * Health comes free from the circuit breaker. `chatResilienceKey` is already
+ * scoped to `provider:modelId`, which is exactly replica granularity, so an
+ * open breaker IS the "this deployment is cooling down" signal — no separate
+ * health subsystem, no second source of truth about what is failing.
+ */
+import type { IModel } from '@/lib/database';
+import { getCircuitState } from '@/lib/core/resilience';
+
+export interface ResolvedReplica {
+  /** Position in the pool, stable across a request for logging. */
+  index: number;
+  providerKey: string;
+  modelId: string;
+  weight: number;
+  label?: string;
+  settings?: Record<string, unknown>;
+}
+
+/**
+ * The pool as a list, including the single-replica case.
+ *
+ * A model with no `replicas` is a pool of one built from its own
+ * `providerKey`/`modelId`, so every path below is the same path whether or not
+ * an operator ever opened the Replicas tab.
+ */
+export function listReplicas(model: IModel): ResolvedReplica[] {
+  const configured = Array.isArray(model.replicas) ? model.replicas : [];
+  const enabled = configured.filter((replica) => replica?.enabled !== false && replica?.providerKey);
+
+  if (enabled.length === 0) {
+    return [{
+      index: 0,
+      providerKey: model.providerKey,
+      modelId: model.modelId,
+      weight: 1,
+    }];
+  }
+
+  return enabled.map((replica, index) => ({
+    index,
+    providerKey: replica.providerKey,
+    modelId: replica.modelId || model.modelId,
+    weight: typeof replica.weight === 'number' && replica.weight > 0 ? replica.weight : 1,
+    label: replica.label,
+    settings: replica.settings,
+  }));
+}
+
+/** True when this replica's breaker is open, i.e. it is cooling down. */
+function isCooling(prefix: string, replica: ResolvedReplica): boolean {
+  return getCircuitState(`${prefix}:${replica.providerKey}:${replica.modelId}`)?.state === 'open';
+}
+
+/**
+ * The order to try replicas in for one request.
+ *
+ * Healthy replicas are shuffled by weight and come first; cooling ones are kept
+ * at the BACK rather than dropped, so a pool whose breakers all tripped still
+ * attempts a call instead of failing the request outright on stale state — the
+ * breaker will re-test one of them on its own half-open schedule.
+ */
+export function replicaOrder(
+  model: IModel,
+  prefix: 'chat' | 'chat-stream',
+  random: () => number = Math.random,
+): ResolvedReplica[] {
+  const replicas = listReplicas(model);
+  if (replicas.length === 1) return replicas;
+
+  const healthy: ResolvedReplica[] = [];
+  const cooling: ResolvedReplica[] = [];
+  for (const replica of replicas) {
+    (isCooling(prefix, replica) ? cooling : healthy).push(replica);
+  }
+
+  return [...weightedShuffle(healthy, random), ...weightedShuffle(cooling, random)];
+}
+
+/**
+ * Weighted random order, drawing without replacement so the whole pool stays
+ * available as a fallback chain rather than only its first pick.
+ */
+function weightedShuffle(
+  replicas: readonly ResolvedReplica[],
+  random: () => number,
+): ResolvedReplica[] {
+  const pool = [...replicas];
+  const ordered: ResolvedReplica[] = [];
+
+  while (pool.length > 0) {
+    const total = pool.reduce((sum, replica) => sum + replica.weight, 0);
+    let ticket = random() * total;
+    let picked = pool.length - 1;
+    for (let i = 0; i < pool.length; i += 1) {
+      ticket -= pool[i].weight;
+      if (ticket <= 0) {
+        picked = i;
+        break;
+      }
+    }
+    ordered.push(pool[picked]);
+    pool.splice(picked, 1);
+  }
+
+  return ordered;
+}
+
+/**
+ * The model as it looks when this replica serves the call.
+ *
+ * Handed to everything downstream — parameter resolution, runtime construction,
+ * the resilience key, the usage row — so none of them needs to know a pool
+ * exists. `settings` is merged shallowly: a replica overrides individual knobs
+ * (`azureApiVersion`) without having to restate the model's whole settings
+ * object.
+ */
+export function modelForReplica(model: IModel, replica: ResolvedReplica): IModel {
+  if (replica.providerKey === model.providerKey && replica.modelId === model.modelId && !replica.settings) {
+    return model;
+  }
+  return {
+    ...model,
+    providerKey: replica.providerKey,
+    modelId: replica.modelId,
+    ...(replica.settings
+      ? { settings: { ...(model.settings ?? {}), ...replica.settings } }
+      : {}),
+  };
+}
+
+/**
+ * Whether a failure should move to the next replica.
+ *
+ * Capacity and availability faults travel; the caller's own mistakes do not. A
+ * 400 or a 401 will fail identically on every replica, so retrying one is pure
+ * cost and pure latency — and for an auth fault it is also a way to lock out
+ * several provider credentials instead of one.
+ */
+export function shouldTryNextReplica(error: unknown): boolean {
+  const status = readStatus(error);
+  if (status !== undefined) {
+    if (status === 408 || status === 409 || status === 429) return true;
+    return status >= 500;
+  }
+
+  const signal = `${(error as Error)?.name ?? ''} ${(error as Error)?.message ?? ''}`.toLowerCase();
+  return /circuit breaker|timeout|timed out|aborterror|econn|enotfound|fetch failed|connection (error|refused|reset)|socket hang up|unavailable/.test(
+    signal,
+  );
+}
+
+function readStatus(error: unknown): number | undefined {
+  const seen = new Set<unknown>();
+  const queue: unknown[] = [error];
+  while (queue.length > 0) {
+    const current = queue.shift();
+    if (!current || typeof current !== 'object' || seen.has(current)) continue;
+    seen.add(current);
+    const record = current as Record<string, unknown>;
+    for (const key of ['status', 'statusCode', 'status_code']) {
+      const value = record[key];
+      if (typeof value === 'number' && value >= 100 && value < 600) return value;
+    }
+    queue.push(record.error, record.response, record.cause);
+  }
+  return undefined;
+}

--- a/src/lib/services/models/types.ts
+++ b/src/lib/services/models/types.ts
@@ -1,4 +1,4 @@
-import type { IModel, IModelPricing, ISemanticCacheConfig, ModelCategory } from '@/lib/database';
+import type { IModel, IModelPricing, IModelReplica, ISemanticCacheConfig, ModelCategory } from '@/lib/database';
 import type { IGuardrailBinding } from '@/lib/database/provider/types.domain';
 import type { ProviderCapabilityFlags } from '@/lib/providers';
 import type {
@@ -56,6 +56,12 @@ export interface UpdateModelInput {
    * console binary on the same tenant DB stops enforcing.
    */
   guardrails?: IGuardrailBinding[];
+  /**
+   * Replica pool — interchangeable deployments of this same model. An empty
+   * array clears the pool and returns the model to its own
+   * `providerKey`/`modelId`.
+   */
+  replicas?: IModelReplica[];
   /** @deprecated Use `guardrails`. Kept as the read fallback for legacy rows. */
   inputGuardrailKey?: string;
   /** @deprecated Use `guardrails`. Kept as the read fallback for legacy rows. */

--- a/src/server/api/plugin.ts
+++ b/src/server/api/plugin.ts
@@ -21,6 +21,7 @@ import { applyCorsHeaders } from './cors';
 import { authApiPlugin } from './plugins/auth';
 import { clientA2aApiPlugin } from './plugins/client-a2a';
 import { clientAgentsApiPlugin } from './plugins/client-agents';
+import { clientAssistantsApiPlugin } from './plugins/client-assistants';
 import { clientAnalyticsApiPlugin } from './plugins/client-analytics';
 import { clientAuditApiPlugin } from './plugins/client-audit';
 import { clientMonitoringApiPlugin } from './plugins/client-monitoring';
@@ -439,6 +440,7 @@ export const fastifyApiPlugin: FastifyPluginAsync = async (app) => {
   await app.register(authApiPlugin);
   await app.register(clientA2aApiPlugin);
   await app.register(clientAgentsApiPlugin);
+  await app.register(clientAssistantsApiPlugin);
   await app.register(clientAnalyticsApiPlugin);
   await app.register(clientAuditApiPlugin);
   await app.register(clientMonitoringApiPlugin);

--- a/src/server/api/plugins/client-assistants.ts
+++ b/src/server/api/plugins/client-assistants.ts
@@ -1,0 +1,888 @@
+/**
+ * Assistants API dialect (OpenAI's legacy Assistants surface), wired onto the
+ * SAME agent engine `client-agents.ts` and `/client/v1/responses` already run.
+ *
+ * This is a WIRE ADAPTER, not a second engine: an Assistant IS an `IAgent`, a
+ * Thread IS an `IAgentConversation`, and a Run is one `executeAgentChat` call.
+ * Nothing here talks to a model, a tool or a guardrail directly — it only
+ * translates the Assistants nouns onto the calls `client-agents.ts` already
+ * makes, so every enforcement path (guardrails, quota, tracing) is exercised
+ * exactly once, in the same place, regardless of which dialect a caller used.
+ *
+ * Three deliberate departures from OpenAI's own semantics, forced by how the
+ * underlying engine actually runs:
+ *
+ * 1. A THREAD IS BOUND TO ONE ASSISTANT FOR ITS LIFETIME, set at creation.
+ *    OpenAI's threads are assistant-agnostic; a run supplies the assistant.
+ *    Our `IAgentConversation.agentKey` is required and, by the database
+ *    contract's own typing (`updateAgentConversation` omits it from its
+ *    patchable fields), immutable — so this was already true of the storage
+ *    this dialect sits on, not a new restriction invented for it.
+ *
+ * 2. EVERY RUN COMPLETES SYNCHRONOUSLY. `executeAgentChat` runs the whole tool
+ *    loop itself (RAG, MCP, system tools) and returns final text; nothing
+ *    pauses mid-run for the caller to act, so there is no `queued` /
+ *    `in_progress` state and no `requires_action` /
+ *    `submit_tool_outputs`. A run is created already `completed` or `failed`.
+ *    `POST .../runs/:runId/cancel` therefore always 400s — there is nothing
+ *    in flight to cancel by the time a caller could reach it.
+ *
+ * 3. CLIENT-EXECUTED FUNCTION TOOLS ARE NOT SUPPORTED, for the same reason:
+ *    a `function` tool's contract is "the run pauses, the caller executes the
+ *    tool locally, the caller submits the result" — which needs the async
+ *    state machine departure (2) rules out. `code_interpreter` has no backing
+ *    runtime wired to this path yet. `file_search` maps to the agent's own
+ *    Knowledge Engine module; Console's own tool/MCP/system catalog is
+ *    reachable through the `console_tool` extension below.
+ */
+import { randomUUID } from 'node:crypto';
+import type { FastifyPluginAsync } from 'fastify';
+import { createLogger } from '@/lib/core/logger';
+import { getDatabase } from '@/lib/database';
+import type {
+  IAgent,
+  IAgentConfig,
+  IAgentConversation,
+  IAgentToolBinding,
+} from '@/lib/database';
+import {
+  createAgentRecord,
+  createConversation,
+  executeAgentChat,
+  getAgentByKey,
+  getConversationById,
+  listAgents,
+  updateAgentRecord,
+} from '@/lib/services/agents';
+import { AgentGuardrailBlockedError } from '@/lib/services/agents/agentService';
+import { buildRuntimeContextFromRequest } from '@/lib/services/runtimeContext';
+import {
+  getApiTokenContextForRequest,
+  readJsonBody,
+  withClientApiRequestContext,
+} from '../fastify-utils';
+import { resolveConfigGuardrailBindings } from './guardrail-bindings';
+
+const logger = createLogger('api:client-assistants');
+
+// ── id scheme ──────────────────────────────────────────────────────────────
+// One prefix per resource, matching the `resp_`/`modr_` convention the other
+// dialects already use, so a caller can tell what an id names on sight.
+
+export const assistantId = (agentKey: string) => `asst_${agentKey}`;
+export const agentKeyFromAssistantId = (id: string) => (id.startsWith('asst_') ? id.slice(5) : id);
+export const threadId = (conversationId: string) => `thread_${conversationId}`;
+export const conversationIdFromThreadId = (id: string) => (id.startsWith('thread_') ? id.slice(7) : id);
+export const messageId = (conversationId: string, index: number) => `msg_${conversationId}_${index}`;
+const runId = () => `run_${randomUUID()}`;
+
+// ── shared shapes ────────────────────────────────────────────────────────
+
+interface PendingMessage {
+  id: string;
+  role: 'user' | 'assistant';
+  content: string;
+  created_at: number;
+}
+
+interface RunRecord {
+  id: string;
+  status: 'completed' | 'failed';
+  created_at: number;
+  completed_at?: number;
+  failed_at?: number;
+  assistant_id: string;
+  last_error?: { code: string; message: string };
+  usage?: { prompt_tokens: number; completion_tokens: number; total_tokens: number };
+}
+
+interface AssistantsMetadata {
+  pendingMessages?: PendingMessage[];
+  runs?: RunRecord[];
+}
+
+function readAssistantsMetadata(conversation: IAgentConversation): AssistantsMetadata {
+  const raw = (conversation.metadata as Record<string, unknown> | undefined)?.assistantsApi;
+  return raw && typeof raw === 'object' ? (raw as AssistantsMetadata) : {};
+}
+
+/** Full-column-replace persistence (both DB backends), so the write always
+ * carries the caller's OTHER metadata keys forward untouched. */
+async function writeAssistantsMetadata(
+  conversationId: string,
+  conversation: IAgentConversation,
+  patch: AssistantsMetadata,
+): Promise<void> {
+  const db = await getDatabase();
+  const metadata = { ...(conversation.metadata ?? {}) };
+  metadata.assistantsApi = { ...readAssistantsMetadata(conversation), ...patch };
+  await db.updateAgentConversation(conversationId, { metadata });
+}
+
+/**
+ * Every message a thread has, in creation order: persisted turns first (each
+ * one INDEX-STABLE forever, since the persisted array only ever grows by
+ * appending), then whatever is still pending a run. A promoted pending message
+ * lands at the SAME merged index it held while pending — the run appends
+ * exactly the (user, assistant) pair the one pending message becomes — so an
+ * id handed out before a run stays valid after it.
+ */
+/**
+ * `IAgentConversation.messages[].timestamp` is typed `Date`, but the SQLite
+ * backend's `mapConversation` reads it back with a plain `JSON.parse`
+ * (`agent.mixin.ts`'s `parseJson`) — no reviver — so a persisted message's
+ * timestamp actually arrives here as an ISO STRING at runtime, not a `Date`
+ * instance. A raw `.getTime()` on it throws; this coerces either shape.
+ */
+export function toDate(value: unknown): Date {
+  return value instanceof Date ? value : new Date(value as string);
+}
+
+export function mergedMessages(
+  conversation: IAgentConversation,
+): Array<{ role: string; content: string; timestamp: Date; pending: boolean }> {
+  const persisted = (conversation.messages || []).map((m) => ({
+    role: m.role,
+    content: m.content,
+    timestamp: toDate(m.timestamp),
+    pending: false,
+  }));
+  const pending = readAssistantsMetadata(conversation).pendingMessages ?? [];
+  return [
+    ...persisted,
+    ...pending.map((m) => ({
+      role: m.role,
+      content: m.content,
+      timestamp: new Date(m.created_at * 1000),
+      pending: true,
+    })),
+  ];
+}
+
+export function toMessageObject(
+  conversationId: string,
+  assistantIdValue: string,
+  index: number,
+  entry: { role: string; content: string; timestamp: Date },
+) {
+  return {
+    id: messageId(conversationId, index),
+    object: 'thread.message' as const,
+    created_at: Math.floor(entry.timestamp.getTime() / 1000),
+    thread_id: threadId(conversationId),
+    role: entry.role,
+    content: [{ type: 'text' as const, text: { value: entry.content, annotations: [] } }],
+    assistant_id: entry.role === 'assistant' ? assistantIdValue : null,
+    run_id: null,
+    metadata: {},
+  };
+}
+
+export function toRunObject(threadIdValue: string, run: RunRecord) {
+  return {
+    id: run.id,
+    object: 'thread.run' as const,
+    thread_id: threadIdValue,
+    assistant_id: run.assistant_id,
+    status: run.status,
+    created_at: run.created_at,
+    started_at: run.created_at,
+    completed_at: run.completed_at ?? null,
+    failed_at: run.failed_at ?? null,
+    last_error: run.last_error ?? null,
+    usage: run.usage ?? null,
+    // Always null: every run this engine produces is already terminal by the
+    // time it exists (see module doc, point 2), so nothing is ever mid-run.
+    required_action: null,
+  };
+}
+
+/** Config-shaping errors are the caller's mistake — 400, never 500. */
+export class AssistantRequestError extends Error {}
+
+/**
+ * Builds `IAgentConfig` fields from an Assistants-shaped body.
+ *
+ * `tools` accepts three shapes: OpenAI's `file_search` (mapped to the agent's
+ * Knowledge Engine module via `tool_resources.file_search.vector_store_ids[0]`
+ * — the one attachment point a native agent has), the Console-specific
+ * `console_tool` extension (reaches the SAME tool/MCP/system catalog the
+ * dashboard's tool picker does, via a raw `IAgentToolBinding`), and everything
+ * else (`function`, `code_interpreter`) is refused with a message that says
+ * why, per the module doc's point 3 — never silently dropped, which would
+ * leave a caller believing a tool is armed when it is not.
+ */
+export async function toolBindingsFromAssistantBody(
+  tenantDbName: string,
+  projectId: string,
+  body: Record<string, unknown>,
+): Promise<{ toolBindings?: IAgentToolBinding[]; knowledgeEngineKey?: string }> {
+  const tools = Array.isArray(body.tools) ? body.tools : [];
+  if (tools.length === 0) return {};
+
+  const toolBindings: IAgentToolBinding[] = [];
+  let knowledgeEngineKey: string | undefined;
+
+  for (const [index, entry] of tools.entries()) {
+    const tool = entry as Record<string, unknown>;
+    switch (tool.type) {
+      case 'file_search': {
+        const resources = (body.tool_resources as Record<string, unknown> | undefined)?.file_search as
+          | Record<string, unknown>
+          | undefined;
+        const moduleKey = Array.isArray(resources?.vector_store_ids)
+          ? resources.vector_store_ids[0]
+          : undefined;
+        if (typeof moduleKey !== 'string' || !moduleKey) {
+          throw new AssistantRequestError(
+            'tools[].type "file_search" requires tool_resources.file_search.vector_store_ids: '
+              + 'a one-element array naming the Knowledge Engine module key to search.',
+          );
+        }
+        const db = await getDatabase();
+        await db.switchToTenant(tenantDbName);
+        const ragModule = await db.findRagModuleByKey(moduleKey, projectId);
+        if (!ragModule) {
+          throw new AssistantRequestError(`No Knowledge Engine module with key "${moduleKey}"`);
+        }
+        knowledgeEngineKey = moduleKey;
+        break;
+      }
+      case 'console_tool': {
+        const binding = tool.tool as Record<string, unknown> | undefined;
+        if (
+          !binding
+          || (binding.source !== 'tool' && binding.source !== 'mcp' && binding.source !== 'system')
+          || typeof binding.sourceKey !== 'string'
+          || !Array.isArray(binding.toolNames)
+        ) {
+          throw new AssistantRequestError(
+            `tools[${index}].tool must be { source: "tool"|"mcp"|"system", sourceKey, toolNames: string[] }`,
+          );
+        }
+        toolBindings.push({
+          source: binding.source,
+          sourceKey: binding.sourceKey,
+          toolNames: binding.toolNames.filter((n): n is string => typeof n === 'string'),
+          ...(binding.config && typeof binding.config === 'object'
+            ? { config: binding.config as Record<string, unknown> }
+            : {}),
+        });
+        break;
+      }
+      case 'function':
+        throw new AssistantRequestError(
+          `tools[${index}].type "function" is not supported: a client-executed tool needs the run to `
+            + 'pause and wait for submitted output, and every run on this Assistants dialect completes '
+            + 'synchronously (see the "console_tool" extension for a server-executed alternative).',
+        );
+      case 'code_interpreter':
+        throw new AssistantRequestError(
+          `tools[${index}].type "code_interpreter" is not backed by a runtime on this Assistants dialect yet.`,
+        );
+      default:
+        throw new AssistantRequestError(`tools[${index}].type "${String(tool.type)}" is not recognized.`);
+    }
+  }
+
+  return {
+    ...(toolBindings.length ? { toolBindings } : {}),
+    ...(knowledgeEngineKey ? { knowledgeEngineKey } : {}),
+  };
+}
+
+export function agentToAssistant(agent: IAgent) {
+  return {
+    id: assistantId(agent.key),
+    object: 'assistant' as const,
+    created_at: agent.createdAt ? Math.floor(new Date(agent.createdAt).getTime() / 1000) : 0,
+    name: agent.name,
+    description: agent.description ?? null,
+    model: agent.config.modelKey ?? null,
+    instructions: agent.config.systemPrompt ?? null,
+    tools: (agent.config.toolBindings ?? []).map((binding) => ({
+      type: 'console_tool' as const,
+      tool: binding,
+    })),
+    tool_resources: agent.config.knowledgeEngineKey
+      ? { file_search: { vector_store_ids: [agent.config.knowledgeEngineKey] } }
+      : {},
+    temperature: agent.config.temperature ?? null,
+    top_p: agent.config.topP ?? null,
+    metadata: agent.metadata ?? {},
+  };
+}
+
+export function extractMessageText(input: unknown): string | null {
+  if (typeof input === 'string') return input.trim() || null;
+  if (Array.isArray(input)) {
+    const text = input.find((part) => (part as Record<string, unknown>)?.type === 'text');
+    const value = (text as { text?: unknown } | undefined)?.text;
+    if (typeof value === 'string') return value.trim() || null;
+    if (value && typeof value === 'object' && typeof (value as { value?: unknown }).value === 'string') {
+      return ((value as { value: string }).value.trim()) || null;
+    }
+  }
+  return null;
+}
+
+async function loadThreadOr404(
+  tenantDbName: string,
+  rawThreadId: string,
+): Promise<{ conversation: IAgentConversation; agent: IAgent } | { error: { code: number; message: string } }> {
+  const conversationId = conversationIdFromThreadId(rawThreadId);
+  const conversation = await getConversationById(tenantDbName, conversationId);
+  if (!conversation) return { error: { code: 404, message: 'Thread not found' } };
+  const agent = await getAgentByKey(tenantDbName, conversation.agentKey);
+  if (!agent) return { error: { code: 404, message: 'Thread references an assistant that no longer exists' } };
+  return { conversation, agent };
+}
+
+export const clientAssistantsApiPlugin: FastifyPluginAsync = async (app) => {
+  // ── Assistants ─────────────────────────────────────────────────────────
+
+  app.post('/client/v1/assistants', withClientApiRequestContext(async (request, reply) => {
+    try {
+      const ctx = await getApiTokenContextForRequest(request);
+      const body = readJsonBody<Record<string, unknown>>(request);
+
+      if (typeof body.model !== 'string' || !body.model) {
+        return reply.code(400).send({ error: '`model` is required and must name a registered model key' });
+      }
+
+      let toolFields: { toolBindings?: IAgentToolBinding[]; knowledgeEngineKey?: string };
+      try {
+        toolFields = await toolBindingsFromAssistantBody(ctx.tenantDbName, ctx.projectId, body);
+      } catch (error) {
+        if (error instanceof AssistantRequestError) return reply.code(400).send({ error: error.message });
+        throw error;
+      }
+
+      const config: IAgentConfig = {
+        modelKey: body.model,
+        ...(typeof body.instructions === 'string' ? { systemPrompt: body.instructions } : {}),
+        ...(typeof body.temperature === 'number' ? { temperature: body.temperature } : {}),
+        ...(typeof body.top_p === 'number' ? { topP: body.top_p } : {}),
+        ...toolFields,
+      };
+
+      const bindings = await resolveConfigGuardrailBindings(
+        ctx.tenantDbName,
+        ctx.projectId,
+        (body.metadata as Record<string, unknown> | undefined)?.guardrails,
+      );
+      if (bindings.error) return reply.code(400).send({ error: bindings.error });
+      if (bindings.patch) Object.assign(config, bindings.patch);
+
+      const name = typeof body.name === 'string' && body.name.trim() ? body.name.trim() : `Assistant (${body.model})`;
+      const agent = await createAgentRecord(ctx.tenantDbName, ctx.tenantId, ctx.projectId, ctx.tokenRecord.userId, {
+        name,
+        description: typeof body.description === 'string' ? body.description : undefined,
+        config,
+      });
+
+      if (body.metadata && typeof body.metadata === 'object') {
+        await updateAgentRecord(ctx.tenantDbName, String(agent._id), { metadata: body.metadata as Record<string, unknown> }, ctx.tokenRecord.userId);
+        agent.metadata = body.metadata as Record<string, unknown>;
+      }
+
+      return reply.code(200).send(agentToAssistant(agent));
+    } catch (error) {
+      logger.error('Create assistant error', { error });
+      return reply.code(500).send({ error: error instanceof Error ? error.message : 'Internal server error' });
+    }
+  }));
+
+  app.get('/client/v1/assistants', withClientApiRequestContext(async (request, reply) => {
+    try {
+      const ctx = await getApiTokenContextForRequest(request);
+      const query = request.query as { limit?: string; order?: string };
+      const limit = Math.min(Math.max(Number(query.limit) || 20, 1), 100);
+      const agents = await listAgents(ctx.tenantDbName, { projectId: ctx.projectId });
+      const ordered = query.order === 'asc' ? agents : [...agents].reverse();
+      const data = ordered.slice(0, limit).map(agentToAssistant);
+      return reply.code(200).send({ object: 'list', data, has_more: ordered.length > limit });
+    } catch (error) {
+      logger.error('List assistants error', { error });
+      return reply.code(500).send({ error: 'Internal server error' });
+    }
+  }));
+
+  app.get('/client/v1/assistants/:assistantId', withClientApiRequestContext(async (request, reply) => {
+    try {
+      const ctx = await getApiTokenContextForRequest(request);
+      const { assistantId: rawId } = request.params as { assistantId: string };
+      const agent = await getAgentByKey(ctx.tenantDbName, agentKeyFromAssistantId(rawId), ctx.projectId);
+      if (!agent) return reply.code(404).send({ error: 'Assistant not found' });
+      return reply.code(200).send(agentToAssistant(agent));
+    } catch (error) {
+      logger.error('Retrieve assistant error', { error });
+      return reply.code(500).send({ error: 'Internal server error' });
+    }
+  }));
+
+  app.post('/client/v1/assistants/:assistantId', withClientApiRequestContext(async (request, reply) => {
+    try {
+      const ctx = await getApiTokenContextForRequest(request);
+      const { assistantId: rawId } = request.params as { assistantId: string };
+      const agent = await getAgentByKey(ctx.tenantDbName, agentKeyFromAssistantId(rawId), ctx.projectId);
+      if (!agent) return reply.code(404).send({ error: 'Assistant not found' });
+
+      const body = readJsonBody<Record<string, unknown>>(request);
+      let toolFields: { toolBindings?: IAgentToolBinding[]; knowledgeEngineKey?: string } = {};
+      if (body.tools !== undefined) {
+        try {
+          toolFields = await toolBindingsFromAssistantBody(ctx.tenantDbName, ctx.projectId, body);
+        } catch (error) {
+          if (error instanceof AssistantRequestError) return reply.code(400).send({ error: error.message });
+          throw error;
+        }
+      }
+
+      const config: Partial<IAgentConfig> = {
+        ...(typeof body.model === 'string' ? { modelKey: body.model } : {}),
+        ...(typeof body.instructions === 'string' ? { systemPrompt: body.instructions } : {}),
+        ...(typeof body.temperature === 'number' ? { temperature: body.temperature } : {}),
+        ...(typeof body.top_p === 'number' ? { topP: body.top_p } : {}),
+        ...(body.tools !== undefined ? toolFields : {}),
+      };
+
+      const updates: Partial<IAgent> = {
+        config: { ...agent.config, ...config },
+        ...(typeof body.name === 'string' ? { name: body.name } : {}),
+        ...(typeof body.description === 'string' ? { description: body.description } : {}),
+        ...(body.metadata && typeof body.metadata === 'object' ? { metadata: body.metadata as Record<string, unknown> } : {}),
+      };
+
+      const updated = await updateAgentRecord(ctx.tenantDbName, String(agent._id), updates, ctx.tokenRecord.userId);
+      if (!updated) return reply.code(404).send({ error: 'Assistant not found' });
+      return reply.code(200).send(agentToAssistant(updated));
+    } catch (error) {
+      logger.error('Modify assistant error', { error });
+      return reply.code(500).send({ error: 'Internal server error' });
+    }
+  }));
+
+  app.delete('/client/v1/assistants/:assistantId', withClientApiRequestContext(async (request, reply) => {
+    try {
+      const ctx = await getApiTokenContextForRequest(request);
+      const { assistantId: rawId } = request.params as { assistantId: string };
+      const agent = await getAgentByKey(ctx.tenantDbName, agentKeyFromAssistantId(rawId), ctx.projectId);
+      if (!agent) return reply.code(404).send({ error: 'Assistant not found' });
+      const { deleteAgentRecord } = await import('@/lib/services/agents');
+      const deleted = await deleteAgentRecord(ctx.tenantDbName, String(agent._id));
+      return reply.code(200).send({ id: rawId, object: 'assistant.deleted', deleted });
+    } catch (error) {
+      logger.error('Delete assistant error', { error });
+      return reply.code(500).send({ error: 'Internal server error' });
+    }
+  }));
+
+  // ── Threads ────────────────────────────────────────────────────────────
+
+  /**
+   * Creates a thread and appends any seed messages, without running one.
+   * `assistant_id` is required — see the module doc's point 1 — so it accepts
+   * a slightly wider body than OpenAI's (which allows a bare `{}`), and 400s
+   * with the reason when it is missing rather than creating an unusable thread.
+   */
+  async function createThread(
+    tenantDbName: string,
+    tenantId: string,
+    projectId: string,
+    userId: string,
+    body: Record<string, unknown>,
+  ): Promise<{ conversation: IAgentConversation } | { error: string }> {
+    if (typeof body.assistant_id !== 'string' || !body.assistant_id) {
+      return {
+        error: 'assistant_id is required: unlike OpenAI, a thread here is bound to one assistant for its '
+          + 'lifetime (the underlying conversation record is written that way), set once at creation.',
+      };
+    }
+    const agentKey = agentKeyFromAssistantId(body.assistant_id);
+    const agent = await getAgentByKey(tenantDbName, agentKey, projectId);
+    if (!agent) return { error: `No assistant with id "${body.assistant_id}"` };
+
+    const conversation = await createConversation(tenantDbName, tenantId, projectId, userId, agentKey);
+
+    const seedMessages = Array.isArray(body.messages) ? body.messages : [];
+    if (seedMessages.length > 0) {
+      const db = await getDatabase();
+      await db.switchToTenant(tenantDbName);
+      const now = new Date();
+      const persisted = seedMessages.slice(0, -1).map((entry) => {
+        const item = entry as Record<string, unknown>;
+        return { role: typeof item.role === 'string' ? item.role : 'user', content: extractMessageText(item.content) ?? '', timestamp: now };
+      });
+      const last = seedMessages[seedMessages.length - 1] as Record<string, unknown>;
+      const lastText = extractMessageText(last.content);
+      const lastIsUser = last.role === 'user' && lastText;
+
+      if (persisted.length > 0) {
+        await db.updateAgentConversation(String(conversation._id), { messages: persisted });
+      }
+      if (lastIsUser) {
+        await writeAssistantsMetadata(String(conversation._id), conversation, {
+          pendingMessages: [{ id: randomUUID(), role: 'user', content: lastText, created_at: Math.floor(Date.now() / 1000) }],
+        });
+      } else if (lastText) {
+        await db.updateAgentConversation(String(conversation._id), { messages: [...persisted, { role: typeof last.role === 'string' ? last.role : 'user', content: lastText, timestamp: now }] });
+      }
+    }
+
+    const refreshed = await getConversationById(tenantDbName, String(conversation._id));
+    return { conversation: refreshed ?? conversation };
+  }
+
+  function threadObject(conversation: IAgentConversation) {
+    return {
+      id: threadId(String(conversation._id)),
+      object: 'thread' as const,
+      created_at: conversation.createdAt ? Math.floor(new Date(conversation.createdAt).getTime() / 1000) : 0,
+      metadata: conversation.metadata && typeof conversation.metadata === 'object'
+        ? Object.fromEntries(Object.entries(conversation.metadata).filter(([key]) => key !== 'assistantsApi'))
+        : {},
+    };
+  }
+
+  app.post('/client/v1/threads', withClientApiRequestContext(async (request, reply) => {
+    try {
+      const ctx = await getApiTokenContextForRequest(request);
+      const body = readJsonBody<Record<string, unknown>>(request);
+      const result = await createThread(ctx.tenantDbName, ctx.tenantId, ctx.projectId, ctx.tokenRecord.userId, body);
+      if ('error' in result) return reply.code(400).send({ error: result.error });
+      return reply.code(200).send(threadObject(result.conversation));
+    } catch (error) {
+      logger.error('Create thread error', { error });
+      return reply.code(500).send({ error: 'Internal server error' });
+    }
+  }));
+
+  app.get('/client/v1/threads/:threadId', withClientApiRequestContext(async (request, reply) => {
+    try {
+      const ctx = await getApiTokenContextForRequest(request);
+      const { threadId: rawId } = request.params as { threadId: string };
+      const loaded = await loadThreadOr404(ctx.tenantDbName, rawId);
+      if ('error' in loaded) return reply.code(loaded.error.code).send({ error: loaded.error.message });
+      return reply.code(200).send(threadObject(loaded.conversation));
+    } catch (error) {
+      logger.error('Retrieve thread error', { error });
+      return reply.code(500).send({ error: 'Internal server error' });
+    }
+  }));
+
+  app.post('/client/v1/threads/:threadId', withClientApiRequestContext(async (request, reply) => {
+    try {
+      const ctx = await getApiTokenContextForRequest(request);
+      const { threadId: rawId } = request.params as { threadId: string };
+      const loaded = await loadThreadOr404(ctx.tenantDbName, rawId);
+      if ('error' in loaded) return reply.code(loaded.error.code).send({ error: loaded.error.message });
+
+      const body = readJsonBody<Record<string, unknown>>(request);
+      const db = await getDatabase();
+      await db.switchToTenant(ctx.tenantDbName);
+      const conversationId = conversationIdFromThreadId(rawId);
+      if (body.metadata && typeof body.metadata === 'object') {
+        const merged = { ...(loaded.conversation.metadata ?? {}), ...(body.metadata as Record<string, unknown>) };
+        // The Assistants bookkeeping namespace is server-owned; a caller
+        // patching `metadata` must not be able to erase pending messages or
+        // run history it never knew existed.
+        merged.assistantsApi = readAssistantsMetadata(loaded.conversation);
+        await db.updateAgentConversation(conversationId, { metadata: merged });
+      }
+      const refreshed = await getConversationById(ctx.tenantDbName, conversationId);
+      return reply.code(200).send(threadObject(refreshed ?? loaded.conversation));
+    } catch (error) {
+      logger.error('Modify thread error', { error });
+      return reply.code(500).send({ error: 'Internal server error' });
+    }
+  }));
+
+  app.delete('/client/v1/threads/:threadId', withClientApiRequestContext(async (request, reply) => {
+    try {
+      const ctx = await getApiTokenContextForRequest(request);
+      const { threadId: rawId } = request.params as { threadId: string };
+      const loaded = await loadThreadOr404(ctx.tenantDbName, rawId);
+      if ('error' in loaded) return reply.code(loaded.error.code).send({ error: loaded.error.message });
+      const { deleteConversation } = await import('@/lib/services/agents');
+      const deleted = await deleteConversation(ctx.tenantDbName, conversationIdFromThreadId(rawId));
+      return reply.code(200).send({ id: rawId, object: 'thread.deleted', deleted });
+    } catch (error) {
+      logger.error('Delete thread error', { error });
+      return reply.code(500).send({ error: 'Internal server error' });
+    }
+  }));
+
+  // ── Messages ───────────────────────────────────────────────────────────
+
+  app.post('/client/v1/threads/:threadId/messages', withClientApiRequestContext(async (request, reply) => {
+    try {
+      const ctx = await getApiTokenContextForRequest(request);
+      const { threadId: rawId } = request.params as { threadId: string };
+      const loaded = await loadThreadOr404(ctx.tenantDbName, rawId);
+      if ('error' in loaded) return reply.code(loaded.error.code).send({ error: loaded.error.message });
+
+      const body = readJsonBody<Record<string, unknown>>(request);
+      const text = extractMessageText(body.content);
+      if (!text) return reply.code(400).send({ error: '`content` is required (a string, or a `text` content part)' });
+      if (body.role !== undefined && body.role !== 'user' && body.role !== 'assistant') {
+        return reply.code(400).send({ error: '`role` must be "user" or "assistant"' });
+      }
+
+      const conversationId = conversationIdFromThreadId(rawId);
+      const pending = readAssistantsMetadata(loaded.conversation).pendingMessages ?? [];
+      const role = (body.role as 'user' | 'assistant' | undefined) ?? 'user';
+      const entry: PendingMessage = { id: randomUUID(), role, content: text, created_at: Math.floor(Date.now() / 1000) };
+
+      // Only ONE un-run message is supported at a time (see module doc): a run
+      // consumes exactly one, and this engine has no way to fold several turns
+      // into a single call without inventing a merge rule OpenAI itself doesn't
+      // have to. Adding a second before running the first is refused rather
+      // than silently queued.
+      if (pending.length > 0 && role === 'user') {
+        return reply.code(400).send({
+          error: 'A message is already pending a run on this thread. Create a run to consume it before adding another.',
+        });
+      }
+      await writeAssistantsMetadata(conversationId, loaded.conversation, { pendingMessages: [...pending, entry] });
+
+      const merged = mergedMessages({ ...loaded.conversation, metadata: { ...(loaded.conversation.metadata ?? {}), assistantsApi: { ...readAssistantsMetadata(loaded.conversation), pendingMessages: [...pending, entry] } } });
+      const index = merged.length - 1;
+      return reply.code(200).send(toMessageObject(conversationId, assistantId(loaded.agent.key), index, merged[index]));
+    } catch (error) {
+      logger.error('Create message error', { error });
+      return reply.code(500).send({ error: 'Internal server error' });
+    }
+  }));
+
+  app.get('/client/v1/threads/:threadId/messages', withClientApiRequestContext(async (request, reply) => {
+    try {
+      const ctx = await getApiTokenContextForRequest(request);
+      const { threadId: rawId } = request.params as { threadId: string };
+      const loaded = await loadThreadOr404(ctx.tenantDbName, rawId);
+      if ('error' in loaded) return reply.code(loaded.error.code).send({ error: loaded.error.message });
+
+      const conversationId = conversationIdFromThreadId(rawId);
+      const query = request.query as { limit?: string; order?: string };
+      const limit = Math.min(Math.max(Number(query.limit) || 20, 1), 100);
+      const merged = mergedMessages(loaded.conversation);
+      const objects = merged.map((entry, index) => toMessageObject(conversationId, assistantId(loaded.agent.key), index, entry));
+      const ordered = query.order === 'asc' ? objects : [...objects].reverse();
+      return reply.code(200).send({ object: 'list', data: ordered.slice(0, limit), has_more: ordered.length > limit });
+    } catch (error) {
+      logger.error('List messages error', { error });
+      return reply.code(500).send({ error: 'Internal server error' });
+    }
+  }));
+
+  app.get('/client/v1/threads/:threadId/messages/:messageId', withClientApiRequestContext(async (request, reply) => {
+    try {
+      const ctx = await getApiTokenContextForRequest(request);
+      const { threadId: rawId, messageId: rawMessageId } = request.params as { threadId: string; messageId: string };
+      const loaded = await loadThreadOr404(ctx.tenantDbName, rawId);
+      if ('error' in loaded) return reply.code(loaded.error.code).send({ error: loaded.error.message });
+
+      const conversationId = conversationIdFromThreadId(rawId);
+      const merged = mergedMessages(loaded.conversation);
+      const index = merged.findIndex((_, i) => messageId(conversationId, i) === rawMessageId);
+      if (index === -1) return reply.code(404).send({ error: 'Message not found' });
+      return reply.code(200).send(toMessageObject(conversationId, assistantId(loaded.agent.key), index, merged[index]));
+    } catch (error) {
+      logger.error('Retrieve message error', { error });
+      return reply.code(500).send({ error: 'Internal server error' });
+    }
+  }));
+
+  // ── Runs ───────────────────────────────────────────────────────────────
+
+  /** Runs the ONE pending message on a thread and records the outcome. Shared
+   * by `POST .../threads/:id/runs` and the create-and-run convenience route. */
+  async function runThread(
+    ctx: Awaited<ReturnType<typeof getApiTokenContextForRequest>>,
+    request: Parameters<Parameters<typeof withClientApiRequestContext>[0]>[0],
+    conversationId: string,
+    conversation: IAgentConversation,
+    agent: IAgent,
+    body: Record<string, unknown>,
+  ): Promise<{ status: number; body: unknown }> {
+    if (typeof body.assistant_id === 'string' && agentKeyFromAssistantId(body.assistant_id) !== agent.key) {
+      return {
+        status: 400,
+        body: {
+          error: `This thread is bound to assistant "${assistantId(agent.key)}"; `
+            + `a run cannot switch it to "${body.assistant_id}" (see the module's thread-binding note).`,
+        },
+      };
+    }
+
+    const pending = readAssistantsMetadata(conversation).pendingMessages ?? [];
+    const toRun = pending.find((m) => m.role === 'user');
+    if (!toRun) {
+      return {
+        status: 400,
+        body: { error: 'Nothing to run: add a user message with POST .../threads/:id/messages first.' },
+      };
+    }
+
+    const record: RunRecord = {
+      id: runId(),
+      status: 'completed',
+      created_at: Math.floor(Date.now() / 1000),
+      assistant_id: assistantId(agent.key),
+    };
+
+    try {
+      const runtimeContext = buildRuntimeContextFromRequest(body.runtime_context, request.headers, {
+        userId: ctx.tokenRecord.userId,
+        tokenId: ctx.tokenRecord._id ? String(ctx.tokenRecord._id) : undefined,
+        source: 'api',
+      });
+
+      const result = await executeAgentChat({
+        agentKey: agent.key,
+        conversationId,
+        projectId: ctx.projectId,
+        tenantDbName: ctx.tenantDbName,
+        tenantId: ctx.tenantId,
+        usePublished: true,
+        userId: ctx.tokenRecord.userId,
+        userMessage: toRun.content,
+        runtimeContext,
+      });
+
+      // `executeAgentChat` just persisted the (user, assistant) pair itself —
+      // the pending entry is now redundant history, so it comes off the queue
+      // rather than being replayed on the next run.
+      record.completed_at = Math.floor(Date.now() / 1000);
+      record.usage = {
+        prompt_tokens: result.usage.input_tokens,
+        completion_tokens: result.usage.output_tokens,
+        total_tokens: result.usage.total_tokens,
+      };
+      const remaining = pending.filter((m) => m.id !== toRun.id);
+      const existingRuns = readAssistantsMetadata(conversation).runs ?? [];
+      await writeAssistantsMetadata(conversationId, conversation, {
+        pendingMessages: remaining,
+        runs: [...existingRuns, record].slice(-50),
+      });
+
+      return { status: 200, body: toRunObject(threadId(conversationId), record) };
+    } catch (error) {
+      // The pending message is DELIBERATELY left in place on failure — same as
+      // OpenAI's own semantics (a failed run never consumes the thread state it
+      // was given), so the caller can fix whatever was wrong and run again
+      // without re-sending the message.
+      if (error instanceof AgentGuardrailBlockedError) {
+        record.status = 'failed';
+        record.failed_at = Math.floor(Date.now() / 1000);
+        record.last_error = { code: 'guardrail_block', message: error.message };
+      } else {
+        record.status = 'failed';
+        record.failed_at = Math.floor(Date.now() / 1000);
+        record.last_error = { code: 'server_error', message: error instanceof Error ? error.message : 'Run failed' };
+      }
+      const existingRuns = readAssistantsMetadata(conversation).runs ?? [];
+      await writeAssistantsMetadata(conversationId, conversation, { runs: [...existingRuns, record].slice(-50) });
+      return { status: 200, body: toRunObject(threadId(conversationId), record) };
+    }
+  }
+
+  app.post('/client/v1/threads/:threadId/runs', withClientApiRequestContext(async (request, reply) => {
+    try {
+      const ctx = await getApiTokenContextForRequest(request);
+      const { threadId: rawId } = request.params as { threadId: string };
+      const loaded = await loadThreadOr404(ctx.tenantDbName, rawId);
+      if ('error' in loaded) return reply.code(loaded.error.code).send({ error: loaded.error.message });
+
+      const body = readJsonBody<Record<string, unknown>>(request);
+      const outcome = await runThread(ctx, request, conversationIdFromThreadId(rawId), loaded.conversation, loaded.agent, body);
+      return reply.code(outcome.status).send(outcome.body);
+    } catch (error) {
+      logger.error('Create run error', { error });
+      return reply.code(500).send({ error: 'Internal server error' });
+    }
+  }));
+
+  /** OpenAI's `client.beta.threads.createAndRun` convenience: create a thread
+   * and immediately run its final seed message, in one call. */
+  app.post('/client/v1/threads/runs', withClientApiRequestContext(async (request, reply) => {
+    try {
+      const ctx = await getApiTokenContextForRequest(request);
+      const body = readJsonBody<Record<string, unknown>>(request);
+      if (typeof body.assistant_id !== 'string' || !body.assistant_id) {
+        return reply.code(400).send({ error: 'assistant_id is required' });
+      }
+
+      const threadBody = { ...(body.thread as Record<string, unknown> | undefined ?? {}), assistant_id: body.assistant_id };
+      const created = await createThread(ctx.tenantDbName, ctx.tenantId, ctx.projectId, ctx.tokenRecord.userId, threadBody);
+      if ('error' in created) return reply.code(400).send({ error: created.error });
+
+      const agent = await getAgentByKey(ctx.tenantDbName, agentKeyFromAssistantId(body.assistant_id), ctx.projectId);
+      if (!agent) return reply.code(404).send({ error: `No assistant with id "${body.assistant_id}"` });
+
+      const outcome = await runThread(ctx, request, String(created.conversation._id), created.conversation, agent, body);
+      return reply.code(outcome.status).send(outcome.body);
+    } catch (error) {
+      logger.error('Create-and-run error', { error });
+      return reply.code(500).send({ error: 'Internal server error' });
+    }
+  }));
+
+  app.get('/client/v1/threads/:threadId/runs', withClientApiRequestContext(async (request, reply) => {
+    try {
+      const ctx = await getApiTokenContextForRequest(request);
+      const { threadId: rawId } = request.params as { threadId: string };
+      const loaded = await loadThreadOr404(ctx.tenantDbName, rawId);
+      if ('error' in loaded) return reply.code(loaded.error.code).send({ error: loaded.error.message });
+
+      const runs = readAssistantsMetadata(loaded.conversation).runs ?? [];
+      const query = request.query as { limit?: string; order?: string };
+      const limit = Math.min(Math.max(Number(query.limit) || 20, 1), 100);
+      const ordered = query.order === 'asc' ? runs : [...runs].reverse();
+      const data = ordered.slice(0, limit).map((run) => toRunObject(rawId, run));
+      return reply.code(200).send({ object: 'list', data, has_more: ordered.length > limit });
+    } catch (error) {
+      logger.error('List runs error', { error });
+      return reply.code(500).send({ error: 'Internal server error' });
+    }
+  }));
+
+  app.get('/client/v1/threads/:threadId/runs/:runId', withClientApiRequestContext(async (request, reply) => {
+    try {
+      const ctx = await getApiTokenContextForRequest(request);
+      const { threadId: rawId, runId: rawRunId } = request.params as { threadId: string; runId: string };
+      const loaded = await loadThreadOr404(ctx.tenantDbName, rawId);
+      if ('error' in loaded) return reply.code(loaded.error.code).send({ error: loaded.error.message });
+
+      const runs = readAssistantsMetadata(loaded.conversation).runs ?? [];
+      const run = runs.find((r) => r.id === rawRunId);
+      if (!run) return reply.code(404).send({ error: 'Run not found' });
+      return reply.code(200).send(toRunObject(rawId, run));
+    } catch (error) {
+      logger.error('Retrieve run error', { error });
+      return reply.code(500).send({ error: 'Internal server error' });
+    }
+  }));
+
+  /** Always refuses: see the module doc's point 2 — a run is terminal the
+   * instant it exists, so there is never anything in flight to cancel. */
+  app.post('/client/v1/threads/:threadId/runs/:runId/cancel', withClientApiRequestContext(async (request, reply) => {
+    try {
+      const ctx = await getApiTokenContextForRequest(request);
+      const { threadId: rawId, runId: rawRunId } = request.params as { threadId: string; runId: string };
+      const loaded = await loadThreadOr404(ctx.tenantDbName, rawId);
+      if ('error' in loaded) return reply.code(loaded.error.code).send({ error: loaded.error.message });
+
+      const runs = readAssistantsMetadata(loaded.conversation).runs ?? [];
+      const run = runs.find((r) => r.id === rawRunId);
+      if (!run) return reply.code(404).send({ error: 'Run not found' });
+      return reply.code(400).send({
+        error: `Run "${rawRunId}" is already "${run.status}": every run on this Assistants dialect completes `
+          + 'synchronously, so by the time a client could reach this endpoint there is nothing left in flight.',
+      });
+    } catch (error) {
+      logger.error('Cancel run error', { error });
+      return reply.code(500).send({ error: 'Internal server error' });
+    }
+  }));
+};

--- a/src/server/api/plugins/models.ts
+++ b/src/server/api/plugins/models.ts
@@ -13,7 +13,7 @@ import {
   updateModel,
 } from '@/lib/services/models/modelService';
 import { parseMetadataGroupByKey, type UsageBreakdownGroupBy } from '@/lib/services/usage/usageBreakdown';
-import type { IDynamicRoutingConfig } from '@/lib/database';
+import type { IDynamicRoutingConfig, IModelReplica } from '@/lib/database';
 import type { UpdateModelInput } from '@/lib/services/models/types';
 import {
   ModelCapabilityValidationError,
@@ -147,6 +147,54 @@ function mergeSettings(
 
 function buildDate(value?: string): Date | undefined {
   return value ? new Date(value) : undefined;
+}
+
+/**
+ * Validates a replica pool from the wire.
+ *
+ * Every replica must name a provider; `modelId` may be omitted to mean "the
+ * same upstream id as the model", which is the normal case for a pool of
+ * identical deployments across regions. A pool of zero enabled replicas is
+ * refused rather than saved: it reads as "pooled" while nothing can serve it,
+ * and the model's own provider would silently take over.
+ */
+function readReplicasField(
+  raw: unknown,
+): { replicas?: IModelReplica[]; error?: string } {
+  if (raw === undefined) return {};
+  if (raw === null) return { replicas: [] };
+  if (!Array.isArray(raw)) return { error: '`replicas` must be an array' };
+
+  const replicas: IModelReplica[] = [];
+  for (const [index, entry] of raw.entries()) {
+    if (!entry || typeof entry !== 'object') {
+      return { error: `replicas[${index}] must be an object` };
+    }
+    const record = entry as Record<string, unknown>;
+    const providerKey = record.providerKey;
+    if (typeof providerKey !== 'string' || !providerKey.trim()) {
+      return { error: `replicas[${index}].providerKey is required` };
+    }
+    const weight = record.weight;
+    if (weight !== undefined && (typeof weight !== 'number' || !(weight > 0))) {
+      return { error: `replicas[${index}].weight must be a positive number` };
+    }
+    replicas.push({
+      providerKey: providerKey.trim(),
+      modelId: typeof record.modelId === 'string' ? record.modelId.trim() : '',
+      ...(typeof weight === 'number' ? { weight } : {}),
+      ...(record.enabled === false ? { enabled: false } : {}),
+      ...(record.label && typeof record.label === 'string' ? { label: record.label } : {}),
+      ...(record.settings && typeof record.settings === 'object'
+        ? { settings: record.settings as Record<string, unknown> }
+        : {}),
+    });
+  }
+
+  if (replicas.length > 0 && replicas.every((replica) => replica.enabled === false)) {
+    return { error: 'a replica pool needs at least one enabled replica' };
+  }
+  return { replicas };
 }
 
 export const modelsApiPlugin: FastifyPluginAsync = async (app) => {
@@ -740,6 +788,14 @@ export const modelsApiPlugin: FastifyPluginAsync = async (app) => {
       // only while they do not contradict a stored list (see the conflict
       // guard) — silently ignoring them is how a screen appears to save and
       // does not.
+      const replicasField = readReplicasField(body.replicas);
+      if (replicasField.error) {
+        return reply.code(400).send({ error: replicasField.error });
+      }
+      if (replicasField.replicas) {
+        updates.replicas = replicasField.replicas;
+      }
+
       const bindingsField = readGuardrailBindingsField(body.guardrails);
       if (bindingsField.error) {
         return reply.code(400).send({ error: bindingsField.error });


### PR DESCRIPTION
## Summary
- **Replica pools**: a model key can now fan out across several interchangeable deployments (weighted, health-aware via the existing circuit breaker, transparent to price/capability/usage/cache-key). Composable with Dynamic LLM routing — Dynamic LLM picks *which model*, a pool then picks *which deployment of it*. New `Replicas` tab on the model detail page.
- **Assistants API**: OpenAI's legacy Assistants/Threads/Messages/Runs surface, wired onto the existing agent engine (`executeAgentChat`) as a fourth wire dialect alongside `/v1/chat/completions`, `/v1/messages`, and `/v1/agents/responses` — so guardrails, quota, and tracing enforce exactly once regardless of dialect. Three deliberate departures from OpenAI's own semantics (thread bound to one assistant for its lifetime, every run completes synchronously, no client-executed `function` tools) are documented in the module header and in the new API reference page.

## Test plan
- [x] `npx tsc --noEmit` clean on this branch
- [x] `npx eslint` clean (0 warnings/errors) on every changed/new file
- [x] `npx vitest run src/__tests__/unit/replica-pool.test.ts src/__tests__/unit/client-assistants.test.ts` — 30/30 passing
- [x] Live-verified in a prior session against real Bedrock + Azure providers: replica failover (dead + healthy 50/50 pool, streaming failover, 400-does-not-failover, usage-row `failedOver` annotation) and the full Assistants lifecycle (create/retrieve/modify/delete assistant, thread binding, multi-turn run, list-messages id stability across pending→persisted, create-and-run, cancel-always-400, all 4 tool-type paths)
- [ ] Reviewer: confirm `Replicas` tab UX and the Assistants tool-rejection error messages read clearly from a client's perspective

Docs for both features are live: [Model Hub guide](https://docs.cognipeer.com/console/guide/model-hub) (Replica pools, Moderation detectors sections) and [Assistants API reference](https://docs.cognipeer.com/console/developer/api/assistants).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KQq6TnVNHRNU6Wz1eQzPpD