### PR TITLE
fix(rag-ui): distinguish a failed load from genuinely empty data (F-19)

### DIFF
--- a/src/app/dashboard/rag/[key]/page.tsx
+++ b/src/app/dashboard/rag/[key]/page.tsx
@@ -52,6 +52,7 @@ import {
   IconChartHistogram,
   IconActivity,
   IconFileUpload,
+  IconAlertTriangle,
 } from '@tabler/icons-react';
 import EditRagModuleModal from '@/components/rag/EditRagModuleModal';
 import ChunkConfigFields from '@/components/rag/ChunkConfigFields';
@@ -267,6 +268,34 @@ function KpiCard({ label, value, icon, color, hint }: KpiCardProps) {
   );
 }
 
+interface InlineLoadErrorProps {
+  message: string;
+  onRetry: () => void;
+}
+
+/**
+ * A failed load must look different from "there is nothing here yet" --
+ * without this, documents/usage/insights sections that failed to fetch
+ * rendered exactly like a genuinely empty tenant, with the actual failure
+ * visible only in devtools (F-19, finance-institution assessment,
+ * 2026-09-05).
+ */
+function InlineLoadError({ message, onRetry }: InlineLoadErrorProps) {
+  return (
+    <Center py="xl">
+      <Stack gap="sm" align="center">
+        <ThemeIcon size={64} radius="xl" variant="light" color="red">
+          <IconAlertTriangle size={32} />
+        </ThemeIcon>
+        <Text size="sm" c="dimmed" ta="center" maw={360}>{message}</Text>
+        <Button size="xs" variant="light" color="red" leftSection={<IconRefresh size={14} />} onClick={onRetry}>
+          Retry
+        </Button>
+      </Stack>
+    </Center>
+  );
+}
+
 /* ── Page ──────────────────────────────────────────────────────────────── */
 
 export default function RagModuleDetailPage() {
@@ -282,6 +311,7 @@ export default function RagModuleDetailPage() {
   /* documents */
   const [documents, setDocuments] = useState<RagDocumentView[]>([]);
   const [docsLoading, setDocsLoading] = useState(false);
+  const [docsError, setDocsError] = useState<string | null>(null);
   const [ingesting, setIngesting] = useState(false);
   const [ingestFileName, setIngestFileName] = useState('');
   const [ingestContent, setIngestContent] = useState('');
@@ -302,11 +332,13 @@ export default function RagModuleDetailPage() {
   const [queryLogs, setQueryLogs] = useState<RagQueryLogView[]>([]);
   const [usageLoading, setUsageLoading] = useState(false);
   const [usageTotals, setUsageTotals] = useState<UsageTotals | null>(null);
+  const [usageError, setUsageError] = useState<string | null>(null);
 
   /* insight panels */
   const [scoreBuckets, setScoreBuckets] = useState<ScoreBucket[]>([]);
   const [zeroQueries, setZeroQueries] = useState<RagQueryLogView[]>([]);
   const [insightsLoading, setInsightsLoading] = useState(false);
+  const [insightsError, setInsightsError] = useState<string | null>(null);
 
   const queryForm = useForm({
     initialValues: { query: '', topK: 5, minScore: 0, filter: '' },
@@ -382,12 +414,17 @@ export default function RagModuleDetailPage() {
     if (!silent) setDocsLoading(true);
     try {
       const res = await fetch(`/api/rag/modules/${encodeURIComponent(moduleKey)}/documents`, { cache: 'no-store' });
-      if (res.ok) {
-        const data = await res.json();
-        setDocuments(data.documents ?? []);
+      if (!res.ok) {
+        throw new Error(`Failed to load documents (HTTP ${res.status})`);
       }
+      const data = await res.json();
+      setDocuments(data.documents ?? []);
+      setDocsError(null);
     } catch (e) {
       console.error('[rag docs]', e);
+      // A failed load must not be mistaken for "zero documents" -- the table
+      // below only renders its empty state when docsError is also cleared.
+      setDocsError(e instanceof Error ? e.message : 'Failed to load documents');
     } finally {
       setDocsLoading(false);
     }
@@ -398,22 +435,25 @@ export default function RagModuleDetailPage() {
     setUsageLoading(true);
     try {
       const res = await fetch(`/api/rag/modules/${encodeURIComponent(moduleKey)}/usage?limit=50`, { cache: 'no-store' });
-      if (res.ok) {
-        const data = await res.json();
-        setQueryLogs(data.logs ?? []);
-        setUsageTotals(
-          typeof data.total === 'number' && typeof data.avgLatencyMs === 'number'
-            ? {
-              total: data.total,
-              avgLatencyMs: data.avgLatencyMs,
-              zeroMatchCount: data.zeroMatchCount ?? 0,
-              minScoreFilteredCount: data.minScoreFilteredCount ?? 0,
-            }
-            : null,
-        );
+      if (!res.ok) {
+        throw new Error(`Failed to load usage (HTTP ${res.status})`);
       }
+      const data = await res.json();
+      setQueryLogs(data.logs ?? []);
+      setUsageTotals(
+        typeof data.total === 'number' && typeof data.avgLatencyMs === 'number'
+          ? {
+            total: data.total,
+            avgLatencyMs: data.avgLatencyMs,
+            zeroMatchCount: data.zeroMatchCount ?? 0,
+            minScoreFilteredCount: data.minScoreFilteredCount ?? 0,
+          }
+          : null,
+      );
+      setUsageError(null);
     } catch (e) {
       console.error('[rag usage]', e);
+      setUsageError(e instanceof Error ? e.message : 'Failed to load usage');
     } finally {
       setUsageLoading(false);
     }
@@ -428,16 +468,17 @@ export default function RagModuleDetailPage() {
         fetch(`${base}/score-distribution`, { cache: 'no-store' }),
         fetch(`${base}/queries?zeroOnly=true&limit=25`, { cache: 'no-store' }),
       ]);
-      if (distributionRes.ok) {
-        const data = await distributionRes.json();
-        setScoreBuckets(data.buckets ?? []);
+      if (!distributionRes.ok || !zeroRes.ok) {
+        const failedStatus = !distributionRes.ok ? distributionRes.status : zeroRes.status;
+        throw new Error(`Failed to load insights (HTTP ${failedStatus})`);
       }
-      if (zeroRes.ok) {
-        const data = await zeroRes.json();
-        setZeroQueries(data.logs ?? []);
-      }
+      const [distributionData, zeroData] = await Promise.all([distributionRes.json(), zeroRes.json()]);
+      setScoreBuckets(distributionData.buckets ?? []);
+      setZeroQueries(zeroData.logs ?? []);
+      setInsightsError(null);
     } catch (e) {
       console.error('[rag insights]', e);
+      setInsightsError(e instanceof Error ? e.message : 'Failed to load insights');
     } finally {
       setInsightsLoading(false);
     }
@@ -897,11 +938,15 @@ export default function RagModuleDetailPage() {
                   </Text>
                 </div>
               </Group>
-              <ScoreDistributionChart
-                buckets={scoreBuckets}
-                minScore={mod.defaultMinScore ?? 0}
-                loading={insightsLoading}
-              />
+              {insightsError ? (
+                <InlineLoadError message={insightsError} onRetry={() => void loadInsights()} />
+              ) : (
+                <ScoreDistributionChart
+                  buckets={scoreBuckets}
+                  minScore={mod.defaultMinScore ?? 0}
+                  loading={insightsLoading}
+                />
+              )}
             </Paper>
 
             {/* Content gaps */}
@@ -927,6 +972,8 @@ export default function RagModuleDetailPage() {
 
               {insightsLoading ? (
                 <Center py="xl"><Loader size="sm" color="violet" /></Center>
+              ) : insightsError ? (
+                <InlineLoadError message={insightsError} onRetry={() => void loadInsights()} />
               ) : zeroQueries.length === 0 ? (
                 <Center py="xl">
                   <Text size="sm" c="dimmed">No zero-result queries logged. Every query found something.</Text>
@@ -1268,6 +1315,8 @@ export default function RagModuleDetailPage() {
 
               {docsLoading ? (
                 <Center py="xl"><Loader size="sm" color="violet" /></Center>
+              ) : docsError ? (
+                <InlineLoadError message={docsError} onRetry={() => void loadDocuments()} />
               ) : documents.length === 0 ? (
                 <Center py="xl">
                   <Stack gap="sm" align="center">
@@ -1551,6 +1600,8 @@ export default function RagModuleDetailPage() {
 
               {usageLoading ? (
                 <Center py="xl"><Loader size="sm" /></Center>
+              ) : usageError ? (
+                <InlineLoadError message={usageError} onRetry={() => void loadUsage()} />
               ) : queryLogs.length === 0 ? (
                 <Center py="xl">
                   <Stack gap="sm" align="center">


### PR DESCRIPTION
## Summary

P2 finding from the 2026-09-05 finance-institution assessment.

`loadDocuments`/`loadUsage`/`loadInsights` on the RAG module detail page did `if (res.ok) { ...update state... }` with no `else` and no persistent error state — a failed fetch left whatever was already in state (on first load, the empty initial array) with no visible sign anything went wrong. The failure was only visible in devtools; an operator looking at the page saw "no documents" / "no queries logged" / "every query found something" and had no way to tell that apart from a genuinely empty tenant.

All three now throw on a non-ok response, set a persistent error message on catch (cleared on the next successful load), and the affected sections render a distinct error state (red icon, the actual error message, a **Retry** button that re-runs the same load) instead of falling through to their empty-state branch. Applies to both insights sub-panels (score distribution chart, zero-result queries) since both come from the same `loadInsights` failure.

## Explicitly out of scope for this PR

The same finding also names a `.catch(() => [])` pattern in `console-ee`'s cluster admin listings, a missing in-flight lock on the token-delete confirm button, and a missing provider-connectivity test flow. Each is a separate location/component with its own scope — bundling all of F-19 into one diff would make this harder to review, not easier. Flagging as follow-ups.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` clean
- [x] Full production `next build` succeeds — the changed route (`/dashboard/rag/[key]`) compiles and is included in the build output
- [x] Full `vitest run`: 5046 passed, 0 failed, 5 skipped (unrelated to this change; no regressions)
- [ ] **Not verified in a live browser.** This repo has no React component test harness (`@testing-library/react` isn't a dependency) to exercise the new branches in an automated test, and I did not stand up a live tenant/module to click through it manually. This change is verified at the type/lint/build level only, not behaviorally in a running app — flagging explicitly rather than claiming a level of confidence I don't have.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KQq6TnVNHRNU6Wz1eQzPpD