### PR TITLE
fix(F-07): stop swallowing audit write failures, track them separately

### DIFF
--- a/src/__tests__/unit/async-task-critical.test.ts
+++ b/src/__tests__/unit/async-task-critical.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Regression tests for F-07 (finance-institution assessment, 2026-09-05):
+ * `criticalFireAndForget` — the audit-log write path — must be visible and
+ * trackable separately from routine fire-and-forget background work
+ * (usage logging, tracing ingestion), so a failure reads as more than a
+ * dropped cache write and a shutdown drain can report an audit backlog
+ * distinctly from routine noise.
+ */
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import {
+  criticalFireAndForget,
+  drainPendingTasks,
+  fireAndForget,
+  pendingCriticalTaskCount,
+  pendingTaskCount,
+} from '@/lib/core/asyncTask';
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe('criticalFireAndForget', () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+  });
+
+  afterEach(async () => {
+    // Drain anything a test left pending so the next test starts clean —
+    // module-level Sets persist across tests in the same file.
+    await drainPendingTasks(50);
+  });
+
+  it('tracks pending critical tasks separately from routine ones', async () => {
+    const critical = deferred<void>();
+    const routine = deferred<void>();
+
+    criticalFireAndForget('audit-write', () => critical.promise);
+    fireAndForget('usage-log', () => routine.promise);
+
+    expect(pendingCriticalTaskCount()).toBe(1);
+    expect(pendingTaskCount()).toBe(1);
+
+    critical.resolve();
+    routine.resolve();
+    await drainPendingTasks(50);
+
+    expect(pendingCriticalTaskCount()).toBe(0);
+    expect(pendingTaskCount()).toBe(0);
+  });
+
+  it('never lets a rejection escape to the caller', () => {
+    expect(() => {
+      criticalFireAndForget('audit-write', () => Promise.reject(new Error('db down')));
+    }).not.toThrow();
+  });
+
+  it('drainPendingTasks waits for a critical task to actually finish', async () => {
+    const critical = deferred<void>();
+    let settled = false;
+    criticalFireAndForget('audit-write', async () => {
+      await critical.promise;
+      settled = true;
+    });
+
+    const drain = drainPendingTasks(2000);
+    // Give the drain a moment to start racing, then resolve the task —
+    // the drain must not return before this happens.
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(settled).toBe(false);
+    critical.resolve();
+    await drain;
+
+    expect(settled).toBe(true);
+    expect(pendingCriticalTaskCount()).toBe(0);
+  });
+});

--- a/src/__tests__/unit/audit-service-write-failure.test.ts
+++ b/src/__tests__/unit/audit-service-write-failure.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Regression tests for F-07 (finance-institution assessment, 2026-09-05):
+ * `recordAuditLog` used to catch its own DB error and log it at `warn`,
+ * resolving normally either way — so even a caller that awaited it could
+ * never tell an audit write was lost. It must now propagate the failure so
+ * `criticalFireAndForget` (its only caller today) can log it loudly and
+ * count it against the critical pending set.
+ */
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+vi.mock('@/lib/database', () => ({ getDatabase: vi.fn() }));
+
+import { getDatabase } from '@/lib/database';
+import { recordAuditLog } from '@/lib/services/audit/auditService';
+
+describe('recordAuditLog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('propagates a DB write failure instead of swallowing it', async () => {
+    const db = {
+      switchToTenant: vi.fn().mockResolvedValue(undefined),
+      createAuditLog: vi.fn().mockRejectedValue(new Error('connection reset')),
+    };
+    (getDatabase as ReturnType<typeof vi.fn>).mockResolvedValue(db);
+
+    await expect(
+      recordAuditLog(
+        { tenantDbName: 'tenant_acme', tenantId: 'tenant-1' },
+        {
+          action: 'read',
+          actorType: 'user',
+          event: 'GET /api/client/v1/rag/docs',
+          method: 'GET',
+          outcome: 'success',
+          path: '/api/client/v1/rag/docs',
+          service: 'rag',
+          statusCode: 200,
+        },
+      ),
+    ).rejects.toThrow('connection reset');
+  });
+
+  it('still writes the row and resolves cleanly on success', async () => {
+    const db = {
+      switchToTenant: vi.fn().mockResolvedValue(undefined),
+      createAuditLog: vi.fn().mockResolvedValue({ _id: 'log-1' }),
+    };
+    (getDatabase as ReturnType<typeof vi.fn>).mockResolvedValue(db);
+
+    await recordAuditLog(
+      { tenantDbName: 'tenant_acme', tenantId: 'tenant-1' },
+      {
+        action: 'write',
+        actorType: 'user',
+        event: 'POST /api/client/v1/rag/docs',
+        method: 'POST',
+        outcome: 'success',
+        path: '/api/client/v1/rag/docs',
+        service: 'rag',
+        statusCode: 201,
+      },
+    );
+
+    expect(db.switchToTenant).toHaveBeenCalledWith('tenant_acme');
+    expect(db.createAuditLog).toHaveBeenCalledWith(
+      expect.objectContaining({ tenantId: 'tenant-1', event: 'POST /api/client/v1/rag/docs' }),
+    );
+  });
+});

--- a/src/lib/core/asyncTask.ts
+++ b/src/lib/core/asyncTask.ts
@@ -13,6 +13,18 @@
  *
  *   // In shutdown handler:
  *   await drainPendingTasks();
+ *
+ * `criticalFireAndForget` is the same non-blocking shape for work whose loss
+ * should be loud rather than routine — today, the audit log write. It is
+ * NOT durability: a lost promise on SIGKILL is lost either way, and this
+ * module cannot change that without a persisted, replayable queue (a
+ * transactional outbox), which is real, separately-scoped work. What it DOES
+ * do is stop a failure from reading exactly like a dropped cache write:
+ * logged at `error` (not `warn`) with a `critical: true` marker a log
+ * pipeline can alert on, tracked in its own pending set so shutdown drain
+ * reports a critical backlog distinctly from routine background noise, and
+ * drained before the general set so it gets first claim on the timeout
+ * budget.
  */
 
 import { createLogger } from './logger';
@@ -22,6 +34,26 @@ const log = createLogger('async-task');
 
 /** Track pending promises so we can drain on shutdown. */
 const pending = new Set<Promise<void>>();
+/** Same tracking, for `criticalFireAndForget` — reported and drained separately. */
+const criticalPending = new Set<Promise<void>>();
+
+function schedule(
+  pendingSet: Set<Promise<void>>,
+  fn: () => Promise<void>,
+  onError: (error: unknown) => void,
+): void {
+  // Reopen the caller's request context around the task so attribution
+  // (userId/apiTokenId/source) survives even if execution outlives the
+  // request's AsyncLocalStorage scope.
+  const snapshot = captureRequestContext();
+  const task = (snapshot ? runWithRequestContext(snapshot, fn) : fn())
+    .catch(onError)
+    .finally(() => {
+      pendingSet.delete(task);
+    });
+
+  pendingSet.add(task);
+}
 
 /**
  * Schedule a non-critical async operation that should not block the caller.
@@ -33,22 +65,30 @@ const pending = new Set<Promise<void>>();
  * @param fn     Async function to execute
  */
 export function fireAndForget(label: string, fn: () => Promise<void>): void {
-  // Reopen the caller's request context around the task so attribution
-  // (userId/apiTokenId/source) survives even if execution outlives the
-  // request's AsyncLocalStorage scope.
-  const snapshot = captureRequestContext();
-  const task = (snapshot ? runWithRequestContext(snapshot, fn) : fn())
-    .catch((error) => {
-      log.error(`Async task "${label}" failed`, {
-        error: error instanceof Error ? error.message : String(error),
-        stack: error instanceof Error ? error.stack : undefined,
-      });
-    })
-    .finally(() => {
-      pending.delete(task);
+  schedule(pending, fn, (error) => {
+    log.error(`Async task "${label}" failed`, {
+      error: error instanceof Error ? error.message : String(error),
+      stack: error instanceof Error ? error.stack : undefined,
     });
+  });
+}
 
-  pending.add(task);
+/**
+ * Same as `fireAndForget`, for work whose failure should stand out from
+ * routine background noise (the audit log write). See the module doc
+ * comment above for exactly what this does and does not guarantee.
+ *
+ * @param label  Short descriptive label for logging (e.g. 'api-audit-log')
+ * @param fn     Async function to execute
+ */
+export function criticalFireAndForget(label: string, fn: () => Promise<void>): void {
+  schedule(criticalPending, fn, (error) => {
+    log.error(`Critical async task "${label}" failed — record may be lost`, {
+      critical: true,
+      error: error instanceof Error ? error.message : String(error),
+      stack: error instanceof Error ? error.stack : undefined,
+    });
+  });
 }
 
 /**
@@ -58,18 +98,38 @@ export function fireAndForget(label: string, fn: () => Promise<void>): void {
  * @param timeoutMs  Maximum time to wait (default: 5000ms)
  */
 export async function drainPendingTasks(timeoutMs = 5000): Promise<void> {
-  if (pending.size === 0) return;
+  const total = pending.size + criticalPending.size;
+  if (total === 0) return;
 
-  log.info(`Draining ${pending.size} pending async task(s)…`);
+  log.info(
+    `Draining ${criticalPending.size} critical + ${pending.size} routine async task(s)…`,
+  );
 
   const deadline = new Promise<void>((resolve) => {
     const timer = setTimeout(() => {
-      log.warn(`Drain timeout (${timeoutMs}ms) — ${pending.size} task(s) still pending`);
+      if (criticalPending.size > 0) {
+        log.error(
+          `Drain timeout (${timeoutMs}ms) — ${criticalPending.size} CRITICAL task(s) `
+          + `still pending (possible audit data loss), ${pending.size} routine task(s) also pending`,
+        );
+      } else {
+        log.warn(`Drain timeout (${timeoutMs}ms) — ${pending.size} task(s) still pending`);
+      }
       resolve();
     }, timeoutMs);
     timer.unref();
   });
 
+  // Critical tasks first: on a tight timeout budget, the audit write gets the
+  // Promise.race's outcome, not whichever background task happened to be
+  // fastest — draining a shared array top-to-bottom does not change which
+  // ones actually finish (allSettled waits for all of them regardless of
+  // order), but it does mean the critical set alone decides whether that
+  // race resolves before the routine set is even added to it.
+  await Promise.race([
+    Promise.allSettled(Array.from(criticalPending)),
+    deadline,
+  ]);
   await Promise.race([
     Promise.allSettled(Array.from(pending)),
     deadline,
@@ -77,8 +137,17 @@ export async function drainPendingTasks(timeoutMs = 5000): Promise<void> {
 }
 
 /**
- * Current count of pending tasks (for monitoring / health).
+ * Current count of pending routine tasks (for monitoring / health).
  */
 export function pendingTaskCount(): number {
   return pending.size;
+}
+
+/**
+ * Current count of pending CRITICAL tasks (e.g. audit writes still in
+ * flight) — for monitoring / health / shutdown reporting, kept separate from
+ * `pendingTaskCount()` so a routine background backlog does not mask one.
+ */
+export function pendingCriticalTaskCount(): number {
+  return criticalPending.size;
 }

--- a/src/lib/core/index.ts
+++ b/src/lib/core/index.ts
@@ -44,4 +44,10 @@ export type { HealthStatus, HealthCheckResult, HealthReport, HealthCheckFn } fro
 export { runtimePool, hashCredentials } from './runtimePool';
 
 // Async Tasks
-export { fireAndForget, drainPendingTasks, pendingTaskCount } from './asyncTask';
+export {
+  fireAndForget,
+  criticalFireAndForget,
+  drainPendingTasks,
+  pendingTaskCount,
+  pendingCriticalTaskCount,
+} from './asyncTask';

--- a/src/lib/services/audit/auditService.ts
+++ b/src/lib/services/audit/auditService.ts
@@ -1,7 +1,4 @@
-import { createLogger } from '@/lib/core/logger';
 import { getDatabase, type IAuditLog } from '@/lib/database';
-
-const logger = createLogger('audit-service');
 
 export interface AuditWriteContext {
   tenantDbName: string;
@@ -10,24 +7,25 @@ export interface AuditWriteContext {
 
 export type AuditLogInput = Omit<IAuditLog, '_id' | 'createdAt' | 'tenantId'>;
 
+/**
+ * Write one audit row. Deliberately does NOT catch its own errors: a
+ * swallowed failure here used to log at `warn` and resolve normally, so even
+ * a caller that awaited this could never tell the write was lost. Letting it
+ * reject lets `criticalFireAndForget` (the caller today) log it at `error`
+ * with a `critical: true` marker and count it against the critical pending
+ * set — or lets any future caller that needs to know retry, alert, or
+ * surface the failure to the request itself.
+ */
 export async function recordAuditLog(
   context: AuditWriteContext,
   input: AuditLogInput,
 ): Promise<void> {
-  try {
-    const db = await getDatabase();
-    await db.switchToTenant(context.tenantDbName);
-    await db.createAuditLog({
-      ...input,
-      tenantId: context.tenantId,
-    });
-  } catch (error) {
-    logger.warn('Failed to write audit log', {
-      error: error instanceof Error ? error.message : String(error),
-      service: input.service,
-      event: input.event,
-    });
-  }
+  const db = await getDatabase();
+  await db.switchToTenant(context.tenantDbName);
+  await db.createAuditLog({
+    ...input,
+    tenantId: context.tenantId,
+  });
 }
 
 export interface AuditLogListFilters {

--- a/src/server/api/plugin.ts
+++ b/src/server/api/plugin.ts
@@ -13,7 +13,7 @@ import {
   setCachedEnterpriseLicense,
 } from '@/lib/license/enterprise-license-cache';
 import { TokenManager, type JWTPayload } from '@/lib/license/token-manager';
-import { fireAndForget } from '@/lib/core/asyncTask';
+import { criticalFireAndForget } from '@/lib/core/asyncTask';
 import { getPermissionServiceForPath, getRequiredPermissionLevel } from '@/lib/security/rbac';
 import { recordAuditLog } from '@/lib/services/audit';
 import { anthropicErrorBody } from '@/lib/services/models/anthropicWire';
@@ -295,7 +295,7 @@ function enqueueAuditLog(request: FastifyRequest, reply: FastifyReply): void {
     ? String(apiToken.tokenRecord._id)
     : undefined;
 
-  fireAndForget('api-audit-log', () => recordAuditLog(
+  criticalFireAndForget('api-audit-log', () => recordAuditLog(
     { tenantDbName, tenantId },
     {
       action,


### PR DESCRIPTION
## Summary

Finance-institution assessment finding F-07: the general audit hook is
fire-and-forget, and `recordAuditLog` caught its own DB error and logged it
at `warn`, resolving normally either way — so even a caller that awaited it
could never tell an audit write was lost. It was also tracked in the same
pending-task set as routine background work (usage logging, tracing
ingestion), so a shutdown drain had no way to report an audit backlog
distinctly from routine noise, and a failure read exactly like a dropped
cache write.

- `recordAuditLog` no longer catches its own error — it propagates.
- New `criticalFireAndForget` in `asyncTask.ts`: same non-blocking shape as
  `fireAndForget`, but logs a failure at `error` with a `critical: true`
  marker a log pipeline can alert on, tracks it in its own pending set
  (`pendingCriticalTaskCount()`), and `drainPendingTasks` waits on the
  critical set first so it gets priority on the shutdown timeout budget,
  logging at `error` (not `warn`) if critical tasks are still pending when
  the deadline hits.
- `plugin.ts`'s general audit hook now uses `criticalFireAndForget` instead
  of `fireAndForget`.

## Explicitly out of scope

This finding's own "Yapılmalı" (remediation) text describes a transactional
outbox, event ID/idempotency, DLQ/replay, SIEM export, and WORM/retention —
and the assessment's own roadmap places that under Phase 2 (31-60 days), not
an incremental pass like this one:

- **No durability is added.** A critical task lost to SIGKILL is still lost
  — Node cannot intercept SIGKILL, and nothing here persists a pending write
  before it completes. What changes is that the loss is loud (error-level,
  `critical: true`, counted) instead of silent.
- No DLQ/replay, no event idempotency, no SIEM forwarding, no
  WORM/immutability/retention policy.
- Successful GETs are still not audited by the general hook
  (`shouldAuditRequest` unchanged) — the assessment's own text frames
  "sensitive data reads need separate events," not blanket GET auditing,
  which is a distinct per-endpoint instrumentation effort.

## Test plan

- `audit-service-write-failure.test.ts` (2 tests): `recordAuditLog`
  propagates a DB failure instead of resolving past it; still writes and
  resolves cleanly on success. Manually verified the failure test goes red
  against the original try/catch implementation.
- `async-task-critical.test.ts` (3 tests): critical vs. routine pending
  counts stay independent; a rejection never escapes the caller;
  `drainPendingTasks` genuinely waits for a slow critical task to finish
  before returning.
- `npx tsc --noEmit` clean; `npx eslint` clean on all changed files.
- Full `npx vitest run`: 5051 passed, 5 skipped, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KQq6TnVNHRNU6Wz1eQzPpD