### PR TITLE
fix(vector): allow attaching an existing provider index instead of always creating

### DIFF
--- a/src/__tests__/integration/vector-service.test.ts
+++ b/src/__tests__/integration/vector-service.test.ts
@@ -56,6 +56,8 @@ import {
   createVectorIndex,
   queryVectorIndex,
   upsertVectors,
+  VectorAttachRequiresDetailsError,
+  VectorAttachNotFoundError,
 } from '@/lib/services/vector/vectorService';
 
 // ── Fixtures ──────────────────────────────────────────────────────────────────
@@ -263,6 +265,110 @@ describe('createVectorIndex', () => {
     await expect(
       createVectorIndex(TENANT_DB, TENANT_ID, PROJECT_ID, makeInput('bad')),
     ).rejects.toThrow(/not active/i);
+  });
+
+  it('requires dimension when creating a new index in the provider', async () => {
+    await expect(
+      createVectorIndex(TENANT_DB, TENANT_ID, PROJECT_ID, {
+        name: 'No Dimension',
+        providerKey: PROVIDER_KEY,
+        createdBy: CREATED_BY,
+      }),
+    ).rejects.toThrow(/dimension is required/i);
+  });
+});
+
+// ── createVectorIndex — attach existing (createInProvider: false) ────────────
+
+describe('createVectorIndex — attach existing', () => {
+  let db: ReturnType<typeof createMockDb>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    db = createMockDb({ findVectorIndexByKey: vi.fn().mockResolvedValue(null) });
+    (getDatabase as ReturnType<typeof vi.fn>).mockResolvedValue(db);
+    (loadProviderRuntimeData as ReturnType<typeof vi.fn>).mockResolvedValue({
+      record: MOCK_PROVIDER_RECORD,
+      credentials: MOCK_CREDENTIALS,
+    });
+    (providerRegistry.createRuntime as ReturnType<typeof vi.fn>).mockResolvedValue(MOCK_RUNTIME);
+    db.createVectorIndex.mockResolvedValue(MOCK_INDEX_RECORD);
+  });
+
+  const makeAttachInput = (overrides: Record<string, unknown> = {}) => ({
+    name: 'Existing Index',
+    providerKey: PROVIDER_KEY,
+    createdBy: CREATED_BY,
+    createInProvider: false,
+    ...overrides,
+  });
+
+  it('never calls runtime.createIndex', async () => {
+    MOCK_RUNTIME.listIndexes.mockResolvedValue([
+      { externalId: 'existing-ext', name: 'Existing Index', dimension: 768, metric: 'cosine' },
+    ]);
+
+    await createVectorIndex(TENANT_DB, TENANT_ID, PROJECT_ID, makeAttachInput());
+
+    expect(MOCK_RUNTIME.createIndex).not.toHaveBeenCalled();
+  });
+
+  it('auto-fills dimension/metric/externalId from a matching remote index', async () => {
+    MOCK_RUNTIME.listIndexes.mockResolvedValue([
+      { externalId: 'existing-ext', name: 'Existing Index', dimension: 768, metric: 'dot' },
+    ]);
+
+    await createVectorIndex(TENANT_DB, TENANT_ID, PROJECT_ID, makeAttachInput());
+
+    const createCall = db.createVectorIndex.mock.calls[0][0];
+    expect(createCall.externalId).toBe('existing-ext');
+    expect(createCall.dimension).toBe(768);
+    expect(createCall.metric).toBe('dot');
+  });
+
+  it('rejects when the caller-supplied dimension conflicts with the provider', async () => {
+    MOCK_RUNTIME.listIndexes.mockResolvedValue([
+      { externalId: 'existing-ext', name: 'Existing Index', dimension: 768, metric: 'cosine' },
+    ]);
+
+    await expect(
+      createVectorIndex(TENANT_DB, TENANT_ID, PROJECT_ID, makeAttachInput({ dimension: 1536 })),
+    ).rejects.toThrow(/dimension 768/);
+  });
+
+  it('throws VectorAttachNotFoundError when listIndexes succeeds but no match exists', async () => {
+    MOCK_RUNTIME.listIndexes.mockResolvedValue([
+      { externalId: 'other', name: 'Some Other Index', dimension: 768, metric: 'cosine' },
+    ]);
+
+    await expect(
+      createVectorIndex(TENANT_DB, TENANT_ID, PROJECT_ID, makeAttachInput()),
+    ).rejects.toThrow(VectorAttachNotFoundError);
+  });
+
+  it('throws VectorAttachRequiresDetailsError when listIndexes fails and no manual details are supplied', async () => {
+    MOCK_RUNTIME.listIndexes.mockRejectedValue(new Error('403 Forbidden'));
+
+    await expect(
+      createVectorIndex(TENANT_DB, TENANT_ID, PROJECT_ID, makeAttachInput()),
+    ).rejects.toThrow(VectorAttachRequiresDetailsError);
+  });
+
+  it('attaches using manually supplied details when listIndexes fails', async () => {
+    MOCK_RUNTIME.listIndexes.mockRejectedValue(new Error('403 Forbidden'));
+
+    await createVectorIndex(
+      TENANT_DB,
+      TENANT_ID,
+      PROJECT_ID,
+      makeAttachInput({ dimension: 1536, metric: 'cosine', externalId: 'manual-ext' }),
+    );
+
+    expect(MOCK_RUNTIME.createIndex).not.toHaveBeenCalled();
+    const createCall = db.createVectorIndex.mock.calls[0][0];
+    expect(createCall.externalId).toBe('manual-ext');
+    expect(createCall.dimension).toBe(1536);
+    expect(createCall.metric).toBe('cosine');
   });
 });
 

--- a/src/components/vector/CreateVectorIndexModal.tsx
+++ b/src/components/vector/CreateVectorIndexModal.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { NumberInput, Select, TextInput, Textarea } from '@mantine/core';
+import { NumberInput, Select, Switch, TextInput, Textarea } from '@mantine/core';
 import { useForm } from '@mantine/form';
 import { notifications } from '@mantine/notifications';
 import { IconDatabase, IconPlus } from '@tabler/icons-react';
@@ -45,6 +45,8 @@ interface FormValues {
 	metric: string;
 	description: string;
 	providerKey: string;
+	createInProvider: boolean;
+	externalId: string;
 }
 
 export default function CreateVectorIndexModal({
@@ -55,6 +57,7 @@ export default function CreateVectorIndexModal({
 }: CreateVectorIndexModalProps) {
 	const [availableProviders, setAvailableProviders] = useState<VectorProviderView[]>(providers);
 	const [submitting, setSubmitting] = useState(false);
+	const [needsManualDetails, setNeedsManualDetails] = useState(false);
 	const wasOpenedRef = useRef(false);
 
 	const form = useForm<FormValues>({
@@ -64,11 +67,15 @@ export default function CreateVectorIndexModal({
 			metric: 'cosine',
 			description: '',
 			providerKey: providers[0]?.key ?? '',
+			createInProvider: true,
+			externalId: '',
 		},
 		validate: {
 			name: (value) => (!value ? 'Name is required' : null),
-			dimension: (value) =>
-				!value || Number(value) <= 0 ? 'Dimension must be a positive number' : null,
+			dimension: (value, values) => {
+				if (!values.createInProvider) return null;
+				return !value || Number(value) <= 0 ? 'Dimension must be a positive number' : null;
+			},
 			providerKey: (value) => (!value ? 'Select a provider' : null),
 		},
 	});
@@ -95,6 +102,7 @@ export default function CreateVectorIndexModal({
 				reset();
 				setAvailableProviders(providers);
 				setFieldValue('providerKey', providers[0]?.key ?? '');
+				setNeedsManualDetails(false);
 				wasOpenedRef.current = false;
 			}
 		} else {
@@ -139,12 +147,20 @@ export default function CreateVectorIndexModal({
 
 	const validProvider = Boolean(formValues.providerKey);
 	const validIdentity = Boolean(formValues.name);
-	const validConfig = Boolean(formValues.dimension && Number(formValues.dimension) > 0 && formValues.metric);
+	const validConfig = formValues.createInProvider
+		? Boolean(formValues.dimension && Number(formValues.dimension) > 0 && formValues.metric)
+		: !needsManualDetails || Boolean(
+			formValues.dimension && Number(formValues.dimension) > 0 && formValues.metric && formValues.externalId,
+		);
 
 	const checklist = [
 		{ id: 1, label: 'Provider selected', done: validProvider },
 		{ id: 2, label: 'Name set', done: validIdentity },
-		{ id: 3, label: 'Dimension & metric configured', done: validConfig },
+		{
+			id: 3,
+			label: formValues.createInProvider ? 'Dimension & metric configured' : 'Attach details resolved',
+			done: validConfig,
+		},
 	];
 
 	const submit = async () => {
@@ -167,6 +183,15 @@ export default function CreateVectorIndexModal({
 			return;
 		}
 
+		// On the first attach attempt, send only the name and let the server try
+		// to read dimension/metric/externalId from the provider — the form's
+		// dimension/metric fields default to values the user never chose, so
+		// forwarding them here would produce false "mismatch" rejections against
+		// whatever the provider actually reports. Only once the server says it
+		// couldn't read the index (needsManualDetails) do we forward what the
+		// user filled in.
+		const sendManualDetails = values.createInProvider || needsManualDetails;
+
 		setSubmitting(true);
 		try {
 			const response = await fetch('/api/vector/indexes', {
@@ -175,26 +200,39 @@ export default function CreateVectorIndexModal({
 				body: JSON.stringify({
 					providerKey: values.providerKey,
 					name: values.name,
-					dimension: Number(values.dimension),
-					metric: values.metric,
+					createInProvider: values.createInProvider,
+					dimension: sendManualDetails && values.dimension !== '' ? Number(values.dimension) : undefined,
+					metric: sendManualDetails ? (values.metric || undefined) : undefined,
+					externalId: needsManualDetails ? (values.externalId || undefined) : undefined,
 					metadata: values.description ? { description: values.description } : undefined,
 				}),
 			});
 
 			if (!response.ok) {
-				const error = await response.json().catch(() => ({ error: 'Unknown error' }));
-				throw new Error(error.error ?? 'Failed to create index');
+				const errorBody = await response.json().catch(() => ({ error: 'Unknown error' }));
+				if (errorBody.code === 'VECTOR_ATTACH_REQUIRES_DETAILS') {
+					setNeedsManualDetails(true);
+					notifications.show({
+						color: 'yellow',
+						title: 'Provider details needed',
+						message: errorBody.error ?? 'Console could not read this index from the provider. Fill in the external ID, dimension and metric below, then try again.',
+						autoClose: 8000,
+					});
+					return;
+				}
+				throw new Error(errorBody.error ?? 'Failed to create index');
 			}
 
 			const data = await response.json();
 			notifications.show({
 				color: 'green',
-				title: 'Vector index created',
+				title: values.createInProvider ? 'Vector index created' : 'Vector index attached',
 				message: `${values.name} is ready to use.`,
 			});
 			onCreated({ index: data.index, provider });
 			onClose();
 			reset();
+			setNeedsManualDetails(false);
 		} catch (error: unknown) {
 			console.error(error);
 			notifications.show({
@@ -355,18 +393,50 @@ export default function CreateVectorIndexModal({
 			<FormSection
 				number={3}
 				title="Configuration"
-				description="Vector dimensionality and similarity metric used by this index."
+				description={
+					formValues.createInProvider
+						? 'Vector dimensionality and similarity metric used by this index.'
+						: 'Console will try to read these from the provider. Fill them in only if it can\'t.'
+				}
 				done={validConfig}
 			>
+				<FormRow cols={1}>
+					<FormField
+						label="Create index in provider"
+						hint={
+							formValues.createInProvider
+								? 'Console calls the provider to create a brand-new index. Turn this off to attach one that already exists there.'
+								: 'Console will attach an existing index instead of creating one — nothing is created on the provider.'
+						}
+					>
+						<Switch
+							checked={formValues.createInProvider}
+							onChange={(event) => {
+								setFieldValue('createInProvider', event.currentTarget.checked);
+								setNeedsManualDetails(false);
+							}}
+							label={formValues.createInProvider ? 'Create new index' : 'Attach existing index'}
+						/>
+					</FormField>
+				</FormRow>
 				<FormRow cols={2}>
-					<FormField label="Dimension" required hint="Must match the embedding model output size.">
+					<FormField
+						label="Dimension"
+						required={formValues.createInProvider || needsManualDetails}
+						optional={!formValues.createInProvider && !needsManualDetails}
+						hint="Must match the embedding model output size. Leave blank to auto-detect from the provider."
+					>
 						<NumberInput
 							placeholder="1536"
 							min={1}
 							{...form.getInputProps('dimension')}
 						/>
 					</FormField>
-					<FormField label="Metric" required>
+					<FormField
+						label="Metric"
+						required={formValues.createInProvider || needsManualDetails}
+						optional={!formValues.createInProvider && !needsManualDetails}
+					>
 						<ChipPicker<MetricValue>
 							options={metricOptions.map((opt) => ({ value: opt.value, label: opt.label }))}
 							value={formValues.metric}
@@ -374,6 +444,21 @@ export default function CreateVectorIndexModal({
 						/>
 					</FormField>
 				</FormRow>
+				{!formValues.createInProvider ? (
+					<FormRow cols={1}>
+						<FormField
+							label="External ID on provider"
+							optional={!needsManualDetails}
+							required={needsManualDetails}
+							hint="Only needed if Console can't list this provider's indexes automatically. Leave blank to try the index name."
+						>
+							<TextInput
+								placeholder={formValues.name || 'index-name-on-provider'}
+								{...form.getInputProps('externalId')}
+							/>
+						</FormField>
+					</FormRow>
+				) : null}
 			</FormSection>
 		</FormShell>
 	);

--- a/src/lib/services/vector/types.ts
+++ b/src/lib/services/vector/types.ts
@@ -16,12 +16,26 @@ export type VectorMetric = IVectorIndexRecord['metric'];
 export type VectorIndexRecord = IVectorIndexRecord;
 
 export interface CreateVectorIndexRequest
-  extends Omit<CreateVectorIndexInput, 'metric'> {
+  extends Omit<CreateVectorIndexInput, 'metric' | 'dimension'> {
   providerKey: string;
   key?: string;
+  /** Required when `createInProvider` is true (the default). */
+  dimension?: number;
   metric?: CreateVectorIndexInput['metric'];
   metadata?: Record<string, unknown>;
   createdBy: string;
+  /**
+   * When false, attach an index that already exists on the provider instead
+   * of calling `runtime.createIndex()`. Defaults to true. Attaching without a
+   * discoverable remote match requires `dimension`, `metric` and `externalId`.
+   */
+  createInProvider?: boolean;
+  /**
+   * Provider-native identifier to attach to, for providers whose external ID
+   * cannot be derived from `name` and that can't be listed to discover it
+   * (e.g. read-only credentials). Ignored when `createInProvider` is true.
+   */
+  externalId?: string;
 }
 
 export interface UpdateVectorIndexRequest {

--- a/src/lib/services/vector/vectorService.ts
+++ b/src/lib/services/vector/vectorService.ts
@@ -341,6 +341,89 @@ export async function createVectorProvider(
   return attachDriverCapabilities(provider);
 }
 
+/**
+ * Thrown by `attachExistingIndex` when the provider can't be listed (missing
+ * permission, or the driver doesn't support discovery) and the caller didn't
+ * supply enough to attach blind. The API layer maps this to a distinguishable
+ * response so the UI can prompt for the missing fields instead of failing flat.
+ */
+export class VectorAttachRequiresDetailsError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'VectorAttachRequiresDetailsError';
+  }
+}
+
+/** Thrown when the provider was listed successfully but no index with this name/externalId exists there. */
+export class VectorAttachNotFoundError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'VectorAttachNotFoundError';
+  }
+}
+
+async function attachExistingIndex(
+  runtime: VectorProviderRuntime,
+  providerKey: string,
+  request: CreateVectorIndexRequest,
+): Promise<VectorIndexHandle> {
+  const wantedExternalId = request.externalId ?? request.name;
+  let remoteIndexes: VectorIndexHandle[] | null = null;
+
+  try {
+    remoteIndexes = await runtime.listIndexes();
+  } catch (error) {
+    logger.warn('Vector attach: listIndexes failed, falling back to manual details', {
+      providerKey,
+      name: request.name,
+      error: error instanceof Error ? error.message : error,
+    });
+  }
+
+  if (remoteIndexes) {
+    const match = remoteIndexes.find(
+      (item) => item.name === request.name || item.externalId === wantedExternalId,
+    );
+
+    if (!match) {
+      throw new VectorAttachNotFoundError(
+        `No index named "${request.name}" was found on this provider. Create it there first, or enable "Create index in provider".`,
+      );
+    }
+
+    if (request.dimension !== undefined && request.dimension !== match.dimension) {
+      throw new Error(
+        `Attach failed: the provider reports dimension ${match.dimension}, but ${request.dimension} was supplied.`,
+      );
+    }
+    if (request.metric !== undefined && request.metric !== match.metric) {
+      throw new Error(
+        `Attach failed: the provider reports metric "${match.metric}", but "${request.metric}" was supplied.`,
+      );
+    }
+
+    return match;
+  }
+
+  // Couldn't list the provider at all (permission or support gap) — we cannot
+  // safely guess externalId ourselves, since adapters derive it differently
+  // (e.g. Postgres/Mongo compose it from provider settings, others echo the
+  // name back). The caller must supply the full shape.
+  if (request.dimension === undefined || !request.metric || !request.externalId) {
+    throw new VectorAttachRequiresDetailsError(
+      'Could not read this index from the provider (insufficient permission, or listing is unsupported). Provide the external ID, dimension and metric manually to attach it.',
+    );
+  }
+
+  return {
+    externalId: request.externalId,
+    name: request.name,
+    dimension: request.dimension,
+    metric: request.metric,
+    metadata: request.metadata,
+  };
+}
+
 export async function createVectorIndex(
   tenantDbName: string,
   tenantId: string,
@@ -362,15 +445,25 @@ export async function createVectorIndex(
     request.key ?? request.name,
   );
 
-  const handle = await withResilience(
-    () => runtime.createIndex({
-      name: request.name,
-      dimension: request.dimension,
-      metric: request.metric,
-      metadata: request.metadata,
-    }),
-    { key: `vector-create:${request.providerKey}` },
-  );
+  const createInProvider = request.createInProvider !== false;
+
+  let handle: VectorIndexHandle;
+  if (createInProvider) {
+    if (request.dimension === undefined) {
+      throw new Error('dimension is required to create a new index in the provider.');
+    }
+    handle = await withResilience(
+      () => runtime.createIndex({
+        name: request.name,
+        dimension: request.dimension as number,
+        metric: request.metric,
+        metadata: request.metadata,
+      }),
+      { key: `vector-create:${request.providerKey}` },
+    );
+  } else {
+    handle = await attachExistingIndex(runtime, request.providerKey, request);
+  }
 
   const metadata = composeMetadataForCreate(handle.metadata, request.metadata);
 

--- a/src/server/api/plugins/vector.ts
+++ b/src/server/api/plugins/vector.ts
@@ -26,6 +26,8 @@ import {
   listVectorMigrationLogs,
   countVectorMigrationLogs,
   getVectorIndexQueryStats,
+  VectorAttachRequiresDetailsError,
+  VectorAttachNotFoundError,
 } from '@/lib/services/vector';
 import type { VectorMetric } from '@/lib/services/vector/types';
 import type { VectorMigrationStatus } from '@/lib/database/provider/types.base';
@@ -331,12 +333,19 @@ export const vectorApiPlugin: FastifyPluginAsync = async (app) => {
         return reply.code(400).send({ error: 'providerKey and name are required' });
       }
 
-      const dimensionValue =
-        typeof body.dimension === 'number'
+      const createInProvider = body.createInProvider !== false;
+
+      let dimensionValue: number | undefined;
+      if (body.dimension !== undefined && body.dimension !== null && body.dimension !== '') {
+        dimensionValue = typeof body.dimension === 'number'
           ? body.dimension
           : Number.parseInt(String(body.dimension), 10);
+        if (!dimensionValue || Number.isNaN(dimensionValue) || dimensionValue <= 0) {
+          return reply.code(400).send({ error: 'dimension must be a positive number' });
+        }
+      }
 
-      if (!dimensionValue || Number.isNaN(dimensionValue) || dimensionValue <= 0) {
+      if (createInProvider && dimensionValue === undefined) {
         return reply.code(400).send({ error: 'dimension must be a positive number' });
       }
 
@@ -389,7 +398,9 @@ export const vectorApiPlugin: FastifyPluginAsync = async (app) => {
         projectId,
         {
           createdBy: session.userId,
+          createInProvider,
           dimension: dimensionValue,
+          externalId: typeof body.externalId === 'string' && body.externalId ? body.externalId : undefined,
           metadata: body.metadata as Record<string, unknown> | undefined,
           metric: body.metric as VectorMetric | undefined,
           name: body.name as string,
@@ -399,6 +410,12 @@ export const vectorApiPlugin: FastifyPluginAsync = async (app) => {
 
       return reply.code(201).send({ index });
     } catch (error) {
+      if (error instanceof VectorAttachRequiresDetailsError) {
+        return reply.code(422).send({ error: error.message, code: 'VECTOR_ATTACH_REQUIRES_DETAILS' });
+      }
+      if (error instanceof VectorAttachNotFoundError) {
+        return reply.code(404).send({ error: error.message, code: 'VECTOR_ATTACH_NOT_FOUND' });
+      }
       return sendProjectContextError(reply, error)
         ?? reply.code(500).send({
           error: error instanceof Error ? error.message : 'Internal server error',


### PR DESCRIPTION
## Summary
- `createVectorIndex` always called `runtime.createIndex()` unconditionally and only checked the local DB for an existing index by name — when the target index already exists on the provider (e.g. Azure AI Search) but isn't registered locally, this failed outright (409 on Azure) instead of attaching.
- Added a `createInProvider` flag (default `true`, preserves current behavior). When `false`, the service calls `runtime.listIndexes()` to auto-detect dimension/metric/externalId from the provider; if listing isn't possible (unsupported driver or insufficient credentials), it asks the caller for those details explicitly rather than guessing an adapter-specific external ID format (Postgres/Mongo compose theirs differently than Azure/Elasticsearch).
- Wired the flag through the dashboard create-index endpoint (`POST /api/vector/indexes`) and the `CreateVectorIndexModal` with a "Create index in provider" toggle; a 422 (`VECTOR_ATTACH_REQUIRES_DETAILS`) from the server reveals the manual dimension/metric/external ID fields in the UI.

## Test plan
- [x] `npx vitest run src/__tests__/integration/vector-service.test.ts` — 31/31 passing (7 new attach-path tests)
- [x] `npx vitest run` on the 8 vector-related API test files — 106/106 passing, no regressions
- [x] `npx tsc --noEmit -p .` — clean
- [x] `npx eslint` on all touched files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012EM5DsvKwsxcKBGtHitmC1