### PR TITLE
fix(auth): JWT expiry parsing + token-delete cache invalidation (F-08)

### DIFF
--- a/src/__tests__/api/tokens-delete-cache-invalidation.test.ts
+++ b/src/__tests__/api/tokens-delete-cache-invalidation.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Regression test for F-08 (finance-institution assessment, 2026-09-05):
+ * the API-token auth cache (requireApiTokenFromHeader, 60s TTL) had no
+ * invalidation path on delete -- a deleted token stayed valid on every
+ * replica for up to the cache's own TTL after the delete already succeeded.
+ * DELETE /tokens/:id now looks up the deleted token's stored hash and
+ * evicts the same cache entry the auth check would have hit.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockDb = vi.hoisted(() => ({
+  listApiTokens: vi.fn(),
+  listProjectApiTokens: vi.fn(),
+  deleteApiToken: vi.fn(),
+  deleteProjectApiToken: vi.fn(),
+}));
+
+const mockCacheDel = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/database', () => ({
+  getDatabase: vi.fn().mockResolvedValue(mockDb),
+}));
+
+vi.mock('@/lib/core/cache', () => ({
+  getCache: vi.fn().mockResolvedValue({ del: mockCacheDel, get: vi.fn(), set: vi.fn() }),
+}));
+
+vi.mock('@/lib/security/rbac', () => ({
+  getPermissionServiceForPath: vi.fn().mockReturnValue(null),
+  authorizeServiceRequest: vi.fn().mockReturnValue({ allowed: true }),
+}));
+
+vi.mock('@/lib/services/projects/projectContext', () => ({
+  resolveProjectContext: vi.fn(),
+  ProjectContextError: class ProjectContextError extends Error {
+    status: number;
+    constructor(msg: string, status: number) {
+      super(msg);
+      this.status = status;
+    }
+  },
+}));
+
+import { resolveProjectContext } from '@/lib/services/projects/projectContext';
+import { apiAuthCacheKey } from '@/lib/services/apiTokenAuth';
+import { tokensApiPlugin } from '@/server/api/plugins/tokens';
+import { createFastifyApiTestApp } from '../helpers/fastify-api';
+
+const SESSION_HEADERS = {
+  'x-tenant-db-name': 'tenant_acme',
+  'x-tenant-id': 'tenant-1',
+  'x-tenant-slug': 'acme',
+  'x-user-email': 'owner@acme.test',
+  'x-user-id': 'user-1',
+  'x-user-role': 'owner',
+  'x-license-type': 'enterprise',
+};
+
+function mockFn(fn: unknown): ReturnType<typeof vi.fn> {
+  return fn as ReturnType<typeof vi.fn>;
+}
+
+async function buildApp() {
+  return createFastifyApiTestApp(tokensApiPlugin);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockFn(resolveProjectContext).mockResolvedValue({ projectId: 'proj-1' });
+});
+
+describe('DELETE /api/tokens/:id — invalidates the auth cache entry', () => {
+  it('evicts the cache entry for the deleted project-scoped token (admin/owner path)', async () => {
+    mockDb.listProjectApiTokens.mockResolvedValue([
+      { _id: 'token-1', tenantId: 'tenant-1', projectId: 'proj-1', tokenHash: 'a'.repeat(64) },
+    ]);
+    mockDb.deleteProjectApiToken.mockResolvedValue(true);
+
+    const app = await buildApp();
+    const res = await app.inject({
+      method: 'DELETE',
+      url: '/api/tokens/token-1',
+      headers: SESSION_HEADERS,
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(mockCacheDel).toHaveBeenCalledWith(apiAuthCacheKey('a'.repeat(64)));
+  });
+
+  it('evicts the cache entry for a self-owned token (user path)', async () => {
+    mockDb.listApiTokens.mockResolvedValue([
+      { _id: 'token-2', tenantId: 'tenant-1', projectId: 'proj-1', tokenHash: 'b'.repeat(64) },
+    ]);
+    mockDb.deleteApiToken.mockResolvedValue(true);
+
+    const app = await buildApp();
+    const res = await app.inject({
+      method: 'DELETE',
+      url: '/api/tokens/token-2',
+      headers: { ...SESSION_HEADERS, 'x-user-role': 'user' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(mockCacheDel).toHaveBeenCalledWith(apiAuthCacheKey('b'.repeat(64)));
+  });
+
+  it('does not touch the cache when the delete target was not found', async () => {
+    mockDb.listProjectApiTokens.mockResolvedValue([]);
+    mockDb.deleteProjectApiToken.mockResolvedValue(false);
+
+    const app = await buildApp();
+    const res = await app.inject({
+      method: 'DELETE',
+      url: '/api/tokens/does-not-exist',
+      headers: SESSION_HEADERS,
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(mockCacheDel).not.toHaveBeenCalled();
+  });
+
+  it('still deletes successfully even if the cache eviction itself fails (best-effort)', async () => {
+    mockDb.listProjectApiTokens.mockResolvedValue([
+      { _id: 'token-3', tenantId: 'tenant-1', projectId: 'proj-1', tokenHash: 'c'.repeat(64) },
+    ]);
+    mockDb.deleteProjectApiToken.mockResolvedValue(true);
+    mockCacheDel.mockRejectedValueOnce(new Error('cache unavailable'));
+
+    const app = await buildApp();
+    const res = await app.inject({
+      method: 'DELETE',
+      url: '/api/tokens/token-3',
+      headers: SESSION_HEADERS,
+    });
+
+    expect(res.statusCode).toBe(200);
+  });
+});

--- a/src/__tests__/unit/token-manager-expiry.test.ts
+++ b/src/__tests__/unit/token-manager-expiry.test.ts
@@ -6,7 +6,7 @@
  * it by.
  */
 import { describe, it, expect, afterEach } from 'vitest';
-import { getConfigSource, setConfigSource, type ConfigSource } from '@/lib/core/config';
+import { getConfigSource, isParsableJwtDuration, setConfigSource, type ConfigSource } from '@/lib/core/config';
 import { TokenManager } from '@/lib/license/token-manager';
 import type { LicenseType } from '@/lib/license/license-manager';
 
@@ -58,5 +58,19 @@ describe('TokenManager.generateToken — JWT_EXPIRES_IN parsing', () => {
   it('fails loudly instead of silently issuing a 7-day token for an unparseable value', async () => {
     setConfigSource(sourceWith({ JWT_EXPIRES_IN: 'seven days please' }));
     await expect(TokenManager.generateToken(BASE_PAYLOAD)).rejects.toThrow();
+  });
+});
+
+describe('JWT_EXPIRES_IN config validation (F-08 follow-up)', () => {
+  it('accepts every duration shape jose understands, plus bare seconds', () => {
+    for (const value of ['7d', '12h', '30m', '45s', '2 weeks', '1 year', '604800', '0']) {
+      expect(isParsableJwtDuration(value)).toBe(true);
+    }
+  });
+
+  it('rejects what would otherwise fail at first login instead of at boot', () => {
+    for (const value of ['', '   ', 'forever', '7 fortnights', 'd7', '7dd']) {
+      expect(isParsableJwtDuration(value)).toBe(false);
+    }
   });
 });

--- a/src/__tests__/unit/token-manager-expiry.test.ts
+++ b/src/__tests__/unit/token-manager-expiry.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Regression test for F-08 (finance-institution assessment, 2026-09-05):
+ * TokenManager.generateToken hardcoded a {'1d','7d','30d'} lookup and fell
+ * back to 7 days for anything else -- an operator setting JWT_EXPIRES_IN to
+ * e.g. "12h" silently got a week-long token instead, with nothing to notice
+ * it by.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { getConfigSource, setConfigSource, type ConfigSource } from '@/lib/core/config';
+import { TokenManager } from '@/lib/license/token-manager';
+import type { LicenseType } from '@/lib/license/license-manager';
+
+const original = getConfigSource();
+
+function sourceWith(overrides: Record<string, string>): ConfigSource {
+  return {
+    get: (key: string) => overrides[key] ?? process.env[key],
+  } as ConfigSource;
+}
+
+afterEach(() => {
+  setConfigSource(original);
+});
+
+const BASE_PAYLOAD = {
+  userId: 'user-1',
+  email: 'a@b.com',
+  tenantId: 'tenant-1',
+  tenantSlug: 'acme',
+  tenantDbName: 'tenant_acme',
+  role: 'user' as const,
+  licenseId: 'lic-1',
+  licenseType: 'community' as LicenseType,
+  features: [],
+};
+
+async function issueAndGetLifetimeSeconds(jwtExpiresIn: string): Promise<number> {
+  setConfigSource(sourceWith({ JWT_EXPIRES_IN: jwtExpiresIn }));
+  const token = await TokenManager.generateToken(BASE_PAYLOAD);
+  const decoded = TokenManager.decodeToken(token);
+  if (!decoded?.exp || !decoded.iat) throw new Error('token missing exp/iat');
+  return decoded.exp - decoded.iat;
+}
+
+describe('TokenManager.generateToken — JWT_EXPIRES_IN parsing', () => {
+  it('still issues exactly 1/7/30 days for the previously hardcoded values', async () => {
+    expect(await issueAndGetLifetimeSeconds('1d')).toBe(86400);
+    expect(await issueAndGetLifetimeSeconds('7d')).toBe(604800);
+    expect(await issueAndGetLifetimeSeconds('30d')).toBe(2592000);
+  });
+
+  it('honours a value the old hardcoded map did not know, instead of silently defaulting to 7 days', async () => {
+    expect(await issueAndGetLifetimeSeconds('12h')).toBe(12 * 3600);
+    expect(await issueAndGetLifetimeSeconds('45m')).toBe(45 * 60);
+    expect(await issueAndGetLifetimeSeconds('2w')).toBe(2 * 7 * 86400);
+  });
+
+  it('fails loudly instead of silently issuing a 7-day token for an unparseable value', async () => {
+    setConfigSource(sourceWith({ JWT_EXPIRES_IN: 'seven days please' }));
+    await expect(TokenManager.generateToken(BASE_PAYLOAD)).rejects.toThrow();
+  });
+});

--- a/src/lib/core/config.ts
+++ b/src/lib/core/config.ts
@@ -545,6 +545,23 @@ export interface ConfigValidationError {
  * Validate critical config values.  Returns an array of problems.
  * An empty array means the config is valid.
  */
+/**
+ * Mirrors jose's own `secs()` duration grammar (the parser `SignJWT
+ * .setExpirationTime` runs on a string), plus a bare number of seconds,
+ * which jose accepts only as an actual number — so `JWT_EXPIRES_IN=604800`,
+ * a perfectly reasonable thing for an operator to write, stays valid.
+ * `token-manager.ts` normalizes it the same way.
+ */
+const JWT_DURATION_RE =
+  /^(\d+|\d+\.\d+) ?(seconds?|secs?|s|minutes?|mins?|m|hours?|hrs?|h|days?|d|weeks?|w|years?|yrs?|y)$/i;
+
+export function isParsableJwtDuration(value: string): boolean {
+  const trimmed = value.trim();
+  if (trimmed.length === 0) return false;
+  if (/^\d+$/.test(trimmed)) return true; // bare seconds
+  return JWT_DURATION_RE.test(trimmed);
+}
+
 export function validateConfig(cfg: AppConfig): ConfigValidationError[] {
   const errors: ConfigValidationError[] = [];
 
@@ -557,6 +574,19 @@ export function validateConfig(cfg: AppConfig): ConfigValidationError[] {
     errors.push({
       key: 'JWT_SECRET',
       message: 'JWT_SECRET must be at least 32 characters (use a high-entropy random value)',
+    });
+  }
+  // Checked at BOOT, not at first login: `generateToken` hands this string
+  // straight to jose's duration parser now (it used to silently coerce
+  // anything unrecognised to 7 days), so an unparseable value would
+  // otherwise surface as every login failing at runtime rather than as a
+  // config error the operator sees while starting the process.
+  if (!isParsableJwtDuration(cfg.auth.jwtExpiresIn)) {
+    errors.push({
+      key: 'JWT_EXPIRES_IN',
+      message:
+        `JWT_EXPIRES_IN="${cfg.auth.jwtExpiresIn}" is not a duration this build can parse. `
+        + 'Use a number of seconds ("604800") or a value with a unit ("30m", "12h", "7d", "2 weeks").',
     });
   }
   if (!cfg.auth.providerEncryptionSecret) {

--- a/src/lib/license/token-manager.ts
+++ b/src/lib/license/token-manager.ts
@@ -42,13 +42,21 @@ export class TokenManager {
     // already understands anything JWT_EXPIRES_IN could reasonably be set
     // to. The previous hardcoded {'1d','7d','30d'} map silently fell back to
     // 7 days for any other value -- an operator setting e.g. "12h" got a
-    // week-long token instead, with no error to notice it by. An operator
-    // who sets something jose truly cannot parse now gets a loud failure
-    // here (every login fails, visibly) instead of a silent, wrong duration.
+    // week-long token instead, with no error to notice it by.
+    //
+    // One shape jose only accepts as a NUMBER is a bare count of seconds, so
+    // `JWT_EXPIRES_IN=604800` is converted rather than rejected. Anything
+    // jose still cannot parse has already failed `validateConfig`'s
+    // JWT_EXPIRES_IN check at boot (production refuses to start), so this
+    // cannot become a surprise at first login.
+    const expiration: string | number = /^\d+$/.test(expiresIn.trim())
+      ? Number.parseInt(expiresIn.trim(), 10)
+      : expiresIn;
+
     const token = await new SignJWT(payload as Record<string, unknown>)
       .setProtectedHeader({ alg: 'HS256' })
       .setIssuedAt()
-      .setExpirationTime(expiresIn)
+      .setExpirationTime(expiration)
       .sign(this.getSecretKey());
 
     return token;

--- a/src/lib/license/token-manager.ts
+++ b/src/lib/license/token-manager.ts
@@ -37,18 +37,18 @@ export class TokenManager {
   ): Promise<string> {
     const expiresIn = getConfig().auth.jwtExpiresIn;
 
-    // Convert expiry string to seconds (7d -> 604800)
-    const expiryMap: Record<string, number> = {
-      '1d': 86400,
-      '7d': 604800,
-      '30d': 2592000,
-    };
-    const expirySeconds = expiryMap[expiresIn] || 604800;
-
+    // jose's own duration parser (used here as an untyped string, exactly
+    // the format it documents: "10 minutes", "12h", "7d", "2 weeks", ...)
+    // already understands anything JWT_EXPIRES_IN could reasonably be set
+    // to. The previous hardcoded {'1d','7d','30d'} map silently fell back to
+    // 7 days for any other value -- an operator setting e.g. "12h" got a
+    // week-long token instead, with no error to notice it by. An operator
+    // who sets something jose truly cannot parse now gets a loud failure
+    // here (every login fails, visibly) instead of a silent, wrong duration.
     const token = await new SignJWT(payload as Record<string, unknown>)
       .setProtectedHeader({ alg: 'HS256' })
       .setIssuedAt()
-      .setExpirationTime(Math.floor(Date.now() / 1000) + expirySeconds)
+      .setExpirationTime(expiresIn)
       .sign(this.getSecretKey());
 
     return token;

--- a/src/lib/services/apiTokenAuth.ts
+++ b/src/lib/services/apiTokenAuth.ts
@@ -36,6 +36,16 @@ export interface ApiTokenRequestLike {
   };
 }
 
+/**
+ * The auth-cache key for a given token hash. Exported so the token-delete
+ * path can invalidate the exact same entry `requireApiTokenFromHeader`
+ * writes — without this, a deleted token stayed valid on every replica for
+ * up to the cache's own TTL after the delete succeeded.
+ */
+export function apiAuthCacheKey(tokenHash: string): string {
+  return `api-auth:${tokenHash.substring(0, 16)}`;
+}
+
 export async function requireApiTokenFromHeader(
   authHeader: string | null | undefined,
 ): Promise<ApiTokenContext> {
@@ -55,7 +65,7 @@ export async function requireApiTokenFromHeader(
 
   // Cache tokenRecord + tenant to avoid 2 DB lookups per request
   const tokenHash = hashApiToken(token);
-  const cacheKey = `api-auth:${tokenHash.substring(0, 16)}`;
+  const cacheKey = apiAuthCacheKey(tokenHash);
 
   interface CachedAuth { tokenRecord: IApiToken; tenant: ITenant }
   let cached: CachedAuth | undefined;

--- a/src/server/api/plugins/tokens.ts
+++ b/src/server/api/plugins/tokens.ts
@@ -2,7 +2,10 @@ import type { FastifyPluginAsync } from 'fastify';
 import { getDatabase } from '@/lib/database';
 import type { IUser } from '@/lib/database';
 import type { LicenseType } from '@/lib/license/license-manager';
+import { getCache } from '@/lib/core/cache';
+import { createLogger } from '@/lib/core/logger';
 import { checkResourceQuota } from '@/lib/quota/quotaGuard';
+import { apiAuthCacheKey } from '@/lib/services/apiTokenAuth';
 import { createApiTokenSecret, getApiTokenPrefix, hashApiToken } from '@/lib/services/apiTokens/tokenHashing';
 import {
   getEffectiveServicePermission,
@@ -23,6 +26,26 @@ import {
 } from '../fastify-utils';
 
 const ALLOWED_ROLES = new Set(['owner', 'admin', 'project_admin', 'user']);
+const logger = createLogger('api:tokens');
+
+/**
+ * Best-effort invalidation of the auth cache entry a deleted token may still
+ * hold. Without this, `requireApiTokenFromHeader` kept accepting the token
+ * on every replica for up to its own cache TTL after the delete already
+ * succeeded -- deletion looked immediate in the UI but was not immediate in
+ * effect. Never blocks the delete response on a cache failure: the token row
+ * is already gone either way, and the cache entry expires on its own TTL as
+ * a fallback.
+ */
+async function invalidateApiTokenAuthCache(tokenHash: string | undefined): Promise<void> {
+  if (!tokenHash) return;
+  try {
+    const cache = await getCache();
+    await cache.del(apiAuthCacheKey(tokenHash));
+  } catch (error) {
+    logger.warn('Failed to invalidate api-auth cache on token delete', { error });
+  }
+}
 
 /**
  * Whether `actorRole` may act on (mint for, or list the tokens of) `target`.
@@ -280,26 +303,32 @@ export const tokensApiPlugin: FastifyPluginAsync = async (app) => {
       const { projectId } = await requireProjectContextForRequest(request);
       const db = await getDatabase();
 
-      const deleted = session.userRole === 'user'
-        ? await (async () => {
-          const ownTokens = await db.listApiTokens(session.userId);
-          const token = ownTokens.find((item) => String(item._id) === String(id));
-          if (!token) {
-            return false;
-          }
-          if (
-            String(token.tenantId) !== String(session.tenantId)
-            || String(token.projectId) !== String(projectId)
-          ) {
-            return false;
-          }
-          return db.deleteApiToken(id, session.userId);
-        })()
-        : await db.deleteProjectApiToken(id, session.tenantId, projectId);
+      let deleted: boolean;
+      let tokenHash: string | undefined;
+      if (session.userRole === 'user') {
+        const ownTokens = await db.listApiTokens(session.userId);
+        const token = ownTokens.find((item) => String(item._id) === String(id));
+        if (
+          !token
+          || String(token.tenantId) !== String(session.tenantId)
+          || String(token.projectId) !== String(projectId)
+        ) {
+          deleted = false;
+        } else {
+          tokenHash = token.tokenHash;
+          deleted = await db.deleteApiToken(id, session.userId);
+        }
+      } else {
+        const projectTokens = await db.listProjectApiTokens(session.tenantId, projectId);
+        tokenHash = projectTokens.find((item) => String(item._id) === String(id))?.tokenHash;
+        deleted = await db.deleteProjectApiToken(id, session.tenantId, projectId);
+      }
 
       if (!deleted) {
         return reply.code(404).send({ error: 'Token not found' });
       }
+
+      await invalidateApiTokenAuthCache(tokenHash);
 
       return reply.code(200).send({ message: 'API token deleted successfully' });
     } catch (error) {


### PR DESCRIPTION
## Summary

P1 finding from the 2026-09-05 finance-institution assessment. Scoped to two concrete, verified bugs — session/token lifecycle as a whole is a much larger topic (see below).

- **JWT expiry silently defaulted for any non-`1d`/`7d`/`30d` value.** `TokenManager.generateToken` hardcoded a `{'1d','7d','30d'}` lookup and fell back to 7 days for anything else — an operator setting `JWT_EXPIRES_IN=12h` silently got a week-long token instead, with no error to notice it by. `jose`'s own `SignJWT.setExpirationTime` already accepts the exact duration-string format this needs (`"12h"`, `"45m"`, `"2 weeks"`, ...) and parses it correctly — passing the config value straight through *removes* a reimplementation instead of growing its lookup table, and now fails loudly (every login fails, visibly) if the value is genuinely unparseable, instead of silently issuing a token with a different lifetime than configured.

- **API-token deletion didn't invalidate the auth cache.** `requireApiTokenFromHeader`'s 60s auth cache had no invalidation path on delete — a deleted token stayed valid on every replica for up to the cache's TTL after the delete already succeeded. `DELETE /tokens/:id` now looks up the deleted token's stored `tokenHash` and evicts the exact cache entry the auth check would have hit (`apiAuthCacheKey` extracted so both call sites build the identical key instead of duplicating the format). Best-effort: a cache-eviction failure never blocks the delete itself.

## Explicitly out of scope for this PR

Central session-level revocation (`authVersion`/denylist) for an already-issued, not-yet-expired JWT, and OIDC/SAML federation, MFA/step-up, SCIM deprovisioning. These are net-new capabilities requiring real architecture and IdP-integration decisions, not bug fixes to existing logic — they don't belong bundled with two targeted corrections.

## Test plan

- [x] New `token-manager-expiry.test.ts`: 1d/7d/30d unchanged, a previously-unsupported value (`12h`/`45m`/`2w`) now honored instead of defaulting, and a genuinely unparseable value now throws instead of silently defaulting
- [x] New `tokens-delete-cache-invalidation.test.ts`: cache evicted on both the admin/owner and self-service delete paths, not touched on a 404, and the delete still succeeds if cache eviction itself fails
- [x] Both regressions manually verified to fail against the pre-fix code (reverted, confirmed red, restored)
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` clean
- [x] Full `vitest run`: 5053 passed, 0 failed, 5 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KQq6TnVNHRNU6Wz1eQzPpD