### PR TITLE
fix(F-12): redact free-text PII from persisted usage logs

### DIFF
--- a/src/__tests__/unit/log-pii-redaction.test.ts
+++ b/src/__tests__/unit/log-pii-redaction.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Regression tests for F-12 (finance-institution assessment, 2026-09-05):
+ * secret-key/value redaction masked `apiKey` but left a synthetic person's
+ * email untouched inside `messages[].content`. logPiiRedaction.ts wires the
+ * already-existing PII detector (@/lib/services/pii/piiService) — whose own
+ * file header admitted it "was intentionally not wired into other
+ * modules... yet" — into the usage-log write path.
+ */
+import { describe, expect, it } from 'vitest';
+import { redactPiiFromLogPayload, redactPiiFromLogString } from '@/lib/services/logPiiRedaction';
+
+describe('redactPiiFromLogPayload', () => {
+  it('redacts an email nested inside messages[].content, matching the assessment\'s synthetic example', () => {
+    const payload = {
+      apiKey: 'sk-should-be-untouched-by-this-module', // logRedaction.ts's job, not this one
+      messages: [
+        { role: 'user', content: 'My name is Jane Doe, reach me at jane.doe@example.com' },
+      ],
+    };
+
+    const result = redactPiiFromLogPayload(payload);
+
+    expect(result.messages[0].content).not.toContain('jane.doe@example.com');
+    expect(result.apiKey).toBe('sk-should-be-untouched-by-this-module');
+  });
+
+  it('leaves content with no PII completely unchanged', () => {
+    const payload = { messages: [{ role: 'user', content: 'What is the capital of France?' }] };
+    const result = redactPiiFromLogPayload(payload);
+    expect(result).toEqual(payload);
+  });
+
+  it('walks arrays and nested objects', () => {
+    const payload = {
+      choices: [
+        { message: { content: 'Contact support at help@example.com for assistance.' } },
+      ],
+    };
+    const result = redactPiiFromLogPayload(payload);
+    expect(result.choices[0].message.content).not.toContain('help@example.com');
+  });
+
+  it('preserves Date, Buffer, and Error instances instead of flattening them to {}', () => {
+    const date = new Date('2026-09-06T00:00:00Z');
+    const buf = Buffer.from('binary');
+    const err = new Error('boom');
+    const payload = { date, buf, err };
+
+    const result = redactPiiFromLogPayload(payload);
+
+    expect(result.date).toBe(date);
+    expect(result.buf).toBe(buf);
+    expect(result.err).toBe(err);
+  });
+
+  it('handles a circular reference without throwing', () => {
+    const payload: Record<string, unknown> = { note: 'hi' };
+    payload.self = payload;
+
+    expect(() => redactPiiFromLogPayload(payload)).not.toThrow();
+  });
+
+  it('passes null/undefined through unchanged', () => {
+    expect(redactPiiFromLogPayload(null)).toBeNull();
+    expect(redactPiiFromLogPayload(undefined)).toBeUndefined();
+  });
+});
+
+describe('redactPiiFromLogString', () => {
+  it('redacts an email inside a free-text error message', () => {
+    const result = redactPiiFromLogString('Delivery failed for jane.doe@example.com: mailbox full');
+    expect(result).not.toContain('jane.doe@example.com');
+  });
+
+  it('passes an empty/undefined string through unchanged', () => {
+    expect(redactPiiFromLogString(undefined)).toBeUndefined();
+    expect(redactPiiFromLogString('')).toBe('');
+  });
+});

--- a/src/__tests__/unit/usage-logger-pii-redaction.test.ts
+++ b/src/__tests__/unit/usage-logger-pii-redaction.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Integration-level regression test for F-12: logModelUsage must not persist
+ * raw customer PII from messages[].content into the usage log row.
+ */
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { createMockDb } from '../helpers/db.mock';
+
+vi.mock('@/lib/database', () => ({ getDatabase: vi.fn() }));
+vi.mock('@/lib/services/usage/usageEvents', () => ({
+  recordUsageEvent: vi.fn().mockReturnValue({
+    userId: 'user-1',
+    apiTokenId: undefined,
+    actorType: 'user',
+    requestId: 'req-1',
+    projectId: 'proj-1',
+  }),
+}));
+
+import { getDatabase } from '@/lib/database';
+import { logModelUsage } from '@/lib/services/models/usageLogger';
+import type { IModel } from '@/lib/database';
+
+const MODEL = {
+  _id: 'model-1',
+  tenantId: 'tenant-1',
+  projectId: 'proj-1',
+  key: 'gpt-test',
+  pricing: {},
+} as unknown as IModel;
+
+describe('logModelUsage — PII redaction on the persisted payload', () => {
+  let db: ReturnType<typeof createMockDb>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    db = createMockDb();
+    (getDatabase as ReturnType<typeof vi.fn>).mockResolvedValue(db);
+  });
+
+  it('does not persist a customer email that appears in messages[].content', async () => {
+    await logModelUsage('tenant_acme', MODEL, {
+      requestId: 'req-1',
+      route: '/client/v1/chat/completions',
+      status: 'success',
+      providerRequest: {
+        apiKey: 'sk-secret-value-should-be-masked',
+        messages: [
+          { role: 'user', content: 'My name is Jane Doe, reach me at jane.doe@example.com' },
+        ],
+      },
+      providerResponse: { choices: [{ message: { content: 'Sure, I\'ll email john.smith@example.com now.' } }] },
+      usage: { inputTokens: 10, outputTokens: 5 },
+    });
+
+    expect(db.createModelUsageLog).toHaveBeenCalledTimes(1);
+    const persisted = db.createModelUsageLog.mock.calls[0][0];
+    const requestJson = JSON.stringify(persisted.providerRequest);
+    const responseJson = JSON.stringify(persisted.providerResponse);
+
+    expect(requestJson).not.toContain('jane.doe@example.com');
+    expect(responseJson).not.toContain('john.smith@example.com');
+    // Secret-value scrub (a different module, logRedaction.ts) still applies too.
+    expect(requestJson).not.toContain('sk-secret-value-should-be-masked');
+  });
+
+  it('redacts PII from a free-text error message', async () => {
+    await logModelUsage('tenant_acme', MODEL, {
+      requestId: 'req-2',
+      route: '/client/v1/chat/completions',
+      status: 'error',
+      providerRequest: {},
+      providerResponse: {},
+      errorMessage: 'Delivery failed for jane.doe@example.com',
+      usage: {},
+    });
+
+    const persisted = db.createModelUsageLog.mock.calls[0][0];
+    expect(persisted.errorMessage).not.toContain('jane.doe@example.com');
+  });
+});

--- a/src/lib/services/logPiiRedaction.ts
+++ b/src/lib/services/logPiiRedaction.ts
@@ -1,0 +1,79 @@
+/**
+ * Free-text PII redaction for PERSISTED usage logs.
+ *
+ * `logRedaction.ts` masks known secret VALUES and sensitive-named KEYS, which
+ * is a different problem from this one: a customer's name or email sitting
+ * inside ordinary free text (`messages[].content`, a tool result, an error
+ * body) has no distinctive key name or known value to match against — it can
+ * only be found by scanning the text itself. This module does that scan,
+ * using the same detector the PII guardrail enforces requests with
+ * (`@/lib/services/pii/piiService`), which already existed but — per its own
+ * file header — was "intentionally not wired into other modules... yet".
+ *
+ * A guardrail binding is a per-request, per-tenant DECISION about whether to
+ * block/warn on PII in a LIVE call. This is unconditional and always runs
+ * before a payload is written to the usage log table: an operator's
+ * decision not to enforce a PII guardrail on a call should not also mean
+ * "and store the customer's email in cost-tracking rows forever". If a
+ * tenant genuinely needs raw, unredacted request/response bodies retained
+ * for debugging, that is a separate, explicitly-permissioned capability to
+ * design later — not the default for every usage log row.
+ */
+
+import { redactPii } from '@/lib/services/pii/piiService';
+
+const MAX_DEPTH = 8;
+
+function scrubPiiValue(value: unknown, depth: number, seen: WeakSet<object>): unknown {
+  if (value === null || value === undefined) return value;
+  if (typeof value === 'string') {
+    if (!value) return value;
+    try {
+      return redactPii({ text: value }).outputText;
+    } catch {
+      // A detector failure must never block or corrupt the write path --
+      // fall back to the untouched string rather than throw.
+      return value;
+    }
+  }
+  if (typeof value !== 'object') return value;
+  // Preserve native instances, matching logRedaction.ts's scrubValue: walking
+  // a Date/Buffer/Error as a plain object would erase it (Object.entries is
+  // empty -> {}).
+  if (value instanceof Error || value instanceof Date || Buffer.isBuffer(value)) return value;
+  if (depth > MAX_DEPTH) return value;
+  if (seen.has(value as object)) return '[Circular]';
+  seen.add(value as object);
+
+  if (Array.isArray(value)) {
+    return value.map((item) => scrubPiiValue(item, depth + 1, seen));
+  }
+
+  const out: Record<string, unknown> = {};
+  for (const [key, val] of Object.entries(value as Record<string, unknown>)) {
+    out[key] = scrubPiiValue(val, depth + 1, seen);
+  }
+  return out;
+}
+
+/**
+ * Returns a deep copy of `payload` with every string value passed through
+ * the PII detector's default category set and redacted. Never mutates the
+ * input. Intended to run AFTER `redactLogPayload` (secret scrub) so a
+ * sensitive-named key is already masked to a fixed marker before this ever
+ * sees it.
+ */
+export function redactPiiFromLogPayload<T>(payload: T): T {
+  if (payload === null || payload === undefined) return payload;
+  return scrubPiiValue(payload, 0, new WeakSet()) as T;
+}
+
+/** Same scan, for a single free-text field (e.g. an error message). */
+export function redactPiiFromLogString(str: string | undefined): string | undefined {
+  if (!str) return str;
+  try {
+    return redactPii({ text: str }).outputText;
+  } catch {
+    return str;
+  }
+}

--- a/src/lib/services/models/usageLogger.ts
+++ b/src/lib/services/models/usageLogger.ts
@@ -13,6 +13,10 @@ import {
   redactLogPayload,
   redactLogString,
 } from '@/lib/services/logRedaction';
+import {
+  redactPiiFromLogPayload,
+  redactPiiFromLogString,
+} from '@/lib/services/logPiiRedaction';
 import { normalizeFinishReason } from '@/lib/shared/finishReason';
 
 const TOKENS_PER_MILLION = 1_000_000;
@@ -190,9 +194,14 @@ export async function logModelUsage(
     requestId: payload.requestId,
     route: payload.route,
     status: payload.status,
-    providerRequest: toRecord(redactLogPayload(payload.providerRequest)),
-    providerResponse: toRecord(redactLogPayload(payload.providerResponse)),
-    errorMessage: redactLogString(payload.errorMessage),
+    // Secret scrub first (known key names / outbound secret values), then a
+    // free-text PII pass -- a customer's email or name inside
+    // messages[].content has no distinctive key or known value to match
+    // against the way a secret does, so it can only be found by scanning
+    // the text itself. See logPiiRedaction.ts.
+    providerRequest: toRecord(redactPiiFromLogPayload(redactLogPayload(payload.providerRequest))),
+    providerResponse: toRecord(redactPiiFromLogPayload(redactLogPayload(payload.providerResponse))),
+    errorMessage: redactPiiFromLogString(redactLogString(payload.errorMessage)),
     latencyMs: payload.latencyMs,
     inputTokens: usage.inputTokens ?? 0,
     outputTokens: usage.outputTokens ?? 0,


### PR DESCRIPTION
## Summary

Finance-institution assessment finding F-12: `logRedaction.ts` masks known
secret-named keys and secret-shaped values, but a customer's name or email
sitting in ordinary free text (`messages[].content`, a tool result, an error
body) has no distinctive key or known value to match against — it can only
be found by scanning the text. The assessment's synthetic test confirmed
this: `apiKey` was masked, a synthetic person/email inside
`messages[].content` was not.

- New `src/lib/services/logPiiRedaction.ts`: `redactPiiFromLogPayload<T>()`
  (deep-walks an object/array, never mutates) and `redactPiiFromLogString()`,
  both built on `@/lib/services/pii/piiService`'s `redactPii` — an existing
  detector whose own file header already admitted it was "intentionally not
  wired into other modules... yet."
- Wired into `usageLogger.ts`'s three persistence call sites
  (`providerRequest`, `providerResponse`, `errorMessage`), composed *after*
  the existing secret scrub (`redactLogPayload`/`redactLogString`).
- This is unconditional, independent of any PII guardrail binding: a
  guardrail is a per-request decision about blocking/warning a live call;
  this is a decision about what gets permanently written into cost-tracking
  rows a tenant's operators can read indefinitely.

## Explicitly out of scope

- The `cognipeer-observability` SDK's own `capture=all` default — a
  separate, standalone package with no dependents in this workspace. See
  companion PR [cognipeer-observability#2](https://github.com/Cognipeer/cognipeer-observability/pull/2),
  which documents (rather than changes) that default, since it's a public
  versioned default with unknown existing integrators.
- A tenant-configurable "raw retention for debugging" exception — the
  assessment's remediation list mentions this as a separate, explicitly
  permissioned capability to design later, not a default behavior change.
- Any change to the PII detector's own category set/policy — this PR only
  adds a new *call site* for the existing detector.

## Test plan

- `log-pii-redaction.test.ts` (8 tests): email redaction in nested
  `messages[].content`, arrays, no-PII pass-through, `Date`/`Buffer`/`Error`
  preservation, circular-ref safety, null/undefined, error-string redaction.
- `usage-logger-pii-redaction.test.ts` (2 tests): integration-level check
  that `logModelUsage` never persists a synthetic email from
  `providerRequest`/`providerResponse`/`errorMessage`. Manually verified
  these fail if the `usageLogger.ts` wiring is reverted (reverted → red →
  restored → green).
- `npx tsc --noEmit` clean.
- `npx eslint` on all 4 changed/new files clean.
- Full `npx vitest run`: 5056 passed, 5 skipped, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KQq6TnVNHRNU6Wz1eQzPpD