### PR TITLE
fix(security): close RBAC/project-scope gaps in client API (F-01/F-02/F-03)

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "backfill:usage-daily": "node --import tsx scripts/backfill-usage-daily.ts",
     "backfill:trace-usage": "node --import tsx scripts/backfill-trace-usage.ts",
     "backfill:trace-fields": "node --import tsx scripts/backfill-trace-fields.ts",
+    "backfill:rag-project-ids": "node --import tsx scripts/backfill-rag-document-project-ids.ts",
     "docs:dev": "vitepress dev docs",
     "docs:build": "vitepress build docs",
     "docs:preview": "vitepress preview docs"

--- a/scripts/backfill-rag-document-project-ids.ts
+++ b/scripts/backfill-rag-document-project-ids.ts
@@ -1,0 +1,151 @@
+/**
+ * Stamp the owning project onto Knowledge Engine documents that were ingested
+ * WITHOUT one.
+ *
+ * WHY THIS EXISTS (F-02, finance-institution assessment 2026-09-05): the
+ * client RAG API used to pass `projectId: undefined` on ingest/list/query, and
+ * the database layer reads `undefined` as "no project filter — tenant-wide".
+ * Every document ingested through `/api/client/v1/rag/...` before that fix
+ * therefore has no `projectId` at all. The fix makes those same calls pass
+ * `ctx.projectId`, which is an EXACT match filter — so without this backfill,
+ * a project-scoped token stops seeing its own previously-ingested documents
+ * the moment the fix ships (they are not deleted, just invisible to the
+ * list/delete/reingest paths, and their chunks stay searchable because vector
+ * search filters by module, not project).
+ *
+ * The owning project is not guessed: a document belongs to its RAG MODULE
+ * (`ragModuleKey`), and the module carries the projectId the dashboard
+ * created it under. Documents whose module ALSO has no projectId cannot be
+ * attributed and are reported, not written — see the summary at the end.
+ *
+ * IDEMPOTENT: only touches documents whose projectId is missing/empty, so a
+ * second run is a no-op.
+ *
+ * Reads the same .env as the server (DB_PROVIDER, MONGODB_URI /
+ * SQLITE_DATA_DIR, MAIN_DB_NAME) — run from the project root against the
+ * deployment you want to backfill.
+ *
+ * Usage:
+ *   npm run backfill:rag-project-ids -- --dry-run     # report only (RUN THIS FIRST)
+ *   npm run backfill:rag-project-ids                  # write, all tenants
+ *   npm run backfill:rag-project-ids -- --tenant acme # one tenant
+ */
+import { loadEnvConfig } from '@next/env';
+
+// Config is read at import time — load env BEFORE any '@/'-aliased import.
+loadEnvConfig(process.cwd(), process.env.NODE_ENV !== 'production');
+
+interface CliArgs {
+  tenant?: string;
+  dryRun: boolean;
+}
+
+function parseArgs(argv: string[]): CliArgs {
+  const args: CliArgs = { dryRun: false };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--tenant') {
+      args.tenant = argv[i + 1];
+      if (!args.tenant) throw new Error('--tenant expects a tenant slug or dbName');
+      i += 1;
+    } else if (arg === '--dry-run') {
+      args.dryRun = true;
+    } else {
+      throw new Error(`Unknown option: ${arg}`);
+    }
+  }
+  return args;
+}
+
+function isMissing(value: string | undefined): boolean {
+  return typeof value !== 'string' || value.trim().length === 0;
+}
+
+async function main(): Promise<number> {
+  const args = parseArgs(process.argv.slice(2));
+
+  const { getDatabase, disconnectDatabase } = await import('../src/lib/database');
+  const db = await getDatabase();
+
+  let totalStamped = 0;
+  let totalUnattributable = 0;
+  const unattributableModules = new Set<string>();
+
+  try {
+    let tenants = await db.listTenants();
+    if (args.tenant) {
+      const wanted = args.tenant;
+      tenants = tenants.filter((t) => t.slug === wanted || t.dbName === wanted);
+      if (tenants.length === 0) throw new Error(`No tenant matched "${wanted}"`);
+    }
+
+    for (const tenant of tenants) {
+      await db.switchToTenant(tenant.dbName);
+      // No project filter: we want every module, including the legacy ones
+      // that have no projectId of their own.
+      const modules = await db.listRagModules();
+      let tenantStamped = 0;
+      let tenantUnattributable = 0;
+
+      for (const ragModule of modules) {
+        const documents = await db.listRagDocuments(ragModule.key);
+        const orphans = documents.filter((doc) => isMissing(doc.projectId));
+        if (orphans.length === 0) continue;
+
+        if (isMissing(ragModule.projectId)) {
+          // The module itself is unscoped, so there is nothing to inherit.
+          // Reported rather than guessed — assigning these to some project
+          // would be inventing an ownership claim, which is the opposite of
+          // what the finding asked for.
+          tenantUnattributable += orphans.length;
+          unattributableModules.add(`${tenant.slug}/${ragModule.key}`);
+          continue;
+        }
+
+        for (const doc of orphans) {
+          const id = doc._id ? String(doc._id) : '';
+          if (!id) continue;
+          if (!args.dryRun) {
+            await db.updateRagDocument(id, { projectId: ragModule.projectId });
+          }
+          tenantStamped += 1;
+        }
+      }
+
+      if (tenantStamped > 0 || tenantUnattributable > 0) {
+        console.log(
+          `[${tenant.slug}] ${args.dryRun ? 'would stamp' : 'stamped'} ${tenantStamped} document(s)`
+          + (tenantUnattributable > 0
+            ? `; ${tenantUnattributable} left alone (their module has no projectId either)`
+            : ''),
+        );
+      }
+      totalStamped += tenantStamped;
+      totalUnattributable += tenantUnattributable;
+    }
+
+    console.log(
+      `\n${args.dryRun ? 'DRY RUN — ' : ''}${totalStamped} document(s) `
+      + `${args.dryRun ? 'would be' : ''} stamped with their module's projectId.`,
+    );
+    if (totalUnattributable > 0) {
+      console.log(
+        `${totalUnattributable} document(s) in ${unattributableModules.size} unscoped module(s) `
+        + 'could not be attributed. These modules have no projectId of their own, so a '
+        + 'project-scoped client token cannot reach them either (findRagModuleByKey is an '
+        + 'exact match). Assign each module to a project in the dashboard, then re-run:',
+      );
+      for (const key of unattributableModules) console.log(`  - ${key}`);
+    }
+    return 0;
+  } finally {
+    await disconnectDatabase();
+  }
+}
+
+main()
+  .then((code) => process.exit(code))
+  .catch((error) => {
+    console.error(error instanceof Error ? error.stack ?? error.message : error);
+    process.exit(1);
+  });

--- a/src/__tests__/api/client-a2a.test.ts
+++ b/src/__tests__/api/client-a2a.test.ts
@@ -181,7 +181,7 @@ describe('message/send', () => {
   });
 
   it('reuses the conversation for a known contextId and rejects a foreign one', async () => {
-    mockFn(getConversationById).mockResolvedValue({ agentKey: 'support-bot', messages: [] });
+    mockFn(getConversationById).mockResolvedValue({ agentKey: 'support-bot', projectId: 'proj-1', messages: [] });
     mockFn(executeAgentChat).mockResolvedValue({
       output: [{ id: 'm1', type: 'message', role: 'assistant', content: [{ type: 'output_text', text: 'again' }] }],
       _conversation_messages: [{}, {}, {}, {}],
@@ -201,7 +201,7 @@ describe('message/send', () => {
     expect(parseJsonBody<{ result: { contextId: string } }>(ok.body).result.contextId).toBe('conv-9');
     expect(mockFn(createConversation)).not.toHaveBeenCalled();
 
-    mockFn(getConversationById).mockResolvedValue({ agentKey: 'other-agent', messages: [] });
+    mockFn(getConversationById).mockResolvedValue({ agentKey: 'other-agent', projectId: 'proj-1', messages: [] });
     const bad = await app.inject({
       method: 'POST',
       url: '/api/client/v1/a2a/support-bot',
@@ -221,6 +221,7 @@ describe('tasks/get and unknown methods', () => {
   it('rebuilds a completed task from the conversation store', async () => {
     mockFn(getConversationById).mockResolvedValue({
       agentKey: 'support-bot',
+      projectId: 'proj-1',
       messages: [
         { role: 'user', content: 'Hello' },
         { role: 'assistant', content: 'Hi there' },

--- a/src/__tests__/api/client-assistants-thread-scope.test.ts
+++ b/src/__tests__/api/client-assistants-thread-scope.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Regression test for F-03 (finance-institution assessment, 2026-09-05):
+ * `loadThreadOr404` resolved a thread purely by tenant + threadId — the
+ * caller's project was never checked, so a token scoped to project A could
+ * fetch project B's thread (agent conversation) just by knowing or guessing
+ * its id. `findAgentConversationById` has no projectId parameter at all, so
+ * the check has to happen in `loadThreadOr404` itself after the load.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/lib/services/apiTokenAuth', () => {
+  class ApiTokenAuthError extends Error {
+    status: number;
+    constructor(message: string, status = 401) {
+      super(message);
+      this.name = 'ApiTokenAuthError';
+      this.status = status;
+    }
+  }
+  return {
+    ApiTokenAuthError,
+    requireApiTokenFromHeader: vi.fn(),
+  };
+});
+
+vi.mock('@/lib/database', () => ({
+  getDatabase: vi.fn(),
+}));
+
+vi.mock('@/lib/security/rbac', () => ({
+  getPermissionServiceForPath: vi.fn(),
+  authorizeServiceRequest: vi.fn(),
+}));
+
+vi.mock('@/lib/core/lifecycle', () => ({
+  isShuttingDown: vi.fn().mockReturnValue(false),
+}));
+
+vi.mock('@/lib/services/agents', () => ({
+  createAgentRecord: vi.fn(),
+  createConversation: vi.fn(),
+  executeAgentChat: vi.fn(),
+  getAgentByKey: vi.fn(),
+  getConversationById: vi.fn(),
+  listAgents: vi.fn(),
+  updateAgentRecord: vi.fn(),
+}));
+
+vi.mock('@/server/api/plugins/guardrail-bindings', () => ({
+  resolveConfigGuardrailBindings: vi.fn().mockResolvedValue([]),
+}));
+
+import { requireApiTokenFromHeader } from '@/lib/services/apiTokenAuth';
+import { getDatabase } from '@/lib/database';
+import { getPermissionServiceForPath, authorizeServiceRequest } from '@/lib/security/rbac';
+import { getAgentByKey, getConversationById } from '@/lib/services/agents';
+import { clientAssistantsApiPlugin } from '@/server/api/plugins/client-assistants';
+import { createFastifyApiTestApp } from '../helpers/fastify-api';
+
+const AUTH_CTX_PROJECT_A = {
+  token: 'tok_a',
+  tokenRecord: { _id: 'tok-1', userId: 'user-1' },
+  tenant: { licenseType: 'STARTER' },
+  tenantId: 'tenant-1',
+  tenantSlug: 'acme',
+  tenantDbName: 'tenant_acme',
+  projectId: 'proj-a',
+  user: { _id: 'user-1', role: 'user', tenantId: 'tenant-1' },
+};
+
+const CONVERSATION_IN_PROJECT_B = {
+  _id: 'conv-1',
+  tenantId: 'tenant-1',
+  projectId: 'proj-b',
+  agentKey: 'support-bot',
+  title: 'A project-B thread',
+  messages: [],
+  createdBy: 'other-user',
+};
+
+const runWithTenant = vi.fn(<T>(_db: string, fn: () => T | Promise<T>) => fn());
+
+function mockFn(fn: unknown): ReturnType<typeof vi.fn> {
+  return fn as ReturnType<typeof vi.fn>;
+}
+
+async function buildApp() {
+  return createFastifyApiTestApp(clientAssistantsApiPlugin);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockFn(requireApiTokenFromHeader).mockResolvedValue(AUTH_CTX_PROJECT_A);
+  mockFn(getDatabase).mockResolvedValue({ runWithTenant });
+  mockFn(getPermissionServiceForPath).mockReturnValue(null);
+  mockFn(authorizeServiceRequest).mockReturnValue({ allowed: true });
+});
+
+describe('client Assistants API — thread ownership across projects', () => {
+  it('404s when a project-A token requests a thread that belongs to project B', async () => {
+    mockFn(getConversationById).mockResolvedValue(CONVERSATION_IN_PROJECT_B);
+    mockFn(getAgentByKey).mockResolvedValue({ key: 'support-bot', status: 'active' });
+    const app = await buildApp();
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/client/v1/threads/thread_conv-1',
+      headers: { authorization: 'Bearer tok' },
+    });
+
+    expect(res.statusCode).toBe(404);
+    // The cross-project record must never reach the response body.
+    expect(res.body).not.toContain('project-B');
+  });
+
+  it('200s and resolves the agent project-scoped when the thread belongs to the caller\'s own project', async () => {
+    const ownConversation = { ...CONVERSATION_IN_PROJECT_B, projectId: 'proj-a', title: 'My own thread' };
+    mockFn(getConversationById).mockResolvedValue(ownConversation);
+    mockFn(getAgentByKey).mockResolvedValue({ key: 'support-bot', status: 'active' });
+    const app = await buildApp();
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/client/v1/threads/thread_conv-1',
+      headers: { authorization: 'Bearer tok' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    // The agent lookup backing loadThreadOr404 must be scoped to the
+    // conversation's own project, not left unscoped.
+    expect(getAgentByKey).toHaveBeenCalledWith('tenant_acme', 'support-bot', 'proj-a');
+  });
+});

--- a/src/__tests__/api/client-rag-project-scope.test.ts
+++ b/src/__tests__/api/client-rag-project-scope.test.ts
@@ -1,0 +1,230 @@
+/**
+ * Regression test for F-02 (finance-institution assessment, 2026-09-05):
+ * the client RAG API (`client-rag.ts`) resolved document-list/ingest/query/
+ * reingest/delete operations without the caller's project, so a token scoped
+ * to project A could see or write into another project's module of the same
+ * key (the underlying DB layer treats a missing projectId as "tenant-wide,
+ * client API" — see `rag.mixin.ts`). Every one of these calls now threads
+ * `ctx.projectId` through; this test locks that contract at the plugin layer
+ * so a future edit cannot silently drop it again the way it did here.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/lib/services/apiTokenAuth', () => {
+  class ApiTokenAuthError extends Error {
+    status: number;
+    constructor(message: string, status = 401) {
+      super(message);
+      this.name = 'ApiTokenAuthError';
+      this.status = status;
+    }
+  }
+  return {
+    ApiTokenAuthError,
+    requireApiTokenFromHeader: vi.fn(),
+  };
+});
+
+vi.mock('@/lib/database', () => ({
+  getDatabase: vi.fn(),
+}));
+
+vi.mock('@/lib/security/rbac', () => ({
+  getPermissionServiceForPath: vi.fn(),
+  authorizeServiceRequest: vi.fn(),
+}));
+
+vi.mock('@/lib/core/lifecycle', () => ({
+  isShuttingDown: vi.fn().mockReturnValue(false),
+}));
+
+vi.mock('@/lib/services/rag/ragService', () => ({
+  createRagModule: vi.fn(),
+  deleteRagModule: vi.fn(),
+  getRagModule: vi.fn(),
+  listRagModules: vi.fn(),
+  getRagDocumentFullText: vi.fn(),
+  getRagDocumentTextLines: vi.fn(),
+  updateRagModule: vi.fn(),
+  listRagDocuments: vi.fn(),
+  ingestDocument: vi.fn(),
+  ingestFile: vi.fn(),
+  queryRag: vi.fn(),
+  deleteRagDocument: vi.fn(),
+  reingestDocument: vi.fn(),
+  shapeRagQueryResponse: vi.fn((result: unknown) => result),
+}));
+
+vi.mock('@/server/api/plugins/rag', () => ({
+  documentInProjectScope: vi.fn(),
+  readDocumentChunkConfig: vi.fn().mockReturnValue(undefined),
+  readRagModuleCreateFields: vi.fn(),
+  readRagModuleUpdateFields: vi.fn(),
+  sendInvalidRequest: vi.fn((reply: { code: (n: number) => { send: (b: unknown) => unknown } }) =>
+    reply.code(400).send({ error: 'invalid' })),
+  withoutSourceText: vi.fn((doc: unknown) => doc),
+}));
+
+import { requireApiTokenFromHeader } from '@/lib/services/apiTokenAuth';
+import { getDatabase } from '@/lib/database';
+import { getPermissionServiceForPath, authorizeServiceRequest } from '@/lib/security/rbac';
+import {
+  listRagDocuments,
+  ingestDocument,
+  ingestFile,
+  queryRag,
+  deleteRagDocument,
+  reingestDocument,
+} from '@/lib/services/rag/ragService';
+import { documentInProjectScope } from '@/server/api/plugins/rag';
+import { clientRagApiPlugin } from '@/server/api/plugins/client-rag';
+import { createFastifyApiTestApp } from '../helpers/fastify-api';
+
+const AUTH_CTX = {
+  token: 'tok_abc',
+  tokenRecord: { _id: 'tok-1', userId: 'user-1' },
+  tenant: { licenseType: 'STARTER' },
+  tenantId: 'tenant-1',
+  tenantSlug: 'acme',
+  tenantDbName: 'tenant_acme',
+  projectId: 'proj-a',
+  user: { _id: 'user-1', role: 'user', tenantId: 'tenant-1' },
+};
+
+const runWithTenant = vi.fn(<T>(_db: string, fn: () => T | Promise<T>) => fn());
+
+function mockFn(fn: unknown): ReturnType<typeof vi.fn> {
+  return fn as ReturnType<typeof vi.fn>;
+}
+
+async function buildApp() {
+  return createFastifyApiTestApp(clientRagApiPlugin);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockFn(requireApiTokenFromHeader).mockResolvedValue(AUTH_CTX);
+  mockFn(getDatabase).mockResolvedValue({ runWithTenant });
+  mockFn(getPermissionServiceForPath).mockReturnValue(null);
+  mockFn(authorizeServiceRequest).mockReturnValue({ allowed: true });
+  mockFn(documentInProjectScope).mockResolvedValue({ _id: 'doc-1', ragModuleKey: 'docs-v1', projectId: 'proj-a' });
+});
+
+describe('client RAG API — project scope threaded to every service call', () => {
+  it('GET .../documents passes the caller project, not a tenant-wide {} filter', async () => {
+    mockFn(listRagDocuments).mockResolvedValue([]);
+    const app = await buildApp();
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/client/v1/rag/modules/docs-v1/documents',
+      headers: { authorization: 'Bearer tok' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(listRagDocuments).toHaveBeenCalledWith('tenant_acme', 'docs-v1', { projectId: 'proj-a' });
+  });
+
+  it('POST .../ingest (text) passes the caller project to ingestDocument', async () => {
+    mockFn(ingestDocument).mockResolvedValue({ _id: 'doc-1' });
+    const app = await buildApp();
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/client/v1/rag/modules/docs-v1/ingest',
+      headers: { authorization: 'Bearer tok', 'content-type': 'application/json' },
+      payload: { fileName: 'a.txt', content: 'hello' },
+    });
+
+    expect(res.statusCode).toBe(201);
+    expect(ingestDocument).toHaveBeenCalledWith('tenant_acme', 'tenant-1', 'proj-a', expect.objectContaining({
+      ragModuleKey: 'docs-v1',
+    }));
+  });
+
+  it('POST .../ingest (base64 file) passes the caller project to ingestFile', async () => {
+    mockFn(ingestFile).mockResolvedValue({ _id: 'doc-1' });
+    const app = await buildApp();
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/client/v1/rag/modules/docs-v1/ingest',
+      headers: { authorization: 'Bearer tok', 'content-type': 'application/json' },
+      payload: { fileName: 'a.pdf', data: Buffer.from('hi').toString('base64') },
+    });
+
+    expect(res.statusCode).toBe(201);
+    expect(ingestFile).toHaveBeenCalledWith('tenant_acme', 'tenant-1', 'proj-a', expect.objectContaining({
+      ragModuleKey: 'docs-v1',
+    }));
+  });
+
+  it('POST .../query passes the caller project to queryRag', async () => {
+    mockFn(queryRag).mockResolvedValue({ matches: [] });
+    const app = await buildApp();
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/client/v1/rag/modules/docs-v1/query',
+      headers: { authorization: 'Bearer tok', 'content-type': 'application/json' },
+      payload: { query: 'what is our refund policy?' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(queryRag).toHaveBeenCalledWith('tenant_acme', 'tenant-1', 'proj-a', expect.objectContaining({
+      ragModuleKey: 'docs-v1',
+      query: 'what is our refund policy?',
+    }));
+  });
+
+  it('DELETE .../documents/:id passes the caller project to deleteRagDocument', async () => {
+    mockFn(deleteRagDocument).mockResolvedValue(true);
+    const app = await buildApp();
+
+    const res = await app.inject({
+      method: 'DELETE',
+      url: '/api/client/v1/rag/modules/docs-v1/documents/doc-1',
+      headers: { authorization: 'Bearer tok' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(deleteRagDocument).toHaveBeenCalledWith('tenant_acme', 'tenant-1', 'proj-a', expect.objectContaining({
+      documentId: 'doc-1',
+      ragModuleKey: 'docs-v1',
+    }));
+  });
+
+  it('POST .../documents/:id (reingest) passes the caller project to reingestDocument', async () => {
+    mockFn(reingestDocument).mockResolvedValue({ _id: 'doc-1' });
+    const app = await buildApp();
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/client/v1/rag/modules/docs-v1/documents/doc-1',
+      headers: { authorization: 'Bearer tok', 'content-type': 'application/json' },
+      payload: { content: 'updated text' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(reingestDocument).toHaveBeenCalledWith('tenant_acme', 'tenant-1', 'proj-a', expect.objectContaining({
+      documentId: 'doc-1',
+      ragModuleKey: 'docs-v1',
+    }));
+  });
+
+  it('does not fall back to documentInProjectScope\'s tenant-wide allowance for delete/reingest', async () => {
+    // A document that exists but belongs to a different project must 404,
+    // not silently resolve tenant-wide.
+    mockFn(documentInProjectScope).mockResolvedValue(null);
+    const app = await buildApp();
+
+    const res = await app.inject({
+      method: 'DELETE',
+      url: '/api/client/v1/rag/modules/docs-v1/documents/doc-other-project',
+      headers: { authorization: 'Bearer tok' },
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(deleteRagDocument).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/unit/rbac-route-mapping-coverage.test.ts
+++ b/src/__tests__/unit/rbac-route-mapping-coverage.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { getPermissionServiceForPath } from '@/lib/security/rbac';
+
+/**
+ * Regression gate for the bug class behind F-01 (finance-institution
+ * assessment, 2026-09-05): `getPermissionServiceForPath` returning `null` for
+ * an unmapped path makes `enforceApiTokenRbac`/`enforceSessionRbac` skip
+ * authorization entirely — a narrow-scope token gets full access to any
+ * `/client/v1/*` route the RBAC table doesn't know about yet.
+ *
+ * This has happened twice already: once for `/a2a` (fixed by a point patch),
+ * then again — simultaneously — for `/audio`, `/images`, `/ocr`,
+ * `/assistants`, `/threads`, and (previously unnoticed) `/rerankers`. A point
+ * fix does not stop a THIRD occurrence when the next `/client/v1/*` plugin
+ * ships. This test statically scans every client-token plugin file for its
+ * registered route paths and fails if any of them falls through the RBAC map
+ * — turning the "silently unenforced" failure mode into a loud CI failure at
+ * the moment a route is added, not months later in a pentest report.
+ *
+ * Every current `/client/v1/*` route is RBAC-mapped by design (no route
+ * currently sets `rbac: false`); ALLOWED_UNMAPPED_PREFIXES exists only for a
+ * future, deliberate exception — add to it with a comment explaining why the
+ * route is intentionally open to any valid token, never to silence a gap you
+ * haven't actually reasoned about.
+ */
+
+const PLUGINS_DIR = path.join(__dirname, '../../server/api/plugins');
+const ROUTE_LITERAL_RE = /app\.(?:get|post|put|delete|patch)\(\s*[`'"](\/client\/v1\/[a-zA-Z0-9_\-:./]*)[`'"]/g;
+
+const ALLOWED_UNMAPPED_PREFIXES: string[] = [];
+
+function isAllowed(clientPath: string): boolean {
+  return ALLOWED_UNMAPPED_PREFIXES.some(
+    (prefix) => clientPath === prefix || clientPath.startsWith(`${prefix}/`),
+  );
+}
+
+function discoverClientRoutePaths(): Map<string, string> {
+  const paths = new Map<string, string>(); // clientPath -> source file (first seen)
+  const files = fs
+    .readdirSync(PLUGINS_DIR)
+    .filter((f) => f.startsWith('client-') && f.endsWith('.ts'));
+
+  for (const file of files) {
+    const content = fs.readFileSync(path.join(PLUGINS_DIR, file), 'utf8');
+    let match: RegExpExecArray | null;
+    ROUTE_LITERAL_RE.lastIndex = 0;
+    while ((match = ROUTE_LITERAL_RE.exec(content))) {
+      if (!paths.has(match[1])) paths.set(match[1], file);
+    }
+  }
+  return paths;
+}
+
+describe('RBAC route-mapping coverage (client/v1 API-token surface)', () => {
+  const routePaths = discoverClientRoutePaths();
+
+  it('discovered a non-trivial number of client/v1 routes to check (sanity check the scanner itself still works)', () => {
+    expect(routePaths.size).toBeGreaterThan(100);
+  });
+
+  it('maps every registered /client/v1/* route to a permission service, or lists it as a deliberate exception', () => {
+    const unmapped: string[] = [];
+    for (const [clientPath, file] of routePaths) {
+      if (isAllowed(clientPath)) continue;
+      const service = getPermissionServiceForPath(`/api${clientPath}`);
+      if (!service) {
+        unmapped.push(`${clientPath}  (registered in ${file})`);
+      }
+    }
+
+    expect(
+      unmapped,
+      'These /client/v1 routes have no RBAC route-prefix entry in src/lib/security/rbac.ts, ' +
+        'so ANY valid API token — regardless of its service scope — passes authorization for ' +
+        'them unchecked (see enforceApiTokenRbac: unmapped paths return early). Either add a ' +
+        '{ prefix, service } entry to ROUTE_PREFIXES, or add the path to ' +
+        'ALLOWED_UNMAPPED_PREFIXES in this test with a comment explaining why it is meant to ' +
+        'be open to any token.',
+    ).toEqual([]);
+  });
+});

--- a/src/lib/security/rbac.ts
+++ b/src/lib/security/rbac.ts
@@ -162,6 +162,13 @@ const ROUTE_PREFIXES: Array<{ prefix: string; service: PermissionService }> = [
   { prefix: '/api/client/v1/crawler', service: 'crawler' },
   { prefix: '/api/client/v1/websearch', service: 'websearch' },
   { prefix: '/api/client/v1/ocr-jobs', service: 'ocr' },
+  // Single-shot OCR completion — same capability tier as ocr-jobs, just a
+  // synchronous call instead of a batch job.
+  { prefix: '/api/client/v1/ocr', service: 'ocr' },
+  // Audio (STT/TTS) and image generation are additional model-invocation
+  // dialects over the Model Hub, same tier as chat/embeddings below.
+  { prefix: '/api/client/v1/audio', service: 'models' },
+  { prefix: '/api/client/v1/images', service: 'models' },
   { prefix: '/api/client/v1/automations', service: 'automations' },
   { prefix: '/api/client/v1/config', service: 'config' },
   { prefix: '/api/client/v1/files', service: 'files' },
@@ -196,6 +203,10 @@ const ROUTE_PREFIXES: Array<{ prefix: string; service: PermissionService }> = [
   { prefix: '/api/client/v1/prompts', service: 'prompts' },
   { prefix: '/api/client/v1/rag', service: 'rag' },
   { prefix: '/api/client/v1/rerank', service: 'reranker' },
+  // `/rerankers` (list) does NOT start with `/rerank/` — it needs its own
+  // entry. A prior comment in client-reranker.ts incorrectly assumed the
+  // `/rerank` prefix above already covered it; it never matched.
+  { prefix: '/api/client/v1/rerankers', service: 'reranker' },
   { prefix: '/api/client/v1/tools', service: 'tools' },
   { prefix: '/api/client/v1/tracing', service: 'tracing' },
   { prefix: '/api/client/v1/traces', service: 'tracing' },
@@ -205,6 +216,11 @@ const ROUTE_PREFIXES: Array<{ prefix: string; service: PermissionService }> = [
   // path as /api/client/v1/agents — gate it identically so a token's 'agents'
   // scope (or lack of it) applies here too.
   { prefix: '/api/client/v1/a2a', service: 'agents' },
+  // OpenAI Assistants API dialect: an "assistant" is an agent (assistantId is
+  // derived from agentKey) and a "thread" is that agent's conversation — same
+  // underlying resource as /api/client/v1/agents, gate it identically.
+  { prefix: '/api/client/v1/assistants', service: 'agents' },
+  { prefix: '/api/client/v1/threads', service: 'agents' },
   { prefix: '/api/client/v1/batches', service: 'models' },
   { prefix: '/api/client/v1/spend', service: 'models' },
   { prefix: '/api/client/v1/budgets', service: 'models' },

--- a/src/lib/services/agents/agentService.ts
+++ b/src/lib/services/agents/agentService.ts
@@ -2393,7 +2393,17 @@ export async function executeAgentChatLocal(
 
     // 2. Load conversation
     const conversation = await db.findAgentConversationById(conversationId);
-    if (!conversation) throw new Error(`Conversation "${conversationId}" not found`);
+    // findAgentConversationById resolves purely by _id — it has no projectId
+    // parameter — so without this check, any caller who can produce another
+    // project's conversationId (a previous_response_id / A2A contextId / any
+    // future caller of this function) gets that project's message history
+    // read back as context AND appended to, regardless of which project the
+    // agent above was resolved from. This is the actual execution chokepoint
+    // shared by every caller, so the check belongs here, not only at each
+    // call site's own pre-check.
+    if (!conversation || conversation.projectId !== projectId) {
+        throw new Error(`Conversation "${conversationId}" not found`);
+    }
 
     // 2b. Connected (external) agent — invoke over HTTP, skip local runtime.
     //

--- a/src/server/api/plugins/client-a2a.ts
+++ b/src/server/api/plugins/client-a2a.ts
@@ -213,7 +213,9 @@ export async function handleA2aRpc(
       let conversationId: string | undefined;
       if (typeof message.contextId === 'string' && message.contextId) {
         const conversation = await getConversationById(ctx.tenantDbName, message.contextId);
-        if (!conversation || conversation.agentKey !== agent.key) {
+        // agentKey alone is not unique across projects — see the identical
+        // check in client-agents.ts's previous_response_id handling.
+        if (!conversation || conversation.agentKey !== agent.key || conversation.projectId !== ctx.projectId) {
           return reply.code(200).send(
             jsonRpcError(rpcId, -32602, 'Invalid params: unknown contextId'),
           );
@@ -271,7 +273,7 @@ export async function handleA2aRpc(
         return reply.code(200).send(jsonRpcError(rpcId, ERR_TASK_NOT_FOUND, 'Task not found'));
       }
       const conversation = await getConversationById(ctx.tenantDbName, parsed.conversationId);
-      const message = conversation?.agentKey === agent.key
+      const message = conversation?.agentKey === agent.key && conversation?.projectId === ctx.projectId
         ? conversation.messages?.[parsed.messageIndex]
         : undefined;
       if (!message || message.role !== 'assistant') {

--- a/src/server/api/plugins/client-agents.ts
+++ b/src/server/api/plugins/client-agents.ts
@@ -178,7 +178,12 @@ function createResponsesHandler(usePublished: boolean) {
         const resolvedConversationId = conversationIdFromResponseId(body.previous_response_id);
         if (resolvedConversationId) {
           const conversation = await getConversationById(ctx.tenantDbName, resolvedConversationId);
-          if (!conversation || conversation.agentKey !== agent.key) {
+          // agentKey alone is not unique across projects (findAgentByKey takes
+          // an optional projectId precisely because the same key can exist in
+          // more than one) — without the projectId check, a token in project B
+          // could reuse a previous_response_id from project A's conversation
+          // with the same-keyed agent and read/append to project A's history.
+          if (!conversation || conversation.agentKey !== agent.key || conversation.projectId !== ctx.projectId) {
             return reply.code(404).send({
               error: 'previous_response_id does not match a valid conversation',
             });

--- a/src/server/api/plugins/client-assistants.ts
+++ b/src/server/api/plugins/client-assistants.ts
@@ -329,16 +329,18 @@ export function extractMessageText(input: unknown): string | null {
 async function loadThreadOr404(
   tenantDbName: string,
   rawThreadId: string,
-  projectId: string | undefined,
+  projectId: string,
 ): Promise<{ conversation: IAgentConversation; agent: IAgent } | { error: { code: number; message: string } }> {
   const conversationId = conversationIdFromThreadId(rawThreadId);
   const conversation = await getConversationById(tenantDbName, conversationId);
   // getConversationById resolves purely by _id (findAgentConversationById has
   // no projectId parameter at all) — without this check, a caller who can
   // guess or enumerate another project's thread id gets that project's whole
-  // conversation history back. A scoped token's projectId must always be
-  // undefined-or-equal to the record's own project, never silently ignored.
-  if (!conversation || (projectId !== undefined && conversation.projectId !== projectId)) {
+  // conversation history back. `projectId` is required, not optional, on
+  // purpose: every caller here has `ctx.projectId` (ApiTokenContext types it
+  // as a plain `string`), and an optional parameter would leave a silent
+  // "pass nothing, check nothing" bypass for the next caller added.
+  if (!conversation || conversation.projectId !== projectId) {
     return { error: { code: 404, message: 'Thread not found' } };
   }
   const agent = await getAgentByKey(tenantDbName, conversation.agentKey, conversation.projectId);

--- a/src/server/api/plugins/client-assistants.ts
+++ b/src/server/api/plugins/client-assistants.ts
@@ -329,11 +329,19 @@ export function extractMessageText(input: unknown): string | null {
 async function loadThreadOr404(
   tenantDbName: string,
   rawThreadId: string,
+  projectId: string | undefined,
 ): Promise<{ conversation: IAgentConversation; agent: IAgent } | { error: { code: number; message: string } }> {
   const conversationId = conversationIdFromThreadId(rawThreadId);
   const conversation = await getConversationById(tenantDbName, conversationId);
-  if (!conversation) return { error: { code: 404, message: 'Thread not found' } };
-  const agent = await getAgentByKey(tenantDbName, conversation.agentKey);
+  // getConversationById resolves purely by _id (findAgentConversationById has
+  // no projectId parameter at all) — without this check, a caller who can
+  // guess or enumerate another project's thread id gets that project's whole
+  // conversation history back. A scoped token's projectId must always be
+  // undefined-or-equal to the record's own project, never silently ignored.
+  if (!conversation || (projectId !== undefined && conversation.projectId !== projectId)) {
+    return { error: { code: 404, message: 'Thread not found' } };
+  }
+  const agent = await getAgentByKey(tenantDbName, conversation.agentKey, conversation.projectId);
   if (!agent) return { error: { code: 404, message: 'Thread references an assistant that no longer exists' } };
   return { conversation, agent };
 }
@@ -562,7 +570,7 @@ export const clientAssistantsApiPlugin: FastifyPluginAsync = async (app) => {
     try {
       const ctx = await getApiTokenContextForRequest(request);
       const { threadId: rawId } = request.params as { threadId: string };
-      const loaded = await loadThreadOr404(ctx.tenantDbName, rawId);
+      const loaded = await loadThreadOr404(ctx.tenantDbName, rawId, ctx.projectId);
       if ('error' in loaded) return reply.code(loaded.error.code).send({ error: loaded.error.message });
       return reply.code(200).send(threadObject(loaded.conversation));
     } catch (error) {
@@ -575,7 +583,7 @@ export const clientAssistantsApiPlugin: FastifyPluginAsync = async (app) => {
     try {
       const ctx = await getApiTokenContextForRequest(request);
       const { threadId: rawId } = request.params as { threadId: string };
-      const loaded = await loadThreadOr404(ctx.tenantDbName, rawId);
+      const loaded = await loadThreadOr404(ctx.tenantDbName, rawId, ctx.projectId);
       if ('error' in loaded) return reply.code(loaded.error.code).send({ error: loaded.error.message });
 
       const body = readJsonBody<Record<string, unknown>>(request);
@@ -602,7 +610,7 @@ export const clientAssistantsApiPlugin: FastifyPluginAsync = async (app) => {
     try {
       const ctx = await getApiTokenContextForRequest(request);
       const { threadId: rawId } = request.params as { threadId: string };
-      const loaded = await loadThreadOr404(ctx.tenantDbName, rawId);
+      const loaded = await loadThreadOr404(ctx.tenantDbName, rawId, ctx.projectId);
       if ('error' in loaded) return reply.code(loaded.error.code).send({ error: loaded.error.message });
       const { deleteConversation } = await import('@/lib/services/agents');
       const deleted = await deleteConversation(ctx.tenantDbName, conversationIdFromThreadId(rawId));
@@ -619,7 +627,7 @@ export const clientAssistantsApiPlugin: FastifyPluginAsync = async (app) => {
     try {
       const ctx = await getApiTokenContextForRequest(request);
       const { threadId: rawId } = request.params as { threadId: string };
-      const loaded = await loadThreadOr404(ctx.tenantDbName, rawId);
+      const loaded = await loadThreadOr404(ctx.tenantDbName, rawId, ctx.projectId);
       if ('error' in loaded) return reply.code(loaded.error.code).send({ error: loaded.error.message });
 
       const body = readJsonBody<Record<string, unknown>>(request);
@@ -659,7 +667,7 @@ export const clientAssistantsApiPlugin: FastifyPluginAsync = async (app) => {
     try {
       const ctx = await getApiTokenContextForRequest(request);
       const { threadId: rawId } = request.params as { threadId: string };
-      const loaded = await loadThreadOr404(ctx.tenantDbName, rawId);
+      const loaded = await loadThreadOr404(ctx.tenantDbName, rawId, ctx.projectId);
       if ('error' in loaded) return reply.code(loaded.error.code).send({ error: loaded.error.message });
 
       const conversationId = conversationIdFromThreadId(rawId);
@@ -679,7 +687,7 @@ export const clientAssistantsApiPlugin: FastifyPluginAsync = async (app) => {
     try {
       const ctx = await getApiTokenContextForRequest(request);
       const { threadId: rawId, messageId: rawMessageId } = request.params as { threadId: string; messageId: string };
-      const loaded = await loadThreadOr404(ctx.tenantDbName, rawId);
+      const loaded = await loadThreadOr404(ctx.tenantDbName, rawId, ctx.projectId);
       if ('error' in loaded) return reply.code(loaded.error.code).send({ error: loaded.error.message });
 
       const conversationId = conversationIdFromThreadId(rawId);
@@ -791,7 +799,7 @@ export const clientAssistantsApiPlugin: FastifyPluginAsync = async (app) => {
     try {
       const ctx = await getApiTokenContextForRequest(request);
       const { threadId: rawId } = request.params as { threadId: string };
-      const loaded = await loadThreadOr404(ctx.tenantDbName, rawId);
+      const loaded = await loadThreadOr404(ctx.tenantDbName, rawId, ctx.projectId);
       if ('error' in loaded) return reply.code(loaded.error.code).send({ error: loaded.error.message });
 
       const body = readJsonBody<Record<string, unknown>>(request);
@@ -832,7 +840,7 @@ export const clientAssistantsApiPlugin: FastifyPluginAsync = async (app) => {
     try {
       const ctx = await getApiTokenContextForRequest(request);
       const { threadId: rawId } = request.params as { threadId: string };
-      const loaded = await loadThreadOr404(ctx.tenantDbName, rawId);
+      const loaded = await loadThreadOr404(ctx.tenantDbName, rawId, ctx.projectId);
       if ('error' in loaded) return reply.code(loaded.error.code).send({ error: loaded.error.message });
 
       const runs = readAssistantsMetadata(loaded.conversation).runs ?? [];
@@ -851,7 +859,7 @@ export const clientAssistantsApiPlugin: FastifyPluginAsync = async (app) => {
     try {
       const ctx = await getApiTokenContextForRequest(request);
       const { threadId: rawId, runId: rawRunId } = request.params as { threadId: string; runId: string };
-      const loaded = await loadThreadOr404(ctx.tenantDbName, rawId);
+      const loaded = await loadThreadOr404(ctx.tenantDbName, rawId, ctx.projectId);
       if ('error' in loaded) return reply.code(loaded.error.code).send({ error: loaded.error.message });
 
       const runs = readAssistantsMetadata(loaded.conversation).runs ?? [];
@@ -870,7 +878,7 @@ export const clientAssistantsApiPlugin: FastifyPluginAsync = async (app) => {
     try {
       const ctx = await getApiTokenContextForRequest(request);
       const { threadId: rawId, runId: rawRunId } = request.params as { threadId: string; runId: string };
-      const loaded = await loadThreadOr404(ctx.tenantDbName, rawId);
+      const loaded = await loadThreadOr404(ctx.tenantDbName, rawId, ctx.projectId);
       if ('error' in loaded) return reply.code(loaded.error.code).send({ error: loaded.error.message });
 
       const runs = readAssistantsMetadata(loaded.conversation).runs ?? [];

--- a/src/server/api/plugins/client-rag.ts
+++ b/src/server/api/plugins/client-rag.ts
@@ -185,7 +185,7 @@ export const clientRagApiPlugin: FastifyPluginAsync = async (app) => {
     try {
       const ctx = await getApiTokenContextForRequest(request);
       const { key } = request.params as { key: string };
-      const documents = await listRagDocuments(ctx.tenantDbName, key, {});
+      const documents = await listRagDocuments(ctx.tenantDbName, key, { projectId: ctx.projectId });
       return reply.code(200).send({ documents });
     } catch (error) {
       logger.error('List client RAG documents error', { error });
@@ -220,7 +220,7 @@ export const clientRagApiPlugin: FastifyPluginAsync = async (app) => {
       const statusCode = deferIndexing ? 202 : 201;
 
       if (typeof body.data === 'string') {
-        const document = await ingestFile(ctx.tenantDbName, ctx.tenantId, undefined, {
+        const document = await ingestFile(ctx.tenantDbName, ctx.tenantId, ctx.projectId, {
           chunkConfig,
           contentType: body.contentType as string | undefined,
           createdBy: ctx.tokenRecord.userId,
@@ -241,7 +241,7 @@ export const clientRagApiPlugin: FastifyPluginAsync = async (app) => {
         });
       }
 
-      const document = await ingestDocument(ctx.tenantDbName, ctx.tenantId, undefined, {
+      const document = await ingestDocument(ctx.tenantDbName, ctx.tenantId, ctx.projectId, {
         chunkConfig,
         content: body.content,
         contentType: body.contentType as string | undefined,
@@ -356,7 +356,7 @@ export const clientRagApiPlugin: FastifyPluginAsync = async (app) => {
         return reply.code(404).send({ error: 'Document not found' });
       }
 
-      await deleteRagDocument(ctx.tenantDbName, ctx.tenantId, undefined, {
+      await deleteRagDocument(ctx.tenantDbName, ctx.tenantId, ctx.projectId, {
         documentId,
         ragModuleKey: key,
       });
@@ -396,7 +396,7 @@ export const clientRagApiPlugin: FastifyPluginAsync = async (app) => {
         return sendInvalidRequest(reply, error);
       }
 
-      const document = await reingestDocument(ctx.tenantDbName, ctx.tenantId, undefined, {
+      const document = await reingestDocument(ctx.tenantDbName, ctx.tenantId, ctx.projectId, {
         chunkConfig,
         content: typeof body.content === 'string' ? body.content : undefined,
         contentType: typeof body.contentType === 'string' ? body.contentType : undefined,
@@ -429,7 +429,7 @@ export const clientRagApiPlugin: FastifyPluginAsync = async (app) => {
         return reply.code(400).send({ error: 'query is required' });
       }
 
-      const result = await queryRag(ctx.tenantDbName, ctx.tenantId, undefined, {
+      const result = await queryRag(ctx.tenantDbName, ctx.tenantId, ctx.projectId, {
         filter: body.filter as Record<string, unknown> | undefined,
         query: body.query,
         ragModuleKey: key,

--- a/src/server/api/plugins/client-reranker.ts
+++ b/src/server/api/plugins/client-reranker.ts
@@ -9,8 +9,9 @@
  *   - PATCH  /api/client/v1/rerank/:key      → update a reranker definition
  *   - DELETE /api/client/v1/rerank/:key      → delete a reranker definition
  *
- * Authoring lives under `/rerank` (not `/rerankers`) so it is covered by the
- * `/api/client/v1/rerank` RBAC prefix and enforced at `write`.
+ * `/rerankers` and `/rerank` each have their own RBAC route-prefix entry
+ * (they don't share a path separator, so one prefix cannot cover both) —
+ * both map to the `reranker` service in `src/lib/security/rbac.ts`.
  *
  * The run request shape mirrors Cohere's /v2/rerank to make it easy to drop in:
  *   { query, documents: string[] | { text }[], top_n? }
@@ -92,8 +93,6 @@ export const clientRerankerApiPlugin: FastifyPluginAsync = async (app) => {
   );
 
   // ── Create a reranker definition ──
-  // Registered on the `/rerank` collection (not `/rerankers`) so it is covered
-  // by the `/api/client/v1/rerank` RBAC prefix.
   app.post(
     '/client/v1/rerank',
     withClientApiRequestContext(async (request, reply) => {


### PR DESCRIPTION
## Summary

Three P0 findings from the 2026-09-05 finance-institution assessment (`FINANS-KURULUSU-GENAI-DEGERLENDIRME-2026-09-05.md`), all confirmed live on `main` — the Assistants/Threads surface these bugs live in merged via PR #268 during that same review.

- **F-01 — RBAC route-mapping gaps.** `/audio`, `/images`, `/ocr`, `/assistants` and `/threads` had no entry in `ROUTE_PREFIXES`, so `enforceApiTokenRbac`/`enforceSessionRbac` skipped authorization entirely for them — a narrow-scope token got full access instead of a 403. While verifying the fix I found a 7th, previously-unknown instance: `/client/v1/rerankers` never actually matched the `/rerank` prefix (no shared `/` boundary) despite a code comment claiming it did. Added `rbac-route-mapping-coverage.test.ts`, which statically scans every `client-*.ts` route registration and fails CI if a future route ships without an RBAC mapping.
- **F-02 — RAG client API project-scope loss.** Document list/ingest/query/reingest/delete passed `undefined` instead of `ctx.projectId` to the RAG service layer, which treats a missing projectId as "tenant-wide, by design" — letting a token see or write into another project's same-keyed module. All five call sites now thread the real projectId through (the service layer already resolves the module ownership correctly once given it). Added `client-rag-project-scope.test.ts` (this plugin had zero test coverage before).
- **F-03 — Thread/conversation ownership not verified.** `loadThreadOr404` checked tenant + id but never the caller's project — another project's thread was loadable by id. Fixed at the Assistants/Threads plugin, and also at the shared execution chokepoint (`executeAgentChatLocal` in `agentService.ts`), since that function is the actual chokepoint for `/responses`, `/agents/responses` and A2A too, not just the Assistants plugin. Also hardened the weaker `agentKey`-only pre-checks in `client-agents.ts` and `client-a2a.ts` (agent keys are not unique across projects). Added `client-assistants-thread-scope.test.ts`.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` clean on all changed files
- [x] Full `vitest run` suite: 5057 passed, 0 failed, 5 skipped
- [x] Each new/fixed regression test manually verified to fail against the pre-fix code (reverted one line at a time, confirmed red, restored)
- [x] `scripts/check-endpoint-coverage.ts` still exits 0 (no new gaps introduced; new tests only add coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KQq6TnVNHRNU6Wz1eQzPpD