### PR TITLE
fix(quota): micro-dollar budget precision + fail-closed on counter error (F-04)

### DIFF
--- a/src/__tests__/unit/quota-guard-budget.test.ts
+++ b/src/__tests__/unit/quota-guard-budget.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Regression tests for F-04 (finance-institution assessment, 2026-09-05):
+ * `checkBudget`'s counter used to round every cost to whole cents — a
+ * $0.004 call rounded to 0, so 1,000 real $0.004 charges ($4 of actual
+ * spend) left the counter at $0 — and a counter-lookup exception was only
+ * logged, never denied, so a Redis/DB blip silently disabled a tenant's own
+ * configured hard cap (fail-open).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createMockDb } from '../helpers/db.mock';
+
+const cacheStore = new Map<string, unknown>();
+const config = { quota: { policyCacheTtlSeconds: 30 } };
+
+vi.mock('@/lib/database', () => ({ getDatabase: vi.fn() }));
+
+vi.mock('@/lib/core/config', () => ({
+  getConfig: () => config,
+}));
+
+vi.mock('@/lib/core/cache', () => ({
+  getCache: async () => ({
+    get: async (key: string) => cacheStore.get(key),
+    set: async (key: string, value: unknown) => { cacheStore.set(key, value); },
+    del: async (key: string) => { cacheStore.delete(key); },
+  }),
+}));
+
+vi.mock('@/lib/core/logger', () => ({
+  createLogger: () => ({
+    debug: () => {}, info: () => {}, warn: () => {}, error: () => {},
+  }),
+}));
+
+import { getDatabase } from '@/lib/database';
+import { checkBudget } from '@/lib/quota/quotaGuard';
+import type { QuotaContext } from '@/lib/quota/quotaGuard';
+import type { ITenant, IQuotaPolicy } from '@/lib/database';
+
+const DB_NAME = 'tenant_acme';
+const TENANT_ID = 'tenant-1';
+const PROJECT_ID = 'proj-1';
+
+function makeContext(overrides: Partial<QuotaContext> = {}): QuotaContext {
+  return {
+    tenantDbName: DB_NAME,
+    tenantId: TENANT_ID,
+    projectId: PROJECT_ID,
+    licenseType: 'enterprise',
+    domain: 'llm',
+    ...overrides,
+  } as QuotaContext;
+}
+
+function budgetPolicy(dailySpendLimit: number): IQuotaPolicy {
+  return {
+    _id: 'p-budget',
+    tenantId: TENANT_ID,
+    domain: 'llm',
+    scope: 'tenant',
+    priority: 10,
+    enabled: true,
+    limits: { budget: { dailySpendLimit, monthlySpendLimit: -1 } },
+  } as unknown as IQuotaPolicy;
+}
+
+describe('checkBudget — micro-dollar precision + fail-closed on counter error', () => {
+  let db: ReturnType<typeof createMockDb>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    cacheStore.clear();
+    db = createMockDb();
+    db.findTenantById.mockResolvedValue({ _id: TENANT_ID, slug: 'acme' } as unknown as ITenant);
+    db.listQuotaPolicies.mockResolvedValue([budgetPolicy(10)]); // $10/day cap
+    (getDatabase as ReturnType<typeof vi.fn>).mockResolvedValue(db);
+  });
+
+  it('does not round a sub-cent cost away to zero', async () => {
+    let counter = 0;
+    db.incrementRateLimit.mockImplementation(async (_key, _windowSeconds, amount) => {
+      counter += amount;
+      return { count: counter, resetAt: new Date() };
+    });
+
+    // 1,000 calls at $0.004 each == $4 of real spend. Whole-cent rounding
+    // used to turn every single one of these into a 0-cent increment.
+    for (let i = 0; i < 1000; i += 1) {
+      await checkBudget(makeContext(), { usd: 0.004 });
+    }
+
+    // 1,000 * $0.004 = $4 = 4,000,000 micros.
+    expect(counter).toBe(4_000_000);
+  });
+
+  it('denies the request when the counter lookup fails and a hard cap IS configured (fail closed)', async () => {
+    db.incrementRateLimit.mockRejectedValue(new Error('cache unavailable'));
+
+    const result = await checkBudget(makeContext(), { usd: 1 });
+
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toMatch(/failing closed/i);
+  });
+
+  it('does not fail closed when the tenant has no budget limit configured', async () => {
+    db.listQuotaPolicies.mockResolvedValue([]); // no budget policy at all
+    db.incrementRateLimit.mockRejectedValue(new Error('cache unavailable'));
+
+    const result = await checkBudget(makeContext(), { usd: 1 });
+
+    // checkWindow's early-return for an unconfigured limit means the failing
+    // counter is never even touched — a tenant who never opted into a hard
+    // cap must not get a new failure mode from this fix.
+    expect(result.allowed).toBe(true);
+    expect(db.incrementRateLimit).not.toHaveBeenCalled();
+  });
+
+  it('rejects once the atomic increment itself pushes the window over the configured cap', async () => {
+    db.incrementRateLimit.mockImplementation(async (_key, _windowSeconds, amount) => {
+      // Peek (amount 0) reports just under the $10 cap; the real increment
+      // (amount > 0) is what actually tips it over.
+      if (amount === 0) return { count: 9_990_000, resetAt: new Date() };
+      return { count: 9_990_000 + amount, resetAt: new Date() };
+    });
+
+    const result = await checkBudget(makeContext(), { usd: 0.02 }); // 20,000 micros
+
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toMatch(/budget exceeded/i);
+  });
+});

--- a/src/lib/quota/quotaGuard.ts
+++ b/src/lib/quota/quotaGuard.ts
@@ -608,9 +608,17 @@ export async function checkRateLimit(
   return { allowed: true, effectiveLimits };
 }
 
-function usdToCents(usd: number): number {
+/**
+ * Micro-dollars (1 USD = 1,000,000 micros), the same precision Google/AWS
+ * billing APIs use for per-call costs. Whole cents lost calls cheaper than
+ * $0.005 entirely: `Math.round(0.004 * 100)` is 0, so 1,000 real $0.004
+ * charges — $4 of actual spend — added up to $0 on the counter.
+ */
+const MICROS_PER_USD = 1_000_000;
+
+function usdToMicros(usd: number): number {
   if (!Number.isFinite(usd)) return 0;
-  return Math.max(0, Math.round(usd * 100));
+  return Math.max(0, Math.round(usd * MICROS_PER_USD));
 }
 
 export async function checkBudget(
@@ -624,54 +632,54 @@ export async function checkBudget(
   const budget = effectiveLimits.budget;
   if (!budget) return { allowed: true, effectiveLimits };
 
-  const costCents = usdToCents(cost.usd ?? 0);
+  const costMicros = usdToMicros(cost.usd ?? 0);
   const errors: string[] = [];
 
   const checkWindow = async (
     windowName: 'perDay' | 'perMonth',
     limitUsd: number | undefined,
-    incrementByCents: number,
+    incrementByMicros: number,
   ) => {
     if (limitUsd === undefined || limitUsd === -1) return;
 
-    const limitCents = usdToCents(limitUsd);
+    const limitMicros = usdToMicros(limitUsd);
     const windowSeconds = windowName === 'perDay' ? 86400 : 2592000;
-
-    const keyParts = ['budget', context.domain, 'usd_cents', windowName];
-    if (context.providerKey) keyParts.push(`prov:${context.providerKey}`);
-    if (context.resourceKey) keyParts.push(`res:${context.resourceKey}`);
-    if (context.userId) keyParts.push(`user:${context.userId}`);
-    else if (context.tokenId) keyParts.push(`token:${context.tokenId}`);
-    else keyParts.push(`tenant:${context.tenantId}`);
-
-    const key = keyParts.join(':');
+    const key = budgetCounterKey(context, windowName);
 
     try {
       // Read current value without incrementing.
       const current = await db.incrementRateLimit(key, windowSeconds, 0);
-      if (current.count >= limitCents) {
-        errors.push(`Budget exceeded for ${windowName} (${current.count}/${limitCents} cents)`);
+      if (current.count >= limitMicros) {
+        errors.push(`Budget exceeded for ${windowName} (${current.count}/${limitMicros} micros)`);
         return;
       }
 
-      if (incrementByCents > 0) {
+      if (incrementByMicros > 0) {
         const updated = await db.incrementRateLimit(
           key,
           windowSeconds,
-          incrementByCents,
+          incrementByMicros,
         );
-        if (updated.count > limitCents) {
-          errors.push(`Budget exceeded for ${windowName} (${updated.count}/${limitCents} cents)`);
+        if (updated.count > limitMicros) {
+          errors.push(`Budget exceeded for ${windowName} (${updated.count}/${limitMicros} micros)`);
         }
       }
     } catch (error) {
       logger.error('Budget check failed', { error });
+      // Fail CLOSED, not open: this branch only runs when the tenant has an
+      // actual dailySpendLimit/monthlySpendLimit configured (the early return
+      // above skips it otherwise) — i.e. only for callers who explicitly
+      // opted into a hard cap. Silently letting spend through on a counter
+      // lookup failure made that cap meaningless during exactly the kind of
+      // outage a hard cap exists to survive; it never affects a tenant that
+      // hasn't configured a budget limit at all.
+      errors.push(`Budget check unavailable for ${windowName}; failing closed`);
     }
   };
 
   await Promise.all([
-    checkWindow('perDay', budget.dailySpendLimit, costCents),
-    checkWindow('perMonth', budget.monthlySpendLimit, costCents),
+    checkWindow('perDay', budget.dailySpendLimit, costMicros),
+    checkWindow('perMonth', budget.monthlySpendLimit, costMicros),
   ]);
 
   if (errors.length > 0) {
@@ -700,9 +708,9 @@ export interface BudgetUsage {
   alertThresholds?: number[];
 }
 
-/** Mirrors the counter key scheme used by `checkBudget`. */
+/** Shared counter key scheme for `checkBudget` and `getBudgetUsage`. */
 function budgetCounterKey(context: QuotaContext, windowName: 'perDay' | 'perMonth'): string {
-  const keyParts = ['budget', context.domain, 'usd_cents', windowName];
+  const keyParts = ['budget', context.domain, 'usd_micros', windowName];
   if (context.providerKey) keyParts.push(`prov:${context.providerKey}`);
   if (context.resourceKey) keyParts.push(`res:${context.resourceKey}`);
   if (context.userId) keyParts.push(`user:${context.userId}`);
@@ -734,7 +742,7 @@ export async function getBudgetUsage(context: QuotaContext): Promise<BudgetUsage
         windowSeconds,
         0,
       );
-      usedUsd = current.count / 100;
+      usedUsd = current.count / MICROS_PER_USD;
     } catch (error) {
       logger.error('Budget usage read failed', { error });
     }


### PR DESCRIPTION
## Summary

P1 finding from the 2026-09-05 finance-institution assessment.

`checkBudget`'s counter rounded every request's cost to whole cents (`Math.round(usd * 100)`), so anything cheaper than $0.005 contributed exactly 0 — a synthetic run of 1,000 real $0.004 charges ($4 of actual spend) left the daily/monthly counter at $0. Separately, a counter lookup/increment exception was only logged, never turned into a denial (`allowed: true` on a DB/cache error) — a Redis blip silently disabled a tenant's own configured hard cap.

- `usdToCents` → `usdToMicros` (1,000,000 micros/USD — the same precision console-ee's App Gateway budget path already uses). Counter key renamed `usd_cents` → `usd_micros` so an in-flight window can't silently mix two unit scales mid-rollout.
- The lookup-failure catch now denies instead of only logging. This **only** changes behavior for a context that has an actual `dailySpendLimit`/`monthlySpendLimit` configured — `checkWindow` already returns early for anything without one, so a tenant who never opted into a hard cap gets no new failure mode here.

Out of scope for this PR: the underlying admission control is still a peek-then-atomic-increment, not a full reserve/settle/release ledger. The assessment calls that out as a separate, larger design item (F-05's "aynı bütçe settlement yolu tamamlanmıyor"), not a same-scope fix with this one.

## Test plan

- [x] New `quota-guard-budget.test.ts`: rounding precision, fail-closed-with-limit-configured, no-new-failure-mode-without-a-limit, and the atomic-increment-crosses-the-cap path
- [x] Each new test manually verified to fail against the pre-fix code (reverted, confirmed red, restored)
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` clean
- [x] Full `vitest run`: 5050 passed, 0 failed, 5 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KQq6TnVNHRNU6Wz1eQzPpD