### PR TITLE
feat(crawler): manual re-sync of a job's results into Knowledge Engine

### DIFF
--- a/src/__tests__/api/crawler-routes.test.ts
+++ b/src/__tests__/api/crawler-routes.test.ts
@@ -17,6 +17,21 @@ process.env.DB_PROVIDER = 'sqlite';
 process.env.SQLITE_DATA_DIR = tmpRoot;
 process.env.MAIN_DB_NAME = 'crawler_routes_main';
 
+// Same RAG-ingest mock as the e2e suite — sync-to-rag calls into the real
+// ingest pipeline otherwise, which is out of scope for an HTTP-wire test.
+const ragIngestCalls = vi.hoisted(() => [] as Array<{ ragModuleKey: string }>);
+vi.mock('@/lib/services/rag', () => ({
+  ingestDocument: async (
+    _tenantDbName: string,
+    _tenantId: string,
+    _projectId: string | undefined,
+    request: { ragModuleKey: string },
+  ) => {
+    ragIngestCalls.push({ ragModuleKey: request.ragModuleKey });
+    return { _id: `ragdoc-${ragIngestCalls.length}`, status: 'indexed' };
+  },
+}));
+
 // Same to-markdown mock as the e2e suite — the underlying file-type CJS
 // import trips vitest's ESM resolver.
 vi.mock('@cognipeer/to-markdown', () => ({
@@ -392,4 +407,64 @@ describe('Crawler webhook HMAC secret is never returned in cleartext (CWE-201)',
     expect(afterRotate.webhook?.secret).not.toBe(NEW_WEBHOOK_SECRET);
     expect(afterRotate.webhook?.secret).not.toBe(WEBHOOK_SECRET);
   }, 30_000);
+});
+
+describe('POST /api/crawler/jobs/:jobId/sync-to-rag', () => {
+  it('backfills a completed job into a Knowledge Engine module chosen after the fact', async () => {
+    ragIngestCalls.length = 0;
+
+    const createRes = await app.inject({
+      method: 'POST',
+      url: '/api/crawler/crawlers',
+      headers: { ...REQUEST_HEADERS, 'content-type': 'application/json' },
+      payload: JSON.stringify({
+        name: 'Sync To RAG Crawler',
+        engine: 'axios',
+        maxDepth: 0,
+        maxPages: 1,
+        autoCrawl: false,
+        http: { allowPrivateNetwork: true },
+      }),
+    });
+    expect(createRes.statusCode).toBe(201);
+    const { crawler } = parseJsonBody<{ crawler: { key: string } }>(createRes.body);
+
+    // No `rag` binding at crawl time — nothing gets ingested yet.
+    const crawlRes = await app.inject({
+      method: 'POST',
+      url: `/api/crawler/crawlers/${crawler.key}/crawl`,
+      headers: { ...REQUEST_HEADERS, 'content-type': 'application/json' },
+      payload: JSON.stringify({ urls: [originUrl], mode: 'sync' }),
+    });
+    expect(crawlRes.statusCode).toBe(202);
+    const { jobId } = parseJsonBody<{ jobId: string }>(crawlRes.body);
+    expect(ragIngestCalls.length).toBe(0);
+
+    const syncRes = await app.inject({
+      method: 'POST',
+      url: `/api/crawler/jobs/${jobId}/sync-to-rag`,
+      headers: { ...REQUEST_HEADERS, 'content-type': 'application/json' },
+      payload: JSON.stringify({ ragModuleKey: 'kb-module-routes-test' }),
+    });
+    expect(syncRes.statusCode).toBe(200);
+    const summary = parseJsonBody<{
+      jobId: string; ragModuleKey: string; total: number; indexed: number; skipped: number; failed: number;
+    }>(syncRes.body);
+    expect(summary.jobId).toBe(jobId);
+    expect(summary.ragModuleKey).toBe('kb-module-routes-test');
+    expect(summary.total).toBe(1);
+    expect(summary.indexed).toBe(1);
+    expect(summary.failed).toBe(0);
+    expect(ragIngestCalls).toEqual([{ ragModuleKey: 'kb-module-routes-test' }]);
+  }, 30_000);
+
+  it('returns 404 for an unknown job id', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/crawler/jobs/does-not-exist/sync-to-rag',
+      headers: { ...REQUEST_HEADERS, 'content-type': 'application/json' },
+      payload: JSON.stringify({ ragModuleKey: 'kb-module-routes-test' }),
+    });
+    expect(res.statusCode).toBe(404);
+  });
 });

--- a/src/__tests__/integration/crawler-e2e.test.ts
+++ b/src/__tests__/integration/crawler-e2e.test.ts
@@ -84,6 +84,7 @@ import {
   runAdhocCrawl,
   runCrawler,
   startCrawlerQueueConsumer,
+  syncCrawlJobToRag,
 } from '@/lib/services/crawler';
 
 let originServer: Server;
@@ -532,5 +533,55 @@ describe('crawler e2e — RAG binding routes ingest to the tenant DB', () => {
     expect(results.length).toBe(1);
     expect(results[0]!.ragStatus).toBe('indexed');
     expect(results[0]!.ragDocumentId).toBe('ragdoc-1');
+  }, 45_000);
+});
+
+describe('crawler e2e — manual sync to Knowledge Engine (no re-crawl)', () => {
+  it('backfills already-fetched pages into a module chosen after the fact', async () => {
+    ragIngestCalls.length = 0;
+    const ctx = { tenantDbName: TENANT_DB_NAME, tenantId: TENANT_ID };
+
+    // No `rag` binding at crawl time — pages are fetched and stored, but
+    // never ingested. This is the state a user is in before deciding they
+    // now want them in a Knowledge Engine module.
+    const created = await createCrawler(ctx, {
+      name: 'Sync-later crawler',
+      seeds: [originUrl],
+      engine: 'axios',
+      maxDepth: 0,
+      maxPages: 1,
+      autoCrawl: false,
+      http: { allowPrivateNetwork: true },
+      createdBy: ACTOR,
+    });
+
+    const summary = await runCrawler(ctx, created.key, {
+      triggerActor: ACTOR,
+      trigger: 'manual',
+    });
+
+    const beforeSync = await listCrawlJobResults(ctx, summary.jobId);
+    expect(beforeSync.length).toBe(1);
+    expect(beforeSync[0]!.ragStatus).toBeUndefined();
+    expect(ragIngestCalls.length).toBe(0);
+
+    // The manual sync pushes the stored page into a module picked after the
+    // crawl — no seeds, no HTTP fetch, no `runCrawler` call involved.
+    const syncSummary = await syncCrawlJobToRag(
+      ctx,
+      summary.jobId,
+      { ragModuleKey: 'kb-module-backfilled' },
+      ACTOR,
+    );
+
+    expect(syncSummary.total).toBe(1);
+    expect(syncSummary.indexed).toBe(1);
+    expect(syncSummary.failed).toBe(0);
+    expect(ragIngestCalls.length).toBe(1);
+    expect(ragIngestCalls[0]!.ragModuleKey).toBe('kb-module-backfilled');
+
+    const afterSync = await listCrawlJobResults(ctx, summary.jobId);
+    expect(afterSync[0]!.ragStatus).toBe('indexed');
+    expect(afterSync[0]!.ragDocumentId).toBe('ragdoc-1');
   }, 45_000);
 });

--- a/src/app/dashboard/crawler/[crawlerId]/page.tsx
+++ b/src/app/dashboard/crawler/[crawlerId]/page.tsx
@@ -116,6 +116,7 @@ export default function CrawlerDetailPage() {
   const [cancelingJob, setCancelingJob] = useState(false);
   const [jobResults, setJobResults] = useState<CrawlResultView[]>([]);
   const [resultsLoading, setResultsLoading] = useState(false);
+  const [syncingToRag, setSyncingToRag] = useState(false);
   const [jobQuery, setJobQuery] = useState('');
   const [jobStatusFilter, setJobStatusFilter] = useState('all');
   const [jobTriggerFilter, setJobTriggerFilter] = useState('all');
@@ -658,6 +659,38 @@ export default function CrawlerDetailPage() {
       });
     } finally {
       setCancelingJob(false);
+    }
+  }
+
+  async function syncJobToRag(jobId: string, ragModuleKey: string) {
+    setSyncingToRag(true);
+    try {
+      const res = await fetch(`/api/crawler/jobs/${jobId}/sync-to-rag`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ ragModuleKey }),
+      });
+      if (!res.ok) {
+        const text = await res.text();
+        throw new Error(text || 'Failed to sync to Knowledge Engine');
+      }
+      const summary = await res.json();
+      notifications.show({
+        color: summary.failed > 0 ? 'orange' : 'teal',
+        title: 'Sent to Knowledge Engine',
+        message: `${summary.indexed} indexed, ${summary.skipped} skipped, ${summary.failed} failed (of ${summary.total} pages)`,
+      });
+      if (openJob?.id === jobId) {
+        await openJobModal(openJob);
+      }
+    } catch (err) {
+      notifications.show({
+        color: 'red',
+        title: 'Error',
+        message: err instanceof Error ? err.message : 'Failed',
+      });
+    } finally {
+      setSyncingToRag(false);
     }
   }
 
@@ -1406,6 +1439,10 @@ Content-Type: application/json
         loading={resultsLoading}
         canceling={cancelingJob}
         onCancel={(jobId) => void cancelJob(jobId)}
+        ragModules={ragModules}
+        defaultRagModuleKey={crawler?.rag?.ragModuleKey}
+        onSyncToRag={syncJobToRag}
+        syncingToRag={syncingToRag}
         onClose={() => {
           setOpenJob(null);
           setJobResults([]);

--- a/src/components/crawler/RunDetailModal.tsx
+++ b/src/components/crawler/RunDetailModal.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useMemo, useState } from 'react';
-import { ActionIcon, Badge, Button, Code, Loader, Modal, Tooltip } from '@mantine/core';
+import { ActionIcon, Badge, Button, Code, Loader, Modal, Select, Tooltip } from '@mantine/core';
 import { notifications } from '@mantine/notifications';
 import {
   IconAlertTriangle,
@@ -10,6 +10,7 @@ import {
   IconFile,
   IconFileText,
   IconSearch,
+  IconUpload,
   IconX,
 } from '@tabler/icons-react';
 import StatusBadge from '@/components/common/ui/StatusBadge';
@@ -22,6 +23,13 @@ interface RunDetailModalProps {
   canceling: boolean;
   onCancel: (jobId: string) => void;
   onClose: () => void;
+  /** Active Knowledge Engine modules available to push this run's pages into. */
+  ragModules: Array<{ key: string; name: string }>;
+  /** Pre-selects the crawler's currently-configured module, if any. */
+  defaultRagModuleKey?: string;
+  /** Pushes the run's already-fetched pages into the chosen module — no re-crawl. */
+  onSyncToRag: (jobId: string, ragModuleKey: string) => Promise<void>;
+  syncingToRag: boolean;
 }
 
 const TYPE_META: Record<
@@ -54,11 +62,16 @@ export default function RunDetailModal({
   canceling,
   onCancel,
   onClose,
+  ragModules,
+  defaultRagModuleKey,
+  onSyncToRag,
+  syncingToRag,
 }: RunDetailModalProps) {
   const [query, setQuery] = useState('');
   const [typeFilter, setTypeFilter] = useState<'all' | 'html' | 'file' | 'error'>('all');
   const [ragFilter, setRagFilter] = useState<'all' | 'indexed' | 'pending' | 'skipped' | 'failed' | 'none'>('all');
   const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [syncModuleKey, setSyncModuleKey] = useState<string | null>(null);
 
   // Reset transient view state whenever a different job is opened.
   useEffect(() => {
@@ -66,7 +79,8 @@ export default function RunDetailModal({
     setTypeFilter('all');
     setRagFilter('all');
     setSelectedId(null);
-  }, [job?.id]);
+    setSyncModuleKey(defaultRagModuleKey || null);
+  }, [job?.id, defaultRagModuleKey]);
 
   const counts = useMemo(() => {
     let html = 0;
@@ -113,6 +127,12 @@ export default function RunDetailModal({
   );
 
   const active = job?.status === 'queued' || job?.status === 'running';
+  const hasFetchablePages = counts.html + counts.file > 0;
+
+  const handleSync = async () => {
+    if (!job || !syncModuleKey) return;
+    await onSyncToRag(job.id, syncModuleKey);
+  };
 
   const copyBody = async (text: string) => {
     try {
@@ -166,7 +186,35 @@ export default function RunDetailModal({
                 {job.startedAt ? ` · started ${new Date(job.startedAt).toLocaleString()}` : ''}
               </div>
             </div>
-            <div className="ds-row ds-gap-sm">
+            <div className="ds-row ds-gap-sm" style={{ alignItems: 'center' }}>
+              {!active && hasFetchablePages ? (
+                <>
+                  <Select
+                    size="xs"
+                    w={220}
+                    placeholder={ragModules.length === 0 ? 'No Knowledge Engine modules' : 'Choose a module'}
+                    data={ragModules.map((m) => ({ value: m.key, label: `${m.name} · ${m.key}` }))}
+                    value={syncModuleKey}
+                    onChange={setSyncModuleKey}
+                    disabled={ragModules.length === 0 || syncingToRag}
+                    searchable
+                    nothingFoundMessage="No matching modules"
+                    aria-label="Knowledge Engine module to sync into"
+                  />
+                  <Tooltip label="Push this run's already-fetched pages into the module — no re-crawl" withArrow>
+                    <Button
+                      variant="light"
+                      size="xs"
+                      leftSection={<IconUpload size={14} />}
+                      loading={syncingToRag}
+                      disabled={!syncModuleKey}
+                      onClick={() => void handleSync()}
+                    >
+                      Send to Knowledge Engine
+                    </Button>
+                  </Tooltip>
+                </>
+              ) : null}
               {active ? (
                 <Button
                   color="red"

--- a/src/lib/database/mongodb/crawler.mixin.ts
+++ b/src/lib/database/mongodb/crawler.mixin.ts
@@ -287,6 +287,26 @@ export function CrawlerMixin<TBase extends Constructor<MongoDBProviderBase>>(Bas
       }
     }
 
+    async updateCrawlResult(
+      id: string,
+      data: Partial<Pick<ICrawlResult, 'ragDocumentId' | 'ragStatus' | 'errorMessage'>>,
+    ): Promise<ICrawlResult | null> {
+      const db = this.getTenantDb();
+      const payload: Record<string, unknown> = {};
+      if (data.ragDocumentId !== undefined) payload.ragDocumentId = data.ragDocumentId;
+      if (data.ragStatus !== undefined) payload.ragStatus = data.ragStatus;
+      if (data.errorMessage !== undefined) payload.errorMessage = data.errorMessage;
+      const result = await db
+        .collection<ICrawlResult>(COLLECTIONS.crawlResults)
+        .findOneAndUpdate(
+          { _id: objectId(id) },
+          { $set: payload },
+          { returnDocument: 'after' },
+        );
+      if (!result) return null;
+      return { ...result, _id: toId(result._id) } as ICrawlResult;
+    }
+
     async countCrawlResults(jobId: string): Promise<number> {
       const db = this.getTenantDb();
       return db

--- a/src/lib/database/provider/contract.ts
+++ b/src/lib/database/provider/contract.ts
@@ -1584,6 +1584,15 @@ export interface DatabaseProvider extends EnterpriseDbMethods {
     options?: { limit?: number; skip?: number; type?: string },
   ): Promise<ICrawlResult[]>;
   findCrawlResultById(id: string): Promise<ICrawlResult | null>;
+  /**
+   * Patch a crawl result's Knowledge Engine ingest outcome. Used both by the
+   * live per-page ingest during a crawl and by a manual re-sync of a
+   * previously-fetched job's results (no re-crawl involved).
+   */
+  updateCrawlResult(
+    id: string,
+    data: Partial<Pick<ICrawlResult, 'ragDocumentId' | 'ragStatus' | 'errorMessage'>>,
+  ): Promise<ICrawlResult | null>;
   countCrawlResults(jobId: string): Promise<number>;
   /**
    * Delete all crawl results for a job. Used when an interrupted job is

--- a/src/lib/database/sqlite/crawler.mixin.ts
+++ b/src/lib/database/sqlite/crawler.mixin.ts
@@ -445,6 +445,30 @@ export function CrawlerMixin<TBase extends Constructor<SQLiteProviderBase>>(Base
       return row ? this.mapCrawlResult(row) : null;
     }
 
+    async updateCrawlResult(
+      id: string,
+      data: Partial<Pick<ICrawlResult, 'ragDocumentId' | 'ragStatus' | 'errorMessage'>>,
+    ): Promise<ICrawlResult | null> {
+      const db = this.getTenantDb();
+      const sets: string[] = [];
+      const params: Record<string, unknown> = { id };
+      if (data.ragDocumentId !== undefined) {
+        sets.push('ragDocumentId = @ragDocumentId');
+        params.ragDocumentId = data.ragDocumentId ?? null;
+      }
+      if (data.ragStatus !== undefined) {
+        sets.push('ragStatus = @ragStatus');
+        params.ragStatus = data.ragStatus ?? null;
+      }
+      if (data.errorMessage !== undefined) {
+        sets.push('errorMessage = @errorMessage');
+        params.errorMessage = data.errorMessage ?? null;
+      }
+      if (sets.length === 0) return this.findCrawlResultById(id);
+      db.prepare(`UPDATE ${TABLES.crawlResults} SET ${sets.join(', ')} WHERE id = @id`).run(params);
+      return this.findCrawlResultById(id);
+    }
+
     async countCrawlResults(jobId: string): Promise<number> {
       const db = this.getTenantDb();
       const row = db.prepare(

--- a/src/lib/services/crawler/crawlerService.ts
+++ b/src/lib/services/crawler/crawlerService.ts
@@ -21,6 +21,7 @@ import type {
 } from '@/lib/database';
 import { resolveUsageAttribution } from '@/lib/services/usage/usageEvents';
 import { crawlerEntityId } from './crawlerEntityId';
+import { ingestCrawlPage } from './crawlerRagBridge';
 import {
   maskHttpConfig,
   maskWebhookConfig,
@@ -39,6 +40,8 @@ import type {
   CrawlRunSummary,
   CrawlerView,
   RunCrawlerOptions,
+  SyncCrawlJobToRagOptions,
+  SyncCrawlJobToRagSummary,
   UpdateCrawlerInput,
 } from './types';
 
@@ -561,6 +564,68 @@ export async function getCrawlResult(
   if (!record) return null;
   if (record.jobId !== jobId) return null;
   return serializeResult(record);
+}
+
+/**
+ * Push a job's already-fetched pages into a Knowledge Engine module without
+ * re-crawling. Lets a user turn on (or repoint) RAG ingestion after the fact —
+ * e.g. after switching which module/engine a crawler feeds — and backfill it
+ * from content that's already sitting in `crawl_results`.
+ */
+export async function syncCrawlJobToRag(
+  ctx: CrawlerContext,
+  jobId: string,
+  options: SyncCrawlJobToRagOptions,
+  actor: string,
+): Promise<SyncCrawlJobToRagSummary> {
+  const job = await getCrawlJob(ctx, jobId);
+  if (!job) throw new Error(`Crawl job ${jobId} not found`);
+
+  const ragModuleKey = options.ragModuleKey ?? job.planSnapshot?.rag?.ragModuleKey;
+  if (!ragModuleKey) {
+    throw new Error('Invalid request: no Knowledge Engine module selected for this crawler or run');
+  }
+
+  const db = await withTenantDb(ctx.tenantDbName);
+  const results = await db.listCrawlResults(jobId);
+  const eligible = results.filter(
+    (r) => (r.type === 'html' || r.type === 'file') && r.bodyMarkdown && r.bodyMarkdown.trim().length > 0,
+  );
+
+  let indexed = 0;
+  let skipped = 0;
+  let failed = 0;
+
+  for (const result of eligible) {
+    const outcome = await ingestCrawlPage({
+      tenantDbName: ctx.tenantDbName,
+      tenantId: job.tenantId,
+      projectId: job.projectId,
+      rag: { enabled: true, ragModuleKey },
+      crawlerKey: job.crawlerKey,
+      jobId,
+      url: result.url,
+      title: result.title,
+      bodyMarkdown: result.bodyMarkdown ?? '',
+      depth: result.depth,
+      createdBy: actor,
+    });
+    if (outcome.ragStatus === 'indexed') indexed += 1;
+    else if (outcome.ragStatus === 'skipped') skipped += 1;
+    else failed += 1;
+
+    await db.updateCrawlResult(String(result._id), {
+      ragDocumentId: outcome.ragDocumentId,
+      ragStatus: outcome.ragStatus,
+      errorMessage: outcome.errorMessage,
+    });
+  }
+
+  logger.info('Manual Knowledge Engine sync completed', {
+    jobId, ragModuleKey, total: eligible.length, indexed, skipped, failed,
+  });
+
+  return { jobId, ragModuleKey, total: eligible.length, indexed, skipped, failed };
 }
 
 export async function cancelCrawlJob(

--- a/src/lib/services/crawler/index.ts
+++ b/src/lib/services/crawler/index.ts
@@ -11,6 +11,7 @@ export {
   getCrawlJob,
   listCrawlJobResults,
   getCrawlResult,
+  syncCrawlJobToRag,
   cancelCrawlJob,
   snapshotCrawlerPlan,
   addCrawlerUrls,
@@ -35,6 +36,7 @@ export {
   adhocCrawlInputSchema,
   crawlerUrlsBodySchema,
   crawlOnContainerSchema,
+  syncCrawlJobToRagSchema,
 } from './validation';
 export type {
   CreateCrawlerBody,
@@ -43,4 +45,5 @@ export type {
   AdhocCrawlBody,
   CrawlerUrlsBody,
   CrawlOnContainerBody,
+  SyncCrawlJobToRagBody,
 } from './validation';

--- a/src/lib/services/crawler/types.ts
+++ b/src/lib/services/crawler/types.ts
@@ -123,4 +123,18 @@ export interface CrawlRunSummary {
   status: ICrawlJob['status'];
 }
 
+export interface SyncCrawlJobToRagOptions {
+  /** Overrides the crawler's saved binding — e.g. after switching modules. */
+  ragModuleKey?: string;
+}
+
+export interface SyncCrawlJobToRagSummary {
+  jobId: string;
+  ragModuleKey: string;
+  total: number;
+  indexed: number;
+  skipped: number;
+  failed: number;
+}
+
 export type { ICrawlPlanSnapshot };

--- a/src/lib/services/crawler/validation.ts
+++ b/src/lib/services/crawler/validation.ts
@@ -160,9 +160,16 @@ export const adhocCrawlInputSchema = z.object({
   metadata: z.record(z.unknown()).optional(),
 });
 
+/** Body for `POST /crawler/jobs/:jobId/sync-to-rag`. */
+export const syncCrawlJobToRagSchema = z.object({
+  /** Overrides the crawler's saved module binding for this sync only. */
+  ragModuleKey: z.string().min(1).optional(),
+});
+
 export type CreateCrawlerBody = z.infer<typeof createCrawlerInputSchema>;
 export type UpdateCrawlerBody = z.infer<typeof updateCrawlerInputSchema>;
 export type RunCrawlerOptionsBody = z.infer<typeof runCrawlerOptionsSchema>;
 export type AdhocCrawlBody = z.infer<typeof adhocCrawlInputSchema>;
 export type CrawlerUrlsBody = z.infer<typeof crawlerUrlsBodySchema>;
 export type CrawlOnContainerBody = z.infer<typeof crawlOnContainerSchema>;
+export type SyncCrawlJobToRagBody = z.infer<typeof syncCrawlJobToRagSchema>;

--- a/src/server/api/plugins/crawler.ts
+++ b/src/server/api/plugins/crawler.ts
@@ -19,6 +19,7 @@ import {
   removeCrawlerUrls,
   runAdhocCrawl,
   runCrawler,
+  syncCrawlJobToRag,
   updateCrawler,
   createCrawlerInputSchema,
   updateCrawlerInputSchema,
@@ -26,6 +27,7 @@ import {
   adhocCrawlInputSchema,
   crawlerUrlsBodySchema,
   crawlOnContainerSchema,
+  syncCrawlJobToRagSchema,
 } from '@/lib/services/crawler';
 import {
   readJsonBody,
@@ -344,6 +346,28 @@ export const crawlerApiPlugin: FastifyPluginAsync = async (app) => {
       if (sendProjectContextError(reply, error)) return;
       logger.error('Get crawl result failed', { error });
       return reply.code(500).send({ error: 'Internal server error' });
+    }
+  }));
+
+  /** Push a job's already-fetched pages into a Knowledge Engine module
+   *  without re-crawling — e.g. after turning ingestion on, or repointing it
+   *  at a different module, once the pages are already sitting in the DB. */
+  app.post('/crawler/jobs/:jobId/sync-to-rag', withApiRequestContext(async (request, reply) => {
+    try {
+      const { projectId, session } = await requireProjectContextForRequest(request);
+      const { jobId } = request.params as { jobId: string };
+      const body = syncCrawlJobToRagSchema.parse(readJsonBody<unknown>(request) ?? {});
+      const summary = await syncCrawlJobToRag(
+        { tenantDbName: session.tenantDbName, tenantId: session.tenantId, projectId },
+        jobId,
+        { ragModuleKey: body.ragModuleKey },
+        session.userEmail ?? session.userId,
+      );
+      return reply.code(200).send(summary);
+    } catch (error) {
+      if (sendProjectContextError(reply, error)) return;
+      logger.error('Sync crawl job to Knowledge Engine failed', { error });
+      return sendError(reply, error, 'Failed to sync results to Knowledge Engine');
     }
   }));
 


### PR DESCRIPTION
## Summary
- `syncCrawlJobToRag` pushes a crawl job's already-fetched pages into a Knowledge Engine module without re-crawling — lets a user turn on (or repoint) RAG ingestion after the fact and backfill from content already sitting in `crawl_results`.
- New `POST /crawler/jobs/:jobId/sync-to-rag` endpoint, optional `ragModuleKey` override.
- Per-result `ragStatus`/`ragDocumentId`/`errorMessage` tracking (`updateCrawlResult`, both Mongo and SQLite backends).
- "Sync to Knowledge Engine" action added to the run detail modal.

## Test plan
- [x] `npx vitest run src/__tests__/integration/crawler-e2e.test.ts` — 8/8 passing (new "manual sync to Knowledge Engine" scenario included)
- [x] `npx vitest run` on unit/API crawler suites (`crawler-schedule`, `crawler-engine`, `crawler-routes`, `client-crawler-sync`) — 50/50 passing, no regressions
- [x] `npx tsc --noEmit -p .` — clean
- [x] `npx eslint` on all touched files — 0 errors (pre-existing unrelated warnings only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012EM5DsvKwsxcKBGtHitmC1