### PR TITLE
fix(prompts): resolver must not serve a planned (unactivated) deployment (F-13)

### DIFF
--- a/src/__tests__/unit/prompt-service.test.ts
+++ b/src/__tests__/unit/prompt-service.test.ts
@@ -23,6 +23,7 @@ import {
   updatePrompt,
   deletePrompt,
   listPromptVersions,
+  resolvePromptForEnvironment,
 } from '@/lib/services/prompts/promptService';
 import type { IPrompt, IPromptVersion } from '@/lib/database';
 
@@ -350,5 +351,86 @@ describe('listPromptVersions', () => {
     expect(latest?.isLatest).toBe(true);
     const older = result.find((v) => v.version === 1);
     expect(older?.isLatest).toBe(false);
+  });
+});
+
+// ── resolvePromptForEnvironment ──────────────────────────────────────────────
+// Regression coverage for F-13 (finance-institution assessment, 2026-09-05):
+// `promotePromptVersion` writes a fresh deployment as `rolloutStatus:
+// 'planned'`, and only `activatePromptDeployment` flips it to 'active'. The
+// resolver used to pick `deployments[environment].versionId` without ever
+// checking that status, so a promoted-but-not-yet-approved version was
+// served identically to an approved one.
+
+describe('resolvePromptForEnvironment', () => {
+  let db: ReturnType<typeof createMockDb>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    db = createMockDb();
+    (getDatabase as ReturnType<typeof vi.fn>).mockResolvedValue(db);
+  });
+
+  it('does not serve a "planned" (not yet activated) deployment', async () => {
+    db.findPromptByKey.mockResolvedValue(makePrompt({
+      currentVersion: 1,
+      deployments: {
+        prod: {
+          environment: 'prod',
+          versionId: 'version-2',
+          version: 2,
+          rolloutStatus: 'planned',
+          rolloutStrategy: 'manual',
+          updatedBy: USER_ID,
+          updatedAt: new Date('2025-01-02'),
+        },
+      },
+    }));
+    db.findPromptById.mockResolvedValue(makePrompt({ currentVersion: 1 }));
+    db.listPromptVersions.mockResolvedValue([
+      makeVersion({ _id: 'version-1', version: 1 }),
+      makeVersion({ _id: 'version-2', version: 2 }),
+    ]);
+
+    const result = await resolvePromptForEnvironment(TENANT_DB, PROJECT_ID, 'my-prompt', 'prod');
+
+    // Must fall back to currentVersion (1), never serve the planned v2.
+    expect(result?.resolvedVersion?.version).toBe(1);
+  });
+
+  it('serves the deployment once it is active', async () => {
+    db.findPromptByKey.mockResolvedValue(makePrompt({
+      currentVersion: 1,
+      deployments: {
+        prod: {
+          environment: 'prod',
+          versionId: 'version-2',
+          version: 2,
+          rolloutStatus: 'active',
+          rolloutStrategy: 'manual',
+          updatedBy: USER_ID,
+          updatedAt: new Date('2025-01-02'),
+        },
+      },
+    }));
+    db.findPromptById.mockResolvedValue(makePrompt({ currentVersion: 1 }));
+    db.listPromptVersions.mockResolvedValue([
+      makeVersion({ _id: 'version-1', version: 1 }),
+      makeVersion({ _id: 'version-2', version: 2 }),
+    ]);
+
+    const result = await resolvePromptForEnvironment(TENANT_DB, PROJECT_ID, 'my-prompt', 'prod');
+
+    expect(result?.resolvedVersion?.version).toBe(2);
+  });
+
+  it('falls back to currentVersion when the environment has no deployment at all', async () => {
+    db.findPromptByKey.mockResolvedValue(makePrompt({ currentVersion: 1, deployments: {} }));
+    db.findPromptById.mockResolvedValue(makePrompt({ currentVersion: 1 }));
+    db.listPromptVersions.mockResolvedValue([makeVersion({ _id: 'version-1', version: 1 })]);
+
+    const result = await resolvePromptForEnvironment(TENANT_DB, PROJECT_ID, 'my-prompt', 'prod');
+
+    expect(result?.resolvedVersion?.version).toBe(1);
   });
 });

--- a/src/lib/services/prompts/promptService.ts
+++ b/src/lib/services/prompts/promptService.ts
@@ -744,7 +744,18 @@ export async function resolvePromptForEnvironment(
 
 	if (typeof version === 'number') {
 		resolvedVersion = getVersionByNumber(versions, version);
-	} else if (environment && prompt.deployments?.[environment]?.versionId) {
+	} else if (
+		environment
+		&& prompt.deployments?.[environment]?.versionId
+		&& prompt.deployments[environment]?.rolloutStatus === 'active'
+	) {
+		// `promotePromptVersion` writes a fresh deployment as `rolloutStatus:
+		// 'planned'` — it only becomes servable once `activatePromptDeployment`
+		// flips it to 'active'. Without this check, a promoted-but-not-yet-
+		// activated version was served identically to an approved one; a
+		// deployment stuck at 'planned' now falls through to the same
+		// currentVersion fallback used when the environment has no deployment
+		// configured at all, rather than serving the half-promoted version.
 		resolvedVersion = versions.find((item) => item.id === prompt.deployments?.[environment]?.versionId) ?? null;
 	} else if (typeof prompt.currentVersion === 'number') {
 		resolvedVersion = getVersionByNumber(versions, prompt.currentVersion);

--- a/src/server/api/plugins/client-agents.ts
+++ b/src/server/api/plugins/client-agents.ts
@@ -297,6 +297,12 @@ export const clientAgentsApiPlugin: FastifyPluginAsync = async (app) => {
     }
   }));
 
+  // Deliberately different defaults, not a typo: /agents/responses always
+  // runs the published version (usePublished=true); the general /responses
+  // dialect runs the current draft config unless the caller asks for a
+  // specific version (usePublished=false). A caller who has only ever seen
+  // a published version in the dashboard can otherwise assume the general
+  // Responses route uses it too — it does not, unless told to.
   app.post('/client/v1/agents/responses', createResponsesHandler(true));
   app.post('/client/v1/responses', createResponsesHandler(false));
 


### PR DESCRIPTION
## Summary

P1 finding from the 2026-09-05 finance-institution assessment.

`promotePromptVersion` writes a fresh deployment as `rolloutStatus: 'planned'`; only `activatePromptDeployment` flips it to `'active'`. But `resolvePromptForEnvironment` — the function actually used to serve a prompt at request time — picked `deployments[environment].versionId` without ever checking that status. An isolated check in the assessment showed a `planned`-only v2 served as "prod".

The resolver now only uses the environment's deployment when its `rolloutStatus` is `'active'`. A deployment stuck at `'planned'` falls through to the same `currentVersion` fallback already used when the environment has no deployment configured at all — so this doesn't change behavior for environments that were never given an explicit deployment, only for the specific "promoted but not yet activated" gap.

Also added a comment (no behavior change) on `/client/v1/agents/responses` vs `/client/v1/responses`'s different `usePublished` defaults, which the same finding flagged as a source of confusion — the agent-execution path uses a simpler single `publishedVersion` field with no per-environment planned/active state, so it doesn't have this specific bug, just needed the intent written down.

## Test plan

- [x] New tests in `prompt-service.test.ts`: planned deployment is skipped, active deployment is served, no-deployment-at-all still falls back to currentVersion
- [x] Manually verified the new test fails against the pre-fix code (reverted the check, confirmed red, restored)
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` clean
- [x] Full `vitest run`: 5049 passed, 0 failed, 5 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KQq6TnVNHRNU6Wz1eQzPpD