### PR TITLE
fix(F-05): settle real cost against budget for streams and audio/OCR

### DIFF
--- a/src/__tests__/api/client-inference-fastify.test.ts
+++ b/src/__tests__/api/client-inference-fastify.test.ts
@@ -57,6 +57,7 @@ vi.mock('@/lib/quota/quotaGuard', () => ({
   checkBudget: vi.fn().mockResolvedValue({ allowed: true }),
   checkPerRequestLimits: vi.fn().mockResolvedValue({ allowed: true }),
   checkRateLimit: vi.fn().mockResolvedValue({ allowed: true }),
+  settleUsageBudget: vi.fn().mockResolvedValue(undefined),
 }));
 
 import { requireApiTokenFromHeader } from '@/lib/services/apiTokenAuth';
@@ -64,6 +65,7 @@ import { getDatabase } from '@/lib/database';
 import { authorizeServiceRequest, getPermissionServiceForPath } from '@/lib/security/rbac';
 import { handleChatCompletion } from '@/lib/services/models/inferenceService';
 import { OutputTokenLimitError } from '@/lib/services/models/openaiErrors';
+import { settleUsageBudget } from '@/lib/quota/quotaGuard';
 import { clientInferenceApiPlugin } from '@/server/api/plugins/client-inference';
 import { createFastifyApiTestApp, parseJsonBody } from '../helpers/fastify-api';
 
@@ -168,5 +170,119 @@ describe('Fastify client inference errors', () => {
       code: 'invalid_request',
     });
     expect(body.error.message).toContain('messages[0].content[1].image_url');
+  });
+});
+
+describe('Fastify client inference — streaming budget settlement (F-05)', () => {
+  let app: Awaited<ReturnType<typeof createFastifyApiTestApp>>;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mockFn(requireApiTokenFromHeader).mockResolvedValue(AUTH_CTX);
+    mockFn(getDatabase).mockResolvedValue({
+      runWithTenant: <T>(_tenantDbName: string, operation: () => T) => operation(),
+    });
+    mockFn(getPermissionServiceForPath).mockReturnValue('models');
+    mockFn(authorizeServiceRequest).mockReturnValue({ allowed: true });
+    app = await createFastifyApiTestApp(clientInferenceApiPlugin);
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  // Regression for the F-05 finding (2026-09-05 assessment): a streamed
+  // chat completion's real usage is only known long after this route has
+  // already returned the (still-open) stream to the caller, so the OLD
+  // post-hoc `if (result.usage) { ...checkBudget... }` block here never ran
+  // for it — the budget counter never debited a single streamed request,
+  // no matter how much it cost. `handleChatCompletion` is mocked here (its
+  // own streaming/cost logic is covered directly in inference-service.test.ts),
+  // so this test stands for the route's wiring alone: does it pass a working
+  // `onUsageSettled` through, and does calling it actually reach the budget
+  // counter for BOTH stream and non-stream calls.
+  it('settles the budget from a streamed completion, not only a non-streaming one', async () => {
+    mockFn(handleChatCompletion).mockImplementation(async (params: {
+      onUsageSettled?: (cost: { currency: string; totalCost: number }) => void;
+    }) => {
+      params.onUsageSettled?.({ currency: 'USD', totalCost: 0.42 });
+      return {
+        stream: new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode('data: [DONE]\n\n'));
+            controller.close();
+          },
+        }),
+        requestId: 'stream-req-1',
+      };
+    });
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/client/v1/chat/completions',
+      headers: { authorization: 'Bearer tok_abc' },
+      payload: {
+        model: 'test-model',
+        messages: [{ role: 'user', content: 'Hello' }],
+        stream: true,
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(settleUsageBudget).toHaveBeenCalledTimes(1);
+    expect(settleUsageBudget).toHaveBeenCalledWith(
+      expect.objectContaining({ resourceKey: 'test-model' }),
+      { currency: 'USD', totalCost: 0.42 },
+    );
+  });
+
+  it('still settles the budget for a non-streaming completion', async () => {
+    mockFn(handleChatCompletion).mockImplementation(async (params: {
+      onUsageSettled?: (cost: { currency: string; totalCost: number }) => void;
+    }) => {
+      params.onUsageSettled?.({ currency: 'USD', totalCost: 0.07 });
+      return {
+        response: { id: 'chatcmpl-1', choices: [] },
+        usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+        requestId: 'req-1',
+      };
+    });
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/client/v1/chat/completions',
+      headers: { authorization: 'Bearer tok_abc' },
+      payload: {
+        model: 'test-model',
+        messages: [{ role: 'user', content: 'Hello' }],
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(settleUsageBudget).toHaveBeenCalledWith(
+      expect.objectContaining({ resourceKey: 'test-model' }),
+      { currency: 'USD', totalCost: 0.07 },
+    );
+  });
+
+  it('does not settle the budget when the call produced no billable usage', async () => {
+    mockFn(handleChatCompletion).mockResolvedValue({
+      response: { id: 'chatcmpl-2', choices: [] },
+      usage: {},
+      requestId: 'req-2',
+    });
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/client/v1/chat/completions',
+      headers: { authorization: 'Bearer tok_abc' },
+      payload: {
+        model: 'test-model',
+        messages: [{ role: 'user', content: 'Hello' }],
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(settleUsageBudget).not.toHaveBeenCalled();
   });
 });

--- a/src/__tests__/unit/inference-service.test.ts
+++ b/src/__tests__/unit/inference-service.test.ts
@@ -22,9 +22,16 @@ vi.mock('@/lib/services/models/semanticCacheService', () => ({
   storeInCache: vi.fn().mockResolvedValue(undefined),
 }));
 
-vi.mock('@/lib/services/models/usageLogger', () => ({
-  logModelUsage: vi.fn().mockResolvedValue(undefined),
-}));
+vi.mock('@/lib/services/models/usageLogger', async (importOriginal) => {
+  const original = await importOriginal<typeof import('@/lib/services/models/usageLogger')>();
+  return {
+    ...original,
+    // calculateCost stays REAL (pure, deterministic) so the budget-settlement
+    // tests below exercise the same arithmetic production traffic gets, not a
+    // stand-in that always returns some fixed number.
+    logModelUsage: vi.fn().mockResolvedValue(undefined),
+  };
+});
 
 vi.mock('@/lib/services/guardrail', () => ({
   evaluateGuardrail: vi.fn().mockResolvedValue({ action: 'allow', findings: [] }),
@@ -246,6 +253,30 @@ describe('handleChatCompletion', () => {
     );
   });
 
+  it('settles the budget with the realized cost for a non-streaming completion too (F-05)', async () => {
+    const model = makeLlmModel({ pricing: { inputTokenPer1M: 10, outputTokenPer1M: 30 } });
+    (getModelByKey as ReturnType<typeof vi.fn>).mockResolvedValue(model);
+    (buildModelRuntime as ReturnType<typeof vi.fn>).mockResolvedValue({
+      runtime: makeChatRuntime(),
+    });
+    (summarizeUsage as ReturnType<typeof vi.fn>).mockReturnValue({
+      inputTokens: 100,
+      outputTokens: 200,
+      totalTokens: 300,
+    });
+
+    const onUsageSettled = vi.fn();
+    await handleChatCompletion({
+      ...BASE_PARAMS,
+      body: { messages: [{ role: 'user', content: 'Hello' }] },
+      onUsageSettled,
+    });
+
+    expect(onUsageSettled).toHaveBeenCalledWith(
+      expect.objectContaining({ currency: 'USD', totalCost: 0.007 }),
+    );
+  });
+
   it('forwards finishReason and reasoningTokens to logModelUsage without perturbing totalTokens', async () => {
     // reasoningTokens is a SUBSET of outputTokens — it must reach logModelUsage
     // as its own field, and totalTokens must stay exactly what summarizeUsage
@@ -448,6 +479,50 @@ describe('handleChatCompletion', () => {
     expect(result).toHaveProperty('stream');
     expect(result).toHaveProperty('requestId');
     expect(result.stream).toBeInstanceOf(ReadableStream);
+  });
+
+  it('settles the budget with the realized cost once a stream completes (F-05)', async () => {
+    // Regression for the 2026-09-05 assessment's F-05: streaming usage was
+    // logged via logModelUsage, but nothing fed it back into the budget
+    // counter — only the non-streaming branch's caller did that, using
+    // `result.usage`, a field a streaming outcome never carries. A caller
+    // that wants the real cost has to be told through `onUsageSettled`,
+    // since it isn't known until the stream this function already returned
+    // finishes.
+    (getModelByKey as ReturnType<typeof vi.fn>).mockResolvedValue(
+      makeLlmModel({ pricing: { inputTokenPer1M: 10, outputTokenPer1M: 30 } }),
+    );
+    const asyncIterator = (async function* () {
+      yield { content: 'Hello' };
+    })();
+    (buildModelRuntime as ReturnType<typeof vi.fn>).mockResolvedValue({
+      runtime: {
+        createChatModel: vi.fn().mockResolvedValue({
+          invoke: vi.fn(),
+          stream: vi.fn().mockResolvedValue(asyncIterator),
+        }),
+      },
+    });
+    (toOpenAIStreamChunk as ReturnType<typeof vi.fn>).mockReturnValue({
+      id: 'chatcmpl-1',
+      object: 'chat.completion.chunk',
+      choices: [{ index: 0, delta: { content: 'Hello' }, finish_reason: 'stop' }],
+      usage: { prompt_tokens: 100, completion_tokens: 200, total_tokens: 300 },
+    });
+
+    const onUsageSettled = vi.fn();
+    const result = await handleChatCompletion({
+      ...BASE_PARAMS,
+      body: { messages: [], stream_options: { include_usage: true } },
+      stream: true,
+      onUsageSettled,
+    });
+    await new Response(result.stream).text();
+
+    // 100 input tokens @ $10/1M + 200 output tokens @ $30/1M = $0.001 + $0.006
+    expect(onUsageSettled).toHaveBeenCalledWith(
+      expect.objectContaining({ currency: 'USD', totalCost: 0.007 }),
+    );
   });
 
   it('emits requested stream usage as a final usage-only chunk', async () => {
@@ -705,7 +780,10 @@ describe('handleChatCompletion', () => {
   });
 
   describe('client disconnects mid-stream', () => {
-    const startCancellableStream = async (modelOverrides = {}) => {
+    const startCancellableStream = async (
+      modelOverrides = {},
+      onUsageSettled?: (cost: { currency: string; totalCost: number }) => void,
+    ) => {
       (getModelByKey as ReturnType<typeof vi.fn>).mockResolvedValue(makeLlmModel(modelOverrides));
       let aborted = false;
       (buildModelRuntime as ReturnType<typeof vi.fn>).mockResolvedValue({
@@ -738,6 +816,7 @@ describe('handleChatCompletion', () => {
         ...BASE_PARAMS,
         body: { messages: [] },
         stream: true,
+        onUsageSettled,
       });
 
       const reader = result.stream!.getReader();
@@ -767,6 +846,19 @@ describe('handleChatCompletion', () => {
         cancelled: 'client_disconnected',
         output_tokens_estimated: true,
       });
+    });
+
+    it('settles the budget for the partial usage too — the provider still billed for it (F-05)', async () => {
+      const onUsageSettled = vi.fn();
+      await startCancellableStream(
+        { pricing: { inputTokenPer1M: 10, outputTokenPer1M: 30 } },
+        onUsageSettled,
+      );
+
+      expect(onUsageSettled).toHaveBeenCalledTimes(1);
+      const [cost] = onUsageSettled.mock.calls[0];
+      expect(cost.currency).toBe('USD');
+      expect(cost.totalCost).toBeGreaterThan(0);
     });
 
     it('still audits the output guardrail over the text that was delivered', async () => {

--- a/src/lib/quota/quotaGuard.ts
+++ b/src/lib/quota/quotaGuard.ts
@@ -613,6 +613,33 @@ function usdToCents(usd: number): number {
   return Math.max(0, Math.round(usd * 100));
 }
 
+/**
+ * Debit a budget window with a call's REALIZED cost, once it is known.
+ *
+ * `checkBudget()` alone is a pre-flight gate — called before a call runs, or
+ * with no `usd` at all it only reads the window without incrementing it.
+ * Every caller that later learns the real cost (a stream's terminal usage
+ * chunk, an audio/OCR provider response) must feed it back through here, or
+ * the budget counter never reflects what actually happened and a hard cap
+ * only ever throttles requests, never spend. Swallows its own errors — same
+ * failure mode as `checkBudget`'s window-read errors — because a settlement
+ * failure must never surface as a user-facing error on a call that already
+ * completed and was already billed by the provider.
+ */
+export async function settleUsageBudget(
+  context: QuotaContext,
+  cost: { currency: string; totalCost: number },
+): Promise<void> {
+  if (cost.currency !== 'USD' || !Number.isFinite(cost.totalCost) || cost.totalCost <= 0) {
+    return;
+  }
+  try {
+    await checkBudget(context, { usd: cost.totalCost });
+  } catch (error) {
+    logger.error('Failed to settle realized budget usage', { error });
+  }
+}
+
 export async function checkBudget(
   context: QuotaContext,
   cost: { usd?: number } = {},

--- a/src/lib/services/models/inferenceService.ts
+++ b/src/lib/services/models/inferenceService.ts
@@ -46,7 +46,7 @@ import {
 
 export { OutputTokenLimitError } from './openaiErrors';
 
-import { logModelUsage, TokenUsage } from './usageLogger';
+import { calculateCost, logModelUsage, TokenUsage, UsageCostResult } from './usageLogger';
 import {
   MAX_ROUTING_DEPTH,
   buildDeciderMessages,
@@ -1264,8 +1264,9 @@ async function resolveDynamicCompletion(args: {
   router: IModel;
   config: IDynamicRoutingConfig;
   depth: number;
+  onUsageSettled?: (cost: UsageCostResult) => void;
 }): Promise<ChatCompletionOutcome> {
-  const { tenantDbName, tenantId, projectId, body, stream, router, config, depth } = args;
+  const { tenantDbName, tenantId, projectId, body, stream, router, config, depth, onUsageSettled } = args;
   const start = Date.now();
   const routerRequestId =
     typeof body.request_id === 'string' && body.request_id.length > 0
@@ -1337,6 +1338,7 @@ async function resolveDynamicCompletion(args: {
       body,
       stream,
       _routingDepth: depth + 1,
+      onUsageSettled,
     });
 
   const buildRouting = (
@@ -1453,8 +1455,21 @@ export async function handleChatCompletion(params: {
   stream?: boolean;
   /** Internal: recursion depth when a Dynamic LLM resolves to another model. */
   _routingDepth?: number;
+  /**
+   * Called with the REALIZED cost of this call, once usage is known — for a
+   * streaming response that is long after this function has already returned
+   * the (still-open) stream to the caller. That's the only reason this
+   * exists: the caller's `quotaContext` (license type, token id, per-user vs
+   * per-tenant budget key) isn't reconstructible from inside this module, but
+   * a plain closure over it costs the caller nothing to provide. Computed
+   * here (not by the caller) so a Dynamic LLM child model's own pricing is
+   * always what gets charged, never the router's. Fires for success and for
+   * a cancelled stream with partial usage (the provider still billed for
+   * those tokens); never for a request that produced no usage at all.
+   */
+  onUsageSettled?: (cost: UsageCostResult) => void;
 }): Promise<ChatCompletionOutcome> {
-  const { tenantDbName, tenantId, modelKey, projectId, stream } = params;
+  const { tenantDbName, tenantId, modelKey, projectId, stream, onUsageSettled } = params;
   let { body } = params;
 
   if (!Array.isArray(body?.messages)) {
@@ -1491,6 +1506,7 @@ export async function handleChatCompletion(params: {
       router: model,
       config: dynamicConfig,
       depth,
+      onUsageSettled,
     });
   }
 
@@ -2192,6 +2208,8 @@ export async function handleChatCompletion(params: {
             ? aggregatedChunk
             : { tool_calls: toolCalls };
 
+          onUsageSettled?.(calculateCost(model.pricing, usage));
+
           fireAndForget('log-stream-usage', () =>
             logModelUsage(tenantDbName, model, {
               requestId,
@@ -2232,6 +2250,8 @@ export async function handleChatCompletion(params: {
           // the error rate rose, alerting fired, and the tokens the provider
           // had already generated (and bills us for) were written as zero.
           if (abortController.signal.aborted) {
+            const cancelledUsage = partialUsageOnCancel();
+            onUsageSettled?.(calculateCost(model.pricing, cancelledUsage));
             fireAndForget('log-stream-cancelled', () =>
               logModelUsage(tenantDbName, model, {
                 requestId,
@@ -2249,7 +2269,7 @@ export async function handleChatCompletion(params: {
                   ...(lastUsage ? {} : { output_tokens_estimated: true }),
                 }),
                 latencyMs,
-                usage: partialUsageOnCancel(),
+                usage: cancelledUsage,
               }),
             );
             auditStreamedOutput('chat.completions:stream:cancelled');
@@ -2358,6 +2378,8 @@ export async function handleChatCompletion(params: {
   if (toolCallCount) {
     usage.toolCalls = toolCallCount;
   }
+
+  onUsageSettled?.(calculateCost(model.pricing, usage));
 
   fireAndForget('log-chat-usage', () =>
     logModelUsage(tenantDbName, model, {
@@ -2702,6 +2724,11 @@ export async function handleTranscriptionRequest(params: {
       usage: result.usage,
     },
     rawUsage: result.usage,
+    // The normalized usage this function itself billed against above — the
+    // one a caller needs to settle a budget with the same numbers that went
+    // into the usage-log row, not the provider's raw (differently-shaped)
+    // usage object.
+    usage,
     latencyMs,
     requestId,
     model,
@@ -2751,6 +2778,14 @@ export async function handleSpeechRequest(params: {
 
   const latencyMs = Date.now() - start;
 
+  const usage: TokenUsage = {
+    inputTokens: 0,
+    outputTokens: 0,
+    totalTokens: 0,
+    inputCharacters: result.usage?.inputCharacters ?? input.text.length,
+    outputSeconds: result.usage?.outputSeconds,
+  };
+
   fireAndForget('log-tts-usage', () =>
     logModelUsage(tenantDbName, model, {
       requestId,
@@ -2769,13 +2804,7 @@ export async function handleSpeechRequest(params: {
         audioBytes: result.audio.byteLength,
       }),
       latencyMs,
-      usage: {
-        inputTokens: 0,
-        outputTokens: 0,
-        totalTokens: 0,
-        inputCharacters: result.usage?.inputCharacters ?? input.text.length,
-        outputSeconds: result.usage?.outputSeconds,
-      },
+      usage,
     }),
   );
 
@@ -2783,7 +2812,10 @@ export async function handleSpeechRequest(params: {
     audio: result.audio,
     contentType: result.contentType,
     format: result.format,
-    usage: result.usage,
+    rawUsage: result.usage,
+    // The normalized usage this function itself billed against above — see
+    // the matching comment on handleTranscriptionRequest's return.
+    usage,
     latencyMs,
     requestId,
     model,
@@ -3064,6 +3096,9 @@ export async function handleOcrRequest(params: {
       invokedVia: result.invokedVia ?? mode,
       usage: result.usage,
     },
+    // The normalized usage this function itself billed against above — see
+    // the matching comment on handleTranscriptionRequest's return.
+    usage,
     latencyMs,
     requestId,
     model,

--- a/src/server/api/plugins/client-audio-ocr.ts
+++ b/src/server/api/plugins/client-audio-ocr.ts
@@ -10,11 +10,13 @@ import {
 } from '@/lib/services/models/inferenceService';
 import { getModelByKey } from '@/lib/services/models/modelService';
 import { normalizeInferenceError } from '@/lib/services/models/openaiErrors';
-import { logModelUsage } from '@/lib/services/models/usageLogger';
+import { calculateCost, logModelUsage } from '@/lib/services/models/usageLogger';
 import {
   checkBudget,
   checkPerRequestLimits,
   checkRateLimit,
+  settleUsageBudget,
+  type QuotaContext,
 } from '@/lib/quota/quotaGuard';
 import { readJsonBody, withOpenAiApiRequestContext } from '../fastify-utils';
 import type {
@@ -302,9 +304,9 @@ async function runQuotaGuard(
   auth: ApiTokenContext,
   domain: 'stt' | 'tts' | 'ocr',
   modelKey: string,
-): Promise<string | null> {
+): Promise<{ ctx: QuotaContext; error: string | null }> {
   const tokenId = auth.tokenRecord._id?.toString() ?? auth.token;
-  const ctx = {
+  const ctx: QuotaContext = {
     tenantDbName: auth.tenantDbName,
     tenantId: auth.tenantId,
     projectId: auth.projectId,
@@ -316,15 +318,31 @@ async function runQuotaGuard(
   };
 
   const perRequest = await checkPerRequestLimits(ctx, {});
-  if (!perRequest.allowed) return perRequest.reason || 'Quota exceeded';
+  if (!perRequest.allowed) return { ctx, error: perRequest.reason || 'Quota exceeded' };
 
   const rate = await checkRateLimit(ctx, { requests: 1 });
-  if (!rate.allowed) return rate.reason || 'Rate limit exceeded';
+  if (!rate.allowed) return { ctx, error: rate.reason || 'Rate limit exceeded' };
 
   const budget = await checkBudget(ctx);
-  if (!budget.allowed) return budget.reason || 'Budget exceeded';
+  if (!budget.allowed) return { ctx, error: budget.reason || 'Budget exceeded' };
 
-  return null;
+  return { ctx, error: null };
+}
+
+/**
+ * Debit the budget window with what this call actually cost, once usage is
+ * known. `runQuotaGuard`'s `checkBudget(ctx)` above is a pre-flight-only
+ * read (no `usd` given, so it never increments) — nothing after it settled
+ * the realized cost, so the budget window tracked zero spend for every
+ * transcription/translation/speech/OCR call regardless of usage. See the
+ * 2026-09-05 assessment, F-05.
+ */
+function settleAudioOcrUsage(
+  ctx: QuotaContext,
+  pricing: Parameters<typeof calculateCost>[0],
+  usage: Parameters<typeof calculateCost>[1],
+): void {
+  void settleUsageBudget(ctx, calculateCost(pricing, usage));
 }
 
 export const clientAudioOcrApiPlugin: FastifyPluginAsync = async (app) => {
@@ -338,7 +356,7 @@ export const clientAudioOcrApiPlugin: FastifyPluginAsync = async (app) => {
         const parsed = await buildSttInput(request);
         modelKey = parsed.modelKey;
 
-        const quotaError = await runQuotaGuard(auth, 'stt', modelKey);
+        const { ctx: quotaContext, error: quotaError } = await runQuotaGuard(auth, 'stt', modelKey);
         if (quotaError) return reply.code(429).send(quotaExceededPayload(quotaError));
 
         const result = await handleTranscriptionRequest({
@@ -347,6 +365,8 @@ export const clientAudioOcrApiPlugin: FastifyPluginAsync = async (app) => {
           projectId: auth.projectId,
           input: parsed.input,
         });
+
+        settleAudioOcrUsage(quotaContext, result.model.pricing, result.usage);
 
         return reply.code(200).send({ ...result.response, request_id: result.requestId });
       } catch (error) {
@@ -387,7 +407,7 @@ export const clientAudioOcrApiPlugin: FastifyPluginAsync = async (app) => {
         const parsed = await buildSttInput(request);
         modelKey = parsed.modelKey;
 
-        const quotaError = await runQuotaGuard(auth, 'stt', modelKey);
+        const { ctx: quotaContext, error: quotaError } = await runQuotaGuard(auth, 'stt', modelKey);
         if (quotaError) return reply.code(429).send(quotaExceededPayload(quotaError));
 
         const translateInput: SttTranslateInput = {
@@ -404,6 +424,8 @@ export const clientAudioOcrApiPlugin: FastifyPluginAsync = async (app) => {
           input: translateInput as SttTranscribeInput,
           translate: true,
         });
+
+        settleAudioOcrUsage(quotaContext, result.model.pricing, result.usage);
 
         return reply.code(200).send({ ...result.response, request_id: result.requestId });
       } catch (error) {
@@ -480,7 +502,7 @@ export const clientAudioOcrApiPlugin: FastifyPluginAsync = async (app) => {
             typeof body.instructions === 'string' ? body.instructions : undefined,
         };
 
-        const quotaError = await runQuotaGuard(auth, 'tts', modelKey);
+        const { ctx: quotaContext, error: quotaError } = await runQuotaGuard(auth, 'tts', modelKey);
         if (quotaError) return reply.code(429).send(quotaExceededPayload(quotaError));
 
         const result = await handleSpeechRequest({
@@ -489,6 +511,8 @@ export const clientAudioOcrApiPlugin: FastifyPluginAsync = async (app) => {
           projectId: auth.projectId,
           input,
         });
+
+        settleAudioOcrUsage(quotaContext, result.model.pricing, result.usage);
 
         reply.raw.setHeader('Content-Type', result.contentType);
         reply.raw.setHeader('Content-Length', String(result.audio.byteLength));
@@ -532,7 +556,7 @@ export const clientAudioOcrApiPlugin: FastifyPluginAsync = async (app) => {
         const parsed = await buildOcrInput(request);
         modelKey = parsed.modelKey;
 
-        const quotaError = await runQuotaGuard(auth, 'ocr', modelKey);
+        const { ctx: quotaContext, error: quotaError } = await runQuotaGuard(auth, 'ocr', modelKey);
         if (quotaError) return reply.code(429).send(quotaExceededPayload(quotaError));
 
         const result = await handleOcrRequest({
@@ -541,6 +565,8 @@ export const clientAudioOcrApiPlugin: FastifyPluginAsync = async (app) => {
           projectId: auth.projectId,
           input: parsed.input,
         });
+
+        settleAudioOcrUsage(quotaContext, result.model.pricing, result.usage);
 
         return reply.code(200).send({ ...result.response, request_id: result.requestId });
       } catch (error) {

--- a/src/server/api/plugins/client-inference.ts
+++ b/src/server/api/plugins/client-inference.ts
@@ -20,6 +20,7 @@ import {
   checkBudget,
   checkPerRequestLimits,
   checkRateLimit,
+  settleUsageBudget,
 } from '@/lib/quota/quotaGuard';
 import {
   anthropicErrorBody,
@@ -246,6 +247,16 @@ export const clientInferenceApiPlugin: FastifyPluginAsync = async (app) => {
         stream: Boolean(body.stream),
         tenantDbName: auth.tenantDbName,
         tenantId: auth.tenantId,
+        // Settling here (rather than after the call returns, as before) is
+        // what makes this work for BOTH stream and non-stream: a streamed
+        // response's real usage isn't known until long after this function
+        // has already returned the still-open stream below, so a post-hoc
+        // `if (result.usage)` check here silently never fired for it — the
+        // budget counter never debited a single streamed request. See the
+        // 2026-09-05 assessment, F-05.
+        onUsageSettled: (cost) => {
+          void settleUsageBudget(quotaContext, cost);
+        },
       });
 
       const actualOutputTokens = result.usage?.outputTokens || 0;
@@ -253,28 +264,6 @@ export const clientInferenceApiPlugin: FastifyPluginAsync = async (app) => {
         void checkRateLimit(quotaContext, { tokens: actualOutputTokens }).catch((error) =>
           logger.error('Failed to update chat rate limit usage', { error }),
         );
-      }
-
-      if (result.usage) {
-        const usage = result.usage;
-        void getModelByKey(auth.tenantDbName, modelKey, auth.projectId)
-          .then((model) => {
-            if (!model) {
-              return undefined;
-            }
-
-            const cost = calculateCost(model.pricing, usage);
-            if (
-              cost.currency !== 'USD'
-              || !Number.isFinite(cost.totalCost)
-              || cost.totalCost <= 0
-            ) {
-              return undefined;
-            }
-
-            return checkBudget(quotaContext, { usd: cost.totalCost });
-          })
-          .catch((error) => logger.error('Failed to update chat budget usage', { error }));
       }
 
       if (result.stream) {


### PR DESCRIPTION
## Summary

Finance-institution assessment finding F-05: chat completions only debited a
tenant's budget counter from the **non-streaming** branch, using
`result.usage` after `handleChatCompletion` returned — a field a streaming
outcome never carries, since real usage isn't known until the stream
(already handed back to the caller) finishes. A tenant on a hard
daily/monthly USD cap could stream past it indefinitely; the counter never
moved. Verification during this fix also confirmed every audio/OCR route
(transcriptions, translations, speech, OCR) has the same underlying gap: they
only ever call `checkBudget(ctx)` with no `usd` (a pre-flight-only read that
never increments) and nothing afterward feeds back the realized cost, so
those routes never debit the budget counter **at all**, regardless of usage.

- `quotaGuard.ts`: new `settleUsageBudget(context, cost)` — skips
  non-USD/zero/negative cost, otherwise delegates to the existing
  `checkBudget(context, { usd })`; swallows its own errors (a settlement
  failure must never surface on a call that already completed and was
  already billed by the provider).
- `handleChatCompletion` gains an optional `onUsageSettled(cost)` callback,
  invoked with `calculateCost(model.pricing, usage)` computed at the model
  actually in scope — the stream's success and cancelled-with-partial-usage
  branches, the non-streaming branch, and threaded through Dynamic LLM
  routing's `runChild` recursion so a routed **child** model's own pricing is
  what gets charged, never the router's (a latent bug in the old
  post-hoc computation, which always re-fetched by the originally-requested
  key).
- `client-inference.ts`'s chat-completions route passes this callback
  instead of its old post-hoc `if (result.usage) {...}` block — one code
  path now covers both stream and non-stream.
- `client-audio-ocr.ts`'s four routes now return the normalized usage from
  their handlers (`handleTranscriptionRequest`/`handleSpeechRequest`/
  `handleOcrRequest`) and settle right after each success.

## Explicitly out of scope

Matches the assessment's own phasing — "F-04/05 maliyet defteri ilk sürüm"
is listed as its own first-30-days milestone, not a drop-in patch:

- In-flight reservation / hold-then-settle accounting. This closes the
  "never settled at all" gap; a request can still race past a limit between
  its pre-flight check and this settlement (the same TOCTOU the assessment
  flags for EE's `chargeBudget`).
- console-ee's App Gateway `limits.ts` post-hoc `chargeBudget` design and its
  `CACHE_PROVIDER=none`/observability-off budget weakening — a separate
  overlay codebase, its own PR.
- `checkRateLimit`'s equivalent post-hoc gap for streaming output tokens
  (`actualOutputTokens` in `client-inference.ts`) — a rate-limit, not a
  budget/dollar, concern; untouched here.
- The dashboard playground's transcription/speech/OCR routes — internal,
  session-authenticated tooling with no budget check at all today, a
  different surface than the assessment's `/client/v1/*` scope.

## Test plan

- `inference-service.test.ts`: 3 new tests — streaming success settles with
  `calculateCost(model.pricing, usage)`; a cancelled stream settles the
  partial (non-zero) usage the provider still billed for; a non-streaming
  completion settles too. All 3 manually verified to fail when the
  corresponding `onUsageSettled?.(...)` call is reverted.
- `client-inference-fastify.test.ts`: 3 new route-level tests against the
  live `clientInferenceApiPlugin` — settles for a streamed response, settles
  for a non-streaming response, and does NOT settle when usage produced no
  billable cost. Manually verified to fail when the route stops passing
  `onUsageSettled` into `handleChatCompletion`.
- `npx tsc --noEmit` clean; `npx eslint` clean on all changed files.
- Full `npx vitest run`: 5052 passed, 5 skipped, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KQq6TnVNHRNU6Wz1eQzPpD