### PR TITLE
fix(security): pin outbound fetch connections to the validated IP (F-11)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -79,6 +79,7 @@
         "recharts": "^3.7.0",
         "remark-gfm": "^4.0.1",
         "slugify": "^1.6.6",
+        "undici": "^6.28.0",
         "winston": "^3.19.0",
         "xls-reader": "^0.7.0",
         "yaml": "^2.8.3"

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "recharts": "^3.7.0",
     "remark-gfm": "^4.0.1",
     "slugify": "^1.6.6",
+    "undici": "^6.28.0",
     "winston": "^3.19.0",
     "xls-reader": "^0.7.0",
     "yaml": "^2.8.3"

--- a/src/__tests__/unit/outbound-fetch-pinning-live.test.ts
+++ b/src/__tests__/unit/outbound-fetch-pinning-live.test.ts
@@ -1,0 +1,101 @@
+/**
+ * The one part of the F-11 pin that unit tests with a mocked `fetch` cannot
+ * prove: that the undici connector contract this code relies on is actually
+ * satisfied by the installed Node/undici at runtime.
+ *
+ * `pinnedDispatcher` hands undici a custom `lookup` that answers with an
+ * ARRAY of `{address, family}` records. If that shape were wrong for this
+ * runtime, every guarded outbound call in the product would fail at connect
+ * time — and no mock-fetch test would ever notice, because a mocked fetch
+ * never reaches the connector. So this test opens a real HTTP server on
+ * loopback and makes a real request through the real dispatcher.
+ *
+ * It does NOT go through `safeFetch` on purpose: `safeFetch` rejects
+ * loopback by design (that is the SSRF guard working), so a live end-to-end
+ * test of it would have to disable the very thing under test. What is
+ * verified here is the connector plumbing; the guard's own decisions are
+ * covered in outbound-fetch.test.ts.
+ */
+import { afterEach, describe, expect, it } from 'vitest';
+import { createServer, type Server } from 'node:http';
+import { Agent, buildConnector } from 'undici';
+import { fetch as undiciFetch } from 'undici';
+
+let server: Server | undefined;
+
+function startServer(): Promise<number> {
+  return new Promise((resolve) => {
+    server = createServer((_req, res) => {
+      res.writeHead(200, { 'content-type': 'text/plain' });
+      res.end('pinned-ok');
+    });
+    server.listen(0, '127.0.0.1', () => {
+      const address = server!.address();
+      resolve(typeof address === 'object' && address ? address.port : 0);
+    });
+  });
+}
+
+afterEach(async () => {
+  await new Promise<void>((resolve) => {
+    if (!server) return resolve();
+    server.close(() => resolve());
+    server = undefined;
+  });
+});
+
+describe('pinned dispatcher — real connection', () => {
+  it('connects to the pinned address even though the URL hostname resolves elsewhere', async () => {
+    const port = await startServer();
+
+    // Mirrors pinnedDispatcher() in outboundFetch.ts exactly, including the
+    // array-shaped lookup callback and the keep-alive settings.
+    const dispatcher = new Agent({
+      connect: buildConnector({
+        lookup: (_hostname, _options, callback) => {
+          callback(null, [{ address: '127.0.0.1', family: 4 }]);
+        },
+      }),
+      keepAliveTimeout: 1,
+      keepAliveMaxTimeout: 1,
+    });
+
+    try {
+      // `example.invalid` can never resolve in DNS (RFC 2606) — reaching the
+      // local server proves the pinned address, not DNS, decided the socket.
+      const response = await undiciFetch(`http://example.invalid:${port}/`, { dispatcher });
+      expect(response.status).toBe(200);
+      expect(await response.text()).toBe('pinned-ok');
+      // The Host header still carries the URL's hostname, which is what keeps
+      // TLS SNI/cert validation honest on the https path.
+    } finally {
+      await dispatcher.destroy();
+    }
+  });
+
+  it('fails over to the second pinned address when the first is unreachable', async () => {
+    const port = await startServer();
+
+    const dispatcher = new Agent({
+      connect: buildConnector({
+        timeout: 1_000,
+        lookup: (_hostname, _options, callback) => {
+          callback(null, [
+            // TEST-NET-1 (RFC 5737): routable-looking, never actually answers.
+            { address: '192.0.2.1', family: 4 },
+            { address: '127.0.0.1', family: 4 },
+          ]);
+        },
+      }),
+      keepAliveTimeout: 1,
+      keepAliveMaxTimeout: 1,
+    });
+
+    try {
+      const response = await undiciFetch(`http://example.invalid:${port}/`, { dispatcher });
+      expect(response.status).toBe(200);
+    } finally {
+      await dispatcher.destroy();
+    }
+  }, 15_000);
+});

--- a/src/__tests__/unit/outbound-fetch.test.ts
+++ b/src/__tests__/unit/outbound-fetch.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { lookup } from 'node:dns/promises';
 import {
   getConfigSource,
   setConfigSource,
@@ -19,6 +20,19 @@ import {
   OutboundNetworkError,
   safeFetch,
 } from '@/lib/security/outboundFetch';
+
+/** Node's global RequestInit type doesn't declare `dispatcher` (undici's addition). */
+type FetchInit = RequestInit & { dispatcher?: unknown };
+
+/** `dns/promises`' overloaded `lookup` type infers the single-address
+ * overload against `vi.mocked(lookup)`; the guard always calls it with
+ * `{ all: true }`, so tests stub the array-returning shape directly. */
+function mockLookupOnce(...results: Array<{ address: string; family: 4 | 6 }[]>): void {
+  const mocked = lookup as unknown as { mockImplementationOnce: (fn: () => Promise<unknown>) => unknown };
+  for (const result of results) {
+    mocked.mockImplementationOnce(async () => result);
+  }
+}
 
 const original = getConfigSource();
 
@@ -136,6 +150,31 @@ describe('safeFetch', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
+  it('pins the connection to the resolved address instead of leaving fetch to re-resolve DNS itself', async () => {
+    const fetchMock = vi.fn(() => new Response('ok', { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+    await safeFetch('https://public.example.com/api');
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect((fetchMock.mock.calls[0] as unknown as [URL, FetchInit?])[1]?.dispatcher).toBeDefined();
+  });
+
+  it('does not attempt to pin a literal-IP URL (nothing to pin)', async () => {
+    const fetchMock = vi.fn(() => new Response('ok', { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+    await safeFetch('https://93.184.216.34/api');
+
+    expect((fetchMock.mock.calls[0] as unknown as [URL, FetchInit?])[1]?.dispatcher).toBeUndefined();
+  });
+
+  it('does not pin when the private-network guard itself was bypassed', async () => {
+    const fetchMock = vi.fn(() => new Response('ok', { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+    await safeFetch('https://internal.corp.example/api', undefined, { allowPrivate: true });
+
+    expect((fetchMock.mock.calls[0] as unknown as [URL, FetchInit?])[1]?.dispatcher).toBeUndefined();
+  });
+
   it('re-validates redirect hops and blocks redirects into private space', async () => {
     const fetchMock = vi.fn(async () => new Response(null, {
       status: 302,
@@ -178,5 +217,44 @@ describe('safeFetch', () => {
     vi.stubGlobal('fetch', fetchMock);
     await expect(safeFetch('https://public.example.com/slow', undefined, { timeoutMs: 20 }))
       .rejects.toThrow();
+  });
+});
+
+// F-11 (finance-institution assessment, 2026-09-05): assertPublicUrl resolved
+// DNS once to decide a hostname was public, then handed the HOSTNAME (not the
+// resolved address) to fetch, which resolves it AGAIN at connect time. An
+// attacker controlling DNS for the target can answer publicly for the check
+// and privately for the connection -- classic TOCTOU / DNS rebinding. Every
+// case below uses its own hostname so the 30s privacy cache from earlier
+// tests in this file can't hide a lookup call these tests need to count.
+describe('DNS rebinding: the address fetch connects to must be the one just checked', () => {
+  it('rejects a target whose SECOND (connection-time) resolution differs and is private, even though the first (policy) resolution was public', async () => {
+    mockLookupOnce(
+      [{ address: '93.184.216.34', family: 4 }], // policy check
+      [{ address: '127.0.0.1', family: 4 }], // rebind at connect time
+    );
+
+    const fetchMock = vi.fn(() => new Response('ok', { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(safeFetch('https://rebind-attack.example.com/api'))
+      .rejects.toThrow(OutboundNetworkError);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('still succeeds when the second resolution legitimately differs but is also public', async () => {
+    mockLookupOnce(
+      [{ address: '93.184.216.34', family: 4 }],
+      [{ address: '203.0.113.9', family: 4 }], // still public, just different
+    );
+
+    const fetchMock = vi.fn(() => new Response('ok', { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const res = await safeFetch('https://rebind-legit.example.com/api');
+
+    expect(res.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect((fetchMock.mock.calls[0] as unknown as [URL, FetchInit?])[1]?.dispatcher).toBeDefined();
   });
 });

--- a/src/lib/security/outboundFetch.ts
+++ b/src/lib/security/outboundFetch.ts
@@ -23,7 +23,7 @@
 
 import { isIP } from 'node:net';
 import { lookup } from 'node:dns/promises';
-import { Agent, buildConnector, type Dispatcher } from 'undici';
+import { Agent, buildConnector } from 'undici';
 
 import { getConfig } from '@/lib/core/config';
 
@@ -167,7 +167,7 @@ export function isAllowlistedHost(host: string, allowedHosts: string[]): boolean
  * addresses that verdict was based on. Cached per the guard's existing TTL —
  * the addresses are cached alongside the verdict, not re-resolved
  * separately, but `assertPublicUrl` always does its own connection-time
- * `dns.lookup()` for the pin (see `resolvePinnedAddress`) rather than trust
+ * `dns.lookup()` for the pin (see `resolvePinnedAddresses`) rather than trust
  * this cache for that: a stale-but-still-public cache entry is fine for the
  * policy question "is this host allowed at all", but pinning specifically
  * exists to close the gap between "resolved" and "connected", which a cache
@@ -212,16 +212,14 @@ async function resolvesToPrivateNetwork(host: string): Promise<{ privateNetwork:
  * address on this fresh lookup (caller re-runs the guard, which will reject
  * it the normal way).
  */
-async function resolvePinnedAddress(host: string): Promise<ResolvedAddress | null> {
+async function resolvePinnedAddresses(host: string): Promise<ResolvedAddress[]> {
   const bare = host.replace(/^\[|\]$/g, '');
-  if (isIP(bare)) return null; // nothing to pin -- the destination already is the address
+  if (isIP(bare)) return []; // nothing to pin -- the destination already is the address
   try {
     const records = await lookup(bare, { all: true, verbatim: true });
-    const first = records[0];
-    if (!first) return null;
-    return { address: first.address, family: first.family as 4 | 6 };
+    return records.map((record) => ({ address: record.address, family: record.family as 4 | 6 }));
   } catch {
-    return null;
+    return [];
   }
 }
 
@@ -230,15 +228,41 @@ async function resolvePinnedAddress(host: string): Promise<ResolvedAddress | nul
  * of what DNS says for the hostname in the request URL. Built fresh per
  * fetch call (never shared/cached) so it can never be reused for an
  * unrelated request.
+ *
+ * ALL validated addresses are handed to the connector, not just the first:
+ * every one of them was checked as public a moment ago, and pinning to a
+ * single record would silently drop the dual-stack failover a normal
+ * `fetch` has — a host whose first DNS answer is an AAAA record this
+ * container cannot route would go from "works" to "always fails".
+ *
+ * Keep-alive is turned down to the minimum because this dispatcher serves
+ * exactly ONE request and is then dropped: undici's default would hold the
+ * socket open for another request that, by construction, never comes — one
+ * leaked file descriptor per outbound call, which a crawl run reaches the
+ * process FD limit with.
  */
-function pinnedDispatcher(pinned: ResolvedAddress): Dispatcher {
+function pinnedDispatcher(pinned: ResolvedAddress[]): Agent {
   return new Agent({
     connect: buildConnector({
-      family: pinned.family,
       lookup: (_hostname, _options, callback) => {
-        callback(null, [{ address: pinned.address, family: pinned.family }]);
+        callback(null, pinned.map(({ address, family }) => ({ address, family })));
       },
     }),
+    keepAliveTimeout: 1,
+    keepAliveMaxTimeout: 1,
+  });
+}
+
+/**
+ * Close a per-request dispatcher once nothing will read from it again.
+ * `destroy()` (not `close()`) because a redirect hop's response body is
+ * deliberately abandoned unread — `close()` waits for in-flight requests to
+ * drain, which for an unread body means waiting forever.
+ */
+function discardDispatcher(dispatcher: Agent | undefined): void {
+  if (!dispatcher) return;
+  void dispatcher.destroy().catch(() => {
+    /* the socket is going away regardless; nothing to recover here */
   });
 }
 
@@ -276,7 +300,7 @@ export async function assertPublicUrl(rawUrl: string, options?: OutboundGuardOpt
 async function checkPublicUrl(
   rawUrl: string,
   options?: OutboundGuardOptions,
-): Promise<{ url: URL; pinned: ResolvedAddress | null }> {
+): Promise<{ url: URL; pinned: ResolvedAddress[] }> {
   let url: URL;
   try {
     url = new URL(rawUrl);
@@ -290,8 +314,8 @@ async function checkPublicUrl(
 
   if (!options?.forceBlock) {
     const { blockPrivateNetwork, allowedHosts } = getConfig().outboundHttp;
-    if (!blockPrivateNetwork || options?.allowPrivate) return { url, pinned: null };
-    if (isAllowlistedHost(url.hostname, allowedHosts)) return { url, pinned: null };
+    if (!blockPrivateNetwork || options?.allowPrivate) return { url, pinned: [] };
+    if (isAllowlistedHost(url.hostname, allowedHosts)) return { url, pinned: [] };
   }
 
   const { privateNetwork } = await resolvesToPrivateNetwork(url.hostname);
@@ -301,11 +325,14 @@ async function checkPublicUrl(
     );
   }
 
-  // Fresh, connection-time resolution for the pin (see resolvePinnedAddress)
+  // Fresh, connection-time resolution for the pin (see resolvePinnedAddresses)
   // -- re-checked for privacy in case DNS answers differently on this second
-  // lookup than it did a moment ago on the cached/policy one above.
-  const pinned = await resolvePinnedAddress(url.hostname);
-  if (pinned && isPrivateIpAddress(pinned.address)) {
+  // lookup than it did a moment ago on the cached/policy one above. EVERY
+  // returned address must be public: handing the connector a list where only
+  // the first was checked would let a second, private record be the one it
+  // actually connects to.
+  const pinned = await resolvePinnedAddresses(url.hostname);
+  if (pinned.some((record) => isPrivateIpAddress(record.address))) {
     throw new OutboundNetworkError(
       `Refusing outbound request to private/loopback host: ${url.hostname}`,
     );
@@ -363,27 +390,49 @@ export async function safeFetch(
     else externalSignal.addEventListener('abort', onExternalAbort, { once: true });
   }
 
+  // The dispatcher belonging to the response this function ultimately
+  // RETURNS must outlive the call: the caller has not read the body yet.
+  // Every other one (each redirect hop, and any hop that threw) is finished
+  // the moment we stop using it, and is destroyed below.
+  let liveDispatcher: Agent | undefined;
+
   try {
     let currentUrl = rawUrl;
     for (let hop = 0; hop <= MAX_REDIRECTS; hop += 1) {
       const { url, pinned } = await checkPublicUrl(currentUrl, options);
-      const response = await fetch(url, {
-        ...init,
-        signal: controller.signal,
-        redirect: 'manual',
-        // Pins the socket to the exact address just validated instead of
-        // letting undici re-resolve DNS itself at connect time -- otherwise
-        // an attacker controlling DNS for this host can answer differently
-        // between the check above and the connection below (TOCTOU / DNS
-        // rebinding). Absent (plain fetch) when there was nothing to pin:
-        // a literal-IP URL, or the private-network guard was bypassed
-        // (allowlisted host / allowPrivate / blocking disabled).
-        ...(pinned ? { dispatcher: pinnedDispatcher(pinned) } : {}),
-      } as RequestInit);
+      // Pins the socket to the exact addresses just validated instead of
+      // letting undici re-resolve DNS itself at connect time -- otherwise
+      // an attacker controlling DNS for this host can answer differently
+      // between the check above and the connection below (TOCTOU / DNS
+      // rebinding). Absent (plain fetch) when there was nothing to pin:
+      // a literal-IP URL, or the private-network guard was bypassed
+      // (allowlisted host / allowPrivate / blocking disabled).
+      const dispatcher = pinned.length > 0 ? pinnedDispatcher(pinned) : undefined;
+      discardDispatcher(liveDispatcher); // previous hop's, now unread
+      liveDispatcher = dispatcher;
+
+      let response: Response;
+      try {
+        response = await fetch(url, {
+          ...init,
+          signal: controller.signal,
+          redirect: 'manual',
+          ...(dispatcher ? { dispatcher } : {}),
+        } as RequestInit);
+      } catch (error) {
+        discardDispatcher(dispatcher);
+        liveDispatcher = undefined;
+        throw error;
+      }
 
       if (response.status >= 300 && response.status < 400) {
         const location = response.headers.get('location');
-        if (!location) return response;
+        if (!location) {
+          // Returned to the caller as-is: its body is theirs to read, so the
+          // dispatcher stays alive with it.
+          liveDispatcher = undefined;
+          return response;
+        }
         if (hop === MAX_REDIRECTS) {
           throw new OutboundNetworkError(`Too many redirects fetching ${rawUrl}`);
         }
@@ -402,11 +451,16 @@ export async function safeFetch(
         continue;
       }
 
+      liveDispatcher = undefined; // handed to the caller together with the body
       return response;
     }
     throw new OutboundNetworkError(`Too many redirects fetching ${rawUrl}`);
   } finally {
     clearTimeout(timer);
     externalSignal?.removeEventListener('abort', onExternalAbort);
+    // Anything still held here belongs to a hop nobody will read (the redirect
+    // cap threw, or the loop fell through) -- releasing it is what keeps a
+    // redirect chain from leaking one socket per hop.
+    discardDispatcher(liveDispatcher);
   }
 }

--- a/src/lib/security/outboundFetch.ts
+++ b/src/lib/security/outboundFetch.ts
@@ -23,13 +23,19 @@
 
 import { isIP } from 'node:net';
 import { lookup } from 'node:dns/promises';
+import { Agent, buildConnector, type Dispatcher } from 'undici';
 
 import { getConfig } from '@/lib/core/config';
 
 const HOST_CACHE_TTL_MS = 30_000;
 const MAX_REDIRECTS = 5;
 
-const hostPrivacyCache = new Map<string, { privateNetwork: boolean; expiresAt: number }>();
+interface ResolvedAddress {
+  address: string;
+  family: 4 | 6;
+}
+
+const hostPrivacyCache = new Map<string, { privateNetwork: boolean; addresses: ResolvedAddress[]; expiresAt: number }>();
 
 export class OutboundNetworkError extends Error {
   constructor(message: string) {
@@ -156,25 +162,84 @@ export function isAllowlistedHost(host: string, allowedHosts: string[]): boolean
   });
 }
 
-async function resolvesToPrivateNetwork(host: string): Promise<boolean> {
+/**
+ * Resolves a hostname and reports both the private/public verdict and the
+ * addresses that verdict was based on. Cached per the guard's existing TTL —
+ * the addresses are cached alongside the verdict, not re-resolved
+ * separately, but `assertPublicUrl` always does its own connection-time
+ * `dns.lookup()` for the pin (see `resolvePinnedAddress`) rather than trust
+ * this cache for that: a stale-but-still-public cache entry is fine for the
+ * policy question "is this host allowed at all", but pinning specifically
+ * exists to close the gap between "resolved" and "connected", which a cache
+ * up to 30s old would reopen.
+ */
+async function resolvesToPrivateNetwork(host: string): Promise<{ privateNetwork: boolean; addresses: ResolvedAddress[] }> {
   const bare = host.replace(/^\[|\]$/g, '');
-  if (isLocalHostname(bare)) return true;
-  if (isIP(bare)) return isPrivateIpAddress(bare);
+  if (isLocalHostname(bare)) return { privateNetwork: true, addresses: [] };
+  if (isIP(bare)) {
+    const family = isIP(bare) as 4 | 6;
+    return { privateNetwork: isPrivateIpAddress(bare), addresses: [{ address: bare, family }] };
+  }
 
   const cached = hostPrivacyCache.get(bare);
-  if (cached && cached.expiresAt > Date.now()) return cached.privateNetwork;
+  if (cached && cached.expiresAt > Date.now()) {
+    return { privateNetwork: cached.privateNetwork, addresses: cached.addresses };
+  }
 
   let privateNetwork = true;
+  let addresses: ResolvedAddress[] = [];
   try {
     const records = await lookup(bare, { all: true, verbatim: true });
+    addresses = records.map((r) => ({ address: r.address, family: r.family as 4 | 6 }));
     privateNetwork = records.length === 0
       || records.some((record) => isPrivateIpAddress(record.address));
   } catch {
     privateNetwork = true;
   }
 
-  hostPrivacyCache.set(bare, { privateNetwork, expiresAt: Date.now() + HOST_CACHE_TTL_MS });
-  return privateNetwork;
+  hostPrivacyCache.set(bare, { privateNetwork, addresses, expiresAt: Date.now() + HOST_CACHE_TTL_MS });
+  return { privateNetwork, addresses };
+}
+
+/**
+ * Connection-time resolution used to pin the socket `fetch` opens to the
+ * exact address the SSRF guard just validated. Deliberately NOT the cached
+ * lookup above: this runs immediately before the connection it protects, so
+ * an attacker controlling DNS cannot answer differently between "checked"
+ * and "connected" — there is no gap left to rebind into. Returns null for a
+ * hostname that fails to resolve here (the caller falls back to plain
+ * `fetch`, which will fail with its own DNS error) or resolves to a private
+ * address on this fresh lookup (caller re-runs the guard, which will reject
+ * it the normal way).
+ */
+async function resolvePinnedAddress(host: string): Promise<ResolvedAddress | null> {
+  const bare = host.replace(/^\[|\]$/g, '');
+  if (isIP(bare)) return null; // nothing to pin -- the destination already is the address
+  try {
+    const records = await lookup(bare, { all: true, verbatim: true });
+    const first = records[0];
+    if (!first) return null;
+    return { address: first.address, family: first.family as 4 | 6 };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * An undici dispatcher whose connector resolves ONLY to `pinned`, regardless
+ * of what DNS says for the hostname in the request URL. Built fresh per
+ * fetch call (never shared/cached) so it can never be reused for an
+ * unrelated request.
+ */
+function pinnedDispatcher(pinned: ResolvedAddress): Dispatcher {
+  return new Agent({
+    connect: buildConnector({
+      family: pinned.family,
+      lookup: (_hostname, _options, callback) => {
+        callback(null, [{ address: pinned.address, family: pinned.family }]);
+      },
+    }),
+  });
 }
 
 export interface OutboundGuardOptions {
@@ -199,6 +264,19 @@ export interface OutboundGuardOptions {
  * DNS-resolves hostnames, so names pointing at private IPs are also rejected.
  */
 export async function assertPublicUrl(rawUrl: string, options?: OutboundGuardOptions): Promise<URL> {
+  return (await checkPublicUrl(rawUrl, options)).url;
+}
+
+/**
+ * Same validation as `assertPublicUrl`, plus the address that validation
+ * decided was public — used by `safeFetch` to pin the actual connection to
+ * it. Kept separate from `assertPublicUrl` so callers that only need the
+ * policy check (e.g. the tool-access guardrail) are unaffected.
+ */
+async function checkPublicUrl(
+  rawUrl: string,
+  options?: OutboundGuardOptions,
+): Promise<{ url: URL; pinned: ResolvedAddress | null }> {
   let url: URL;
   try {
     url = new URL(rawUrl);
@@ -212,16 +290,27 @@ export async function assertPublicUrl(rawUrl: string, options?: OutboundGuardOpt
 
   if (!options?.forceBlock) {
     const { blockPrivateNetwork, allowedHosts } = getConfig().outboundHttp;
-    if (!blockPrivateNetwork || options?.allowPrivate) return url;
-    if (isAllowlistedHost(url.hostname, allowedHosts)) return url;
+    if (!blockPrivateNetwork || options?.allowPrivate) return { url, pinned: null };
+    if (isAllowlistedHost(url.hostname, allowedHosts)) return { url, pinned: null };
   }
 
-  if (await resolvesToPrivateNetwork(url.hostname)) {
+  const { privateNetwork } = await resolvesToPrivateNetwork(url.hostname);
+  if (privateNetwork) {
     throw new OutboundNetworkError(
       `Refusing outbound request to private/loopback host: ${url.hostname}`,
     );
   }
-  return url;
+
+  // Fresh, connection-time resolution for the pin (see resolvePinnedAddress)
+  // -- re-checked for privacy in case DNS answers differently on this second
+  // lookup than it did a moment ago on the cached/policy one above.
+  const pinned = await resolvePinnedAddress(url.hostname);
+  if (pinned && isPrivateIpAddress(pinned.address)) {
+    throw new OutboundNetworkError(
+      `Refusing outbound request to private/loopback host: ${url.hostname}`,
+    );
+  }
+  return { url, pinned };
 }
 
 export interface SafeFetchOptions extends OutboundGuardOptions {
@@ -277,12 +366,20 @@ export async function safeFetch(
   try {
     let currentUrl = rawUrl;
     for (let hop = 0; hop <= MAX_REDIRECTS; hop += 1) {
-      const url = await assertPublicUrl(currentUrl, options);
+      const { url, pinned } = await checkPublicUrl(currentUrl, options);
       const response = await fetch(url, {
         ...init,
         signal: controller.signal,
         redirect: 'manual',
-      });
+        // Pins the socket to the exact address just validated instead of
+        // letting undici re-resolve DNS itself at connect time -- otherwise
+        // an attacker controlling DNS for this host can answer differently
+        // between the check above and the connection below (TOCTOU / DNS
+        // rebinding). Absent (plain fetch) when there was nothing to pin:
+        // a literal-IP URL, or the private-network guard was bypassed
+        // (allowlisted host / allowPrivate / blocking disabled).
+        ...(pinned ? { dispatcher: pinnedDispatcher(pinned) } : {}),
+      } as RequestInit);
 
       if (response.status >= 300 && response.status < 400) {
         const location = response.headers.get('location');


### PR DESCRIPTION
## Summary

P1 finding from the 2026-09-05 finance-institution assessment.

`assertPublicUrl` resolved DNS once to decide a hostname was public, then handed the **hostname** (not the resolved address) to `fetch`, which resolves it again, independently, at connect time. An attacker controlling DNS for the target can answer publicly for the policy check and privately for the actual connection — classic TOCTOU / DNS rebinding — and nothing between those two lookups closed the gap.

`safeFetch` now:
1. Does a second, connection-time DNS resolution immediately before each `fetch` call (not reused from the 30s policy cache — freshness is the whole point).
2. Re-validates *that* result for privacy too, in case the two lookups already disagree.
3. Pins the actual socket to that exact address via an `undici.Agent` with a custom connector, so whatever `fetch`'s own internal resolution would have produced is never consulted — the connection goes to the address this guard just checked, not to whatever DNS answers a moment later.

Applies per redirect hop, since `safeFetch` already re-validates every hop the same way.

`undici` was already an installed transitive dependency (several other packages pull it in) — promoted to a direct dependency since the app now imports it explicitly for this.

No pin is attempted for a literal-IP URL (nothing to resolve) or when the private-network guard itself was bypassed (allowlisted host, `allowPrivate`, or blocking disabled globally) — those paths weren't making an "is this the address I checked" promise to begin with.

## Test plan

- [x] New tests: a dispatcher is attached for a resolved hostname, absent for a literal IP, absent when the guard is bypassed
- [x] **The core regression test**: mocked DNS returns a public address on the first (policy) lookup and a private address on the second (connection-time) lookup — `safeFetch` now rejects it (proven to fail against the pre-fix code: reverted the re-check, confirmed red, restored)
- [x] A companion test confirms a *legitimately* different-but-still-public second answer still succeeds (not just "always reject a second lookup")
- [x] All 20 pre-existing `outbound-fetch.test.ts` + `guardrail-fix2-outbound-redirect-ssrf.test.ts` tests still pass unmodified
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` clean (0 errors, 0 warnings on changed files)
- [x] Full `vitest run`: 5051 passed, 0 failed, 5 skipped
- [x] Manually verified the pinning mechanism against a real local HTTP server before wiring it into the guard (a hostname that does not resolve to it in real DNS, pinned via a custom connector, actually reached it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KQq6TnVNHRNU6Wz1eQzPpD