### PR TITLE
fix(browser): boot reconciliation must not orphan another replica's live session (F-06)

### DIFF
--- a/src/__tests__/unit/browser-operations-reconcile.test.ts
+++ b/src/__tests__/unit/browser-operations-reconcile.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Regression tests for F-06 (finance-institution assessment, 2026-09-05):
+ * boot reconciliation used to decide a session was orphaned purely on
+ * whether THIS process's in-memory browserManager knew about it — so a
+ * session genuinely alive on another replica got marked expired the moment
+ * any other replica booted or rolled. It now cross-checks the session's
+ * recorded ownerNode against the cluster node registry before touching it.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createMockDb } from '../helpers/db.mock';
+
+const { mockGetDatabase } = vi.hoisted(() => ({ mockGetDatabase: vi.fn() }));
+vi.mock('@/lib/database', () => ({
+  getDatabase: mockGetDatabase,
+  runWithTenantScope: vi.fn(async (_tenantDbName: string, fn: (db: unknown) => unknown) => {
+    const db = await mockGetDatabase();
+    return fn(db);
+  }),
+}));
+
+vi.mock('@/lib/core/cluster', () => ({
+  listClusterNodes: vi.fn(),
+}));
+
+vi.mock('@/lib/services/browser/browserManager', () => ({
+  browserManager: { hasSession: vi.fn().mockReturnValue(false) },
+}));
+
+import { getDatabase } from '@/lib/database';
+import { listClusterNodes } from '@/lib/core/cluster';
+import { browserManager } from '@/lib/services/browser/browserManager';
+import { reconcileOrphanedBrowserSessions } from '@/lib/services/browser/browserOperationsService';
+import type { IBrowserSession, INodeRecord, ITenant } from '@/lib/database';
+
+function mockFn(fn: unknown): ReturnType<typeof vi.fn> {
+  return fn as ReturnType<typeof vi.fn>;
+}
+
+function makeSession(overrides: Partial<IBrowserSession> = {}): IBrowserSession {
+  return {
+    _id: 'sess-1',
+    tenantId: 'tenant-1',
+    browserId: 'browser-1',
+    sessionKey: 'bs_abc',
+    status: 'running',
+    config: {},
+    createdBy: 'user-1',
+    ...overrides,
+  };
+}
+
+function makeNode(name: string): INodeRecord {
+  return {
+    name,
+    role: 'all',
+    status: 'online',
+    startedAt: new Date(),
+  } as INodeRecord;
+}
+
+describe('reconcileOrphanedBrowserSessions — owner-node aware', () => {
+  let db: ReturnType<typeof createMockDb>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    db = createMockDb();
+    db.listTenants.mockResolvedValue([
+      { _id: 'tenant-1', dbName: 'tenant_acme', slug: 'acme' } as unknown as ITenant,
+    ]);
+    mockFn(getDatabase).mockResolvedValue(db);
+    mockFn(browserManager.hasSession).mockReturnValue(false);
+  });
+
+  it('does NOT expire a session whose owner node is still online (the F-06 scenario)', async () => {
+    mockFn(listClusterNodes).mockResolvedValue([makeNode('node-a'), makeNode('node-b')]);
+    db.listBrowserSessions.mockResolvedValue([
+      makeSession({ ownerNode: 'node-a' }), // alive on a DIFFERENT replica than the one reconciling
+    ]);
+
+    const result = await reconcileOrphanedBrowserSessions();
+
+    expect(result.sessionsReconciled).toBe(0);
+    expect(db.updateBrowserSession).not.toHaveBeenCalled();
+  });
+
+  it('expires a session whose owner node is gone', async () => {
+    mockFn(listClusterNodes).mockResolvedValue([makeNode('node-b')]); // node-a is not in the online set
+    db.listBrowserSessions.mockResolvedValue([
+      makeSession({ ownerNode: 'node-a' }),
+    ]);
+
+    const result = await reconcileOrphanedBrowserSessions();
+
+    expect(result.sessionsReconciled).toBe(1);
+    expect(db.updateBrowserSession).toHaveBeenCalledWith('sess-1', expect.objectContaining({ status: 'expired' }));
+  });
+
+  it('still expires a legacy session with no ownerNode recorded (pre-migration row), matching prior behavior', async () => {
+    mockFn(listClusterNodes).mockResolvedValue([makeNode('node-a')]);
+    db.listBrowserSessions.mockResolvedValue([
+      makeSession({ ownerNode: undefined }),
+    ]);
+
+    const result = await reconcileOrphanedBrowserSessions();
+
+    expect(result.sessionsReconciled).toBe(1);
+  });
+
+  it('never touches a session this process already knows about locally', async () => {
+    mockFn(browserManager.hasSession).mockReturnValue(true);
+    mockFn(listClusterNodes).mockResolvedValue([]);
+    db.listBrowserSessions.mockResolvedValue([
+      makeSession({ ownerNode: 'some-other-node' }),
+    ]);
+
+    const result = await reconcileOrphanedBrowserSessions();
+
+    expect(result.sessionsReconciled).toBe(0);
+  });
+});

--- a/src/lib/database/provider/types.domain.ts
+++ b/src/lib/database/provider/types.domain.ts
@@ -2379,6 +2379,15 @@ export interface IBrowserSession extends IUsageAttributionFields {
   /** Raw counters for fast list views. */
   eventCount?: number;
   metadata?: Record<string, unknown>;
+  /**
+   * Name of the cluster node (nodeRegistry.getThisNodeName()) that launched
+   * this session, i.e. the only process whose in-memory browserManager can
+   * actually know this session is alive. Boot reconciliation cross-checks
+   * this against the node registry before expiring an active-status session
+   * — a session is only truly orphaned when its owner node is gone, not
+   * merely unknown to whichever replica happens to be reconciling.
+   */
+  ownerNode?: string;
   createdBy: string;
   updatedBy?: string;
   createdAt?: Date;

--- a/src/lib/database/sqlite/base.ts
+++ b/src/lib/database/sqlite/base.ts
@@ -310,6 +310,12 @@ export class SQLiteProviderBase {
     this.ensureTableColumn(db, TABLES.browsers, 'storageStateEnc', 'storageStateEnc TEXT');
     this.ensureTableColumn(db, TABLES.browsers, 'storageStateMeta', 'storageStateMeta TEXT');
 
+    // Owning cluster node name (see src/lib/core/cluster/nodeRegistry.ts) —
+    // without this, boot reconciliation on any replica could only ask "does
+    // THIS process know about this session", so a session genuinely alive on
+    // another replica looked identical to one truly orphaned by a crash.
+    this.ensureTableColumn(db, TABLES.browserSessions, 'ownerNode', 'ownerNode TEXT');
+
     // Knowledge Engine: richer chunking (offsets, heading path, real token
     // counts) plus the stored source a re-index rebuilds from. CREATE TABLE IF
     // NOT EXISTS never alters an existing tenant DB, so without these the

--- a/src/lib/database/sqlite/browser.mixin.ts
+++ b/src/lib/database/sqlite/browser.mixin.ts
@@ -167,11 +167,11 @@ export function BrowserMixin<TBase extends Constructor<SQLiteProviderBase>>(Base
         (id, tenantId, projectId, browserId, sessionKey, name, agentId, agentKey, status,
          config, currentUrl, pageTitle, lastActivityAt, lastScreenshot, artifactBucketKey,
          startedAt, endedAt, errorMessage, eventCount, metadata, userId, apiTokenId, actorType,
-         createdBy, updatedBy, createdAt, updatedAt)
+         ownerNode, createdBy, updatedBy, createdAt, updatedAt)
         VALUES (@id, @tenantId, @projectId, @browserId, @sessionKey, @name, @agentId, @agentKey, @status,
          @config, @currentUrl, @pageTitle, @lastActivityAt, @lastScreenshot, @artifactBucketKey,
          @startedAt, @endedAt, @errorMessage, @eventCount, @metadata, @userId, @apiTokenId, @actorType,
-         @createdBy, @updatedBy, @createdAt, @updatedAt)
+         @ownerNode, @createdBy, @updatedBy, @createdAt, @updatedAt)
       `).run({
         id,
         tenantId: record.tenantId,
@@ -196,6 +196,7 @@ export function BrowserMixin<TBase extends Constructor<SQLiteProviderBase>>(Base
         userId: record.userId ?? null,
         apiTokenId: record.apiTokenId ?? null,
         actorType: record.actorType ?? null,
+        ownerNode: record.ownerNode ?? null,
         createdBy: record.createdBy,
         updatedBy: record.updatedBy ?? null,
         createdAt: now,
@@ -214,7 +215,7 @@ export function BrowserMixin<TBase extends Constructor<SQLiteProviderBase>>(Base
       const params: Record<string, unknown> = { id, updatedAt: now };
       const stringFields = [
         'sessionKey', 'name', 'agentId', 'agentKey', 'status', 'currentUrl', 'pageTitle',
-        'artifactBucketKey', 'errorMessage', 'updatedBy', 'projectId', 'browserId',
+        'artifactBucketKey', 'errorMessage', 'updatedBy', 'projectId', 'browserId', 'ownerNode',
       ];
       for (const f of stringFields) {
         if ((data as Record<string, unknown>)[f] !== undefined) {
@@ -336,6 +337,7 @@ export function BrowserMixin<TBase extends Constructor<SQLiteProviderBase>>(Base
         userId: (row.userId as string | null) ?? undefined,
         apiTokenId: (row.apiTokenId as string | null) ?? undefined,
         actorType: (row.actorType as IBrowserSession['actorType'] | null) ?? undefined,
+        ownerNode: (row.ownerNode as string | null) ?? undefined,
         createdBy: row.createdBy as string,
         updatedBy: (row.updatedBy as string) ?? undefined,
         createdAt: this.toDate(row.createdAt),

--- a/src/lib/database/sqlite/schema.ts
+++ b/src/lib/database/sqlite/schema.ts
@@ -1876,6 +1876,7 @@ export const TENANT_SCHEMA_SQL = `
     userId TEXT,
     apiTokenId TEXT,
     actorType TEXT,
+    ownerNode TEXT,
     createdBy TEXT NOT NULL,
     updatedBy TEXT,
     createdAt TEXT NOT NULL,

--- a/src/lib/services/browser/browserOperationsService.ts
+++ b/src/lib/services/browser/browserOperationsService.ts
@@ -1,5 +1,6 @@
 import { getDatabase, runWithTenantScope } from '@/lib/database';
 import { createLogger } from '@/lib/core/logger';
+import { listClusterNodes } from '@/lib/core/cluster';
 import { browserManager } from './browserManager';
 
 const logger = createLogger('browser:operations');
@@ -12,6 +13,15 @@ export async function reconcileOrphanedBrowserSessions(): Promise<{
 }> {
   const mainDb = await getDatabase();
   const tenants = await mainDb.listTenants();
+
+  // A session unknown to THIS process's browserManager is not necessarily
+  // dead — it may simply belong to a different, still-live replica. Only a
+  // session whose owner node is itself gone (or was created before this
+  // field existed) is a real orphan. One registry read per sweep, not one
+  // per session.
+  const onlineNodes = new Set(
+    (await listClusterNodes({ status: 'online' })).map((node) => node.name),
+  );
 
   let tenantsScanned = 0;
   let sessionsReconciled = 0;
@@ -28,6 +38,7 @@ export async function reconcileOrphanedBrowserSessions(): Promise<{
         for (const session of sessions) {
           if (!ACTIVE_SESSION_STATUSES.has(session.status)) continue;
           if (browserManager.hasSession(session.sessionKey)) continue;
+          if (session.ownerNode && onlineNodes.has(session.ownerNode)) continue;
 
           await tenantDb.updateBrowserSession(String(session._id), {
             endedAt: new Date(),

--- a/src/lib/services/browser/browserSessionService.ts
+++ b/src/lib/services/browser/browserSessionService.ts
@@ -10,7 +10,7 @@
 import { randomUUID } from 'node:crypto';
 import { createLogger } from '@/lib/core/logger';
 import { getConfig } from '@/lib/core/config';
-import { routeInstanceCall } from '@/lib/core/cluster';
+import { getThisNodeName, routeInstanceCall } from '@/lib/core/cluster';
 import type { QueuePayload } from '@/lib/core/queue';
 import { getDatabase, runWithTenantScope, type DatabaseProvider } from '@/lib/database';
 import { downloadFile, uploadFile } from '@/lib/services/files';
@@ -180,6 +180,11 @@ export async function createBrowserSession(
     eventCount: 0,
     metadata: input.metadata,
     createdBy: input.createdBy,
+    // browserManager.openSession below always runs on whichever node handled
+    // this request (session creation is not itself assignment-routed) — this
+    // is what boot reconciliation checks before treating an unknown session
+    // as orphaned.
+    ownerNode: getThisNodeName(),
   });
 
   const sessionId = created._id ? String(created._id) : '';


### PR DESCRIPTION
## Summary

P1 finding from the 2026-09-05 finance-institution assessment.

`reconcileOrphanedBrowserSessions` decided a session was dead purely on whether THIS process's in-memory `browserManager` knew about it. A replica that just booted knows about none of them, so it marked every active-status session across every tenant "expired" the moment it ran — including sessions genuinely alive on a different, still-running replica. The assessment's isolated check reproduced exactly this: a second node's empty local session map was enough to write another node's live session as expired.

The cluster already has the infrastructure this needed — a node registry with heartbeat + online/offline tracking (`src/lib/core/cluster`). This PR:

- Adds `ownerNode` to `IBrowserSession` (SQLite migration via the existing `ensureTableColumn` mechanism + schema.ts for fresh installs; Mongo needs no schema change).
- Stamps it once, in the single service function all six call sites already funnel through (`browserSessionService.createBrowserSession`) — so no call site had to remember to set it.
- `reconcileOrphanedBrowserSessions` now reads the node registry once per sweep (`listClusterNodes({status:'online'})`) and only expires a session when its owner node is not currently online, or the session predates this field (pre-migration rows keep the exact prior behavior — no regression for the single-node case this already worked correctly for).

## Explicitly out of scope for this PR

`crawlerJobReconciler.ts` has the **exact same bug pattern** (requeues every `running`/`queued` job tenant-wide with no owner/heartbeat check, and can delete partial results) — but job requeue has failure modes session-expiry doesn't (in-flight partial results, retry/idempotency semantics), so it deserves its own review rather than being folded into this diff. Flagging as a direct follow-up using the identical `ownerNode` + node-registry pattern proven here.

## Test plan

- [x] New `browser-operations-reconcile.test.ts`: owner node still online → not touched (the exact F-06 scenario), owner node gone → expired, legacy row with no `ownerNode` → expired (matches prior behavior), session known to local `browserManager` → never touched regardless of registry state
- [x] Manually verified the "owner node still online" test fails against the pre-fix code (reverted the check, confirmed red, restored)
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` clean
- [x] Full `vitest run` (including `db-parity.test.ts`, which exercises the SQLite/Mongo schema in both backends): 5050 passed, 0 failed, 5 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KQq6TnVNHRNU6Wz1eQzPpD