### PR TITLE
fix(browser): forward HTTP(S)_PROXY to Chromium — it doesn't read env vars

### DIFF
--- a/src/__tests__/unit/browser-proxy-config.test.ts
+++ b/src/__tests__/unit/browser-proxy-config.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Regression test for a live incident: on a network that requires an egress
+ * proxy (HTTP(S)_PROXY set, matching what stdioRunner.ts already forwards to
+ * MCP subprocesses), the crawler's axios engine worked while both the
+ * interactive Browser feature and the crawler's Playwright engine could not
+ * reach ANY external site — not just a blocked one, not even the simplest
+ * page — because chromium.launch() never received the proxy Chromium itself
+ * does not read from the environment. The only visible symptom was every
+ * page.goto() eventually hitting Playwright's own 30s timeout.
+ */
+import { afterEach, describe, expect, it } from 'vitest';
+import { resolveBrowserProxyConfig } from '@/lib/core/browserProxyConfig';
+
+const PROXY_VARS = ['HTTP_PROXY', 'http_proxy', 'HTTPS_PROXY', 'https_proxy', 'NO_PROXY', 'no_proxy'];
+
+function clearProxyEnv(): void {
+  for (const key of PROXY_VARS) delete process.env[key];
+}
+
+describe('resolveBrowserProxyConfig', () => {
+  afterEach(() => {
+    clearProxyEnv();
+  });
+
+  it('returns undefined when no proxy env var is set — unchanged default for every existing deployment', () => {
+    clearProxyEnv();
+    expect(resolveBrowserProxyConfig()).toBeUndefined();
+  });
+
+  it('prefers HTTPS_PROXY over HTTP_PROXY when both are set', () => {
+    clearProxyEnv();
+    process.env.HTTPS_PROXY = 'http://https-proxy.internal:8080';
+    process.env.HTTP_PROXY = 'http://http-proxy.internal:8080';
+    expect(resolveBrowserProxyConfig()).toEqual({ server: 'http://https-proxy.internal:8080' });
+  });
+
+  it('falls back to HTTP_PROXY when HTTPS_PROXY is not set', () => {
+    clearProxyEnv();
+    process.env.HTTP_PROXY = 'http://proxy.internal:3128';
+    expect(resolveBrowserProxyConfig()).toEqual({ server: 'http://proxy.internal:3128' });
+  });
+
+  it('honours the lowercase variants some environments set instead', () => {
+    clearProxyEnv();
+    process.env.https_proxy = 'http://lower-case-proxy.internal:8080';
+    expect(resolveBrowserProxyConfig()).toEqual({ server: 'http://lower-case-proxy.internal:8080' });
+  });
+
+  it('includes NO_PROXY as the bypass list when a proxy is configured', () => {
+    clearProxyEnv();
+    process.env.HTTPS_PROXY = 'http://proxy.internal:8080';
+    process.env.NO_PROXY = 'localhost,.internal,10.0.0.0/8';
+    expect(resolveBrowserProxyConfig()).toEqual({
+      server: 'http://proxy.internal:8080',
+      bypass: 'localhost,.internal,10.0.0.0/8',
+    });
+  });
+
+  it('omits bypass entirely when NO_PROXY is not set', () => {
+    clearProxyEnv();
+    process.env.HTTPS_PROXY = 'http://proxy.internal:8080';
+    const result = resolveBrowserProxyConfig();
+    expect(result).toEqual({ server: 'http://proxy.internal:8080' });
+    expect(result).not.toHaveProperty('bypass');
+  });
+});

--- a/src/lib/core/browserProxyConfig.ts
+++ b/src/lib/core/browserProxyConfig.ts
@@ -1,0 +1,35 @@
+/**
+ * Resolves a Playwright `proxy` launch option from the standard
+ * HTTP(S)_PROXY / NO_PROXY environment variables -- the same variables
+ * `stdioRunner.ts` already forwards to MCP subprocesses for on-prem
+ * deployments that egress through a corporate proxy.
+ *
+ * Chromium does NOT read these env vars itself. Most Node HTTP clients
+ * (axios, undici) honor them directly or through a configured agent, so on a
+ * network that requires an egress proxy, every OTHER outbound path in the
+ * same process keeps working while a headless browser launched without this
+ * silently cannot reach the public internet at all -- not even a single
+ * trivial page. The only visible symptom is `chromium.launch()`'s own
+ * connection attempts, or every subsequent `page.goto()`, eventually hitting
+ * Playwright's default timeout, with nothing that names a proxy as the cause.
+ */
+export interface BrowserProxyConfig {
+  server: string;
+  bypass?: string;
+}
+
+export function resolveBrowserProxyConfig(): BrowserProxyConfig | undefined {
+  const server =
+    process.env.HTTPS_PROXY || process.env.https_proxy
+    || process.env.HTTP_PROXY || process.env.http_proxy;
+  if (!server) return undefined;
+
+  // Playwright's `bypass` is a plain comma-separated host list; passed
+  // through as-is rather than reparsed, since NO_PROXY's own conventions
+  // (leading dots, occasional CIDR-ish entries) aren't standardized enough
+  // for any Node HTTP client to agree on either, and Playwright already
+  // tolerates the common comma-separated form.
+  const bypass = process.env.NO_PROXY || process.env.no_proxy;
+
+  return bypass ? { server, bypass } : { server };
+}

--- a/src/lib/services/browser/browserManager.ts
+++ b/src/lib/services/browser/browserManager.ts
@@ -23,6 +23,7 @@ import { lookup } from 'node:dns/promises';
 import { isIP } from 'node:net';
 import { createLogger } from '@/lib/core/logger';
 import { getConfig } from '@/lib/core/config';
+import { resolveBrowserProxyConfig } from '@/lib/core/browserProxyConfig';
 import { registerShutdownHandler } from '@/lib/core/lifecycle';
 import {
   getConcurrencyLimiter,
@@ -274,7 +275,8 @@ class BrowserManager {
       }
 
       const cfg = getConfig().browser;
-      logger.info('Launching Chromium', { headless: cfg.headless });
+      const proxy = resolveBrowserProxyConfig();
+      logger.info('Launching Chromium', { headless: cfg.headless, proxied: Boolean(proxy) });
       return chromium.launch({
         headless: cfg.headless,
         // Chromium's own setuid/user-namespace sandbox needs privileges that
@@ -284,6 +286,13 @@ class BrowserManager {
         // around the default 64MB /dev/shm in containers, which otherwise
         // crashes the renderer. Matches the crawler's playwrightFetcher.ts.
         args: ['--no-sandbox', '--disable-setuid-sandbox', '--disable-dev-shm-usage'],
+        // Chromium does not read HTTP(S)_PROXY itself, unlike axios/undici —
+        // without this, a network that requires an egress proxy leaves every
+        // browser session unable to reach anything at all (not just blocked
+        // hosts), surfacing only as a page.goto timeout with nothing naming
+        // the actual cause. A session's own `config.proxy` (below, at context
+        // creation) overrides this per-session; this is just the default.
+        ...(proxy ? { proxy } : {}),
       });
     })();
 

--- a/src/lib/services/crawler/engine/playwrightFetcher.ts
+++ b/src/lib/services/crawler/engine/playwrightFetcher.ts
@@ -8,6 +8,7 @@ import { createReadStream } from 'node:fs';
 import fs from 'node:fs/promises';
 import { chromium, type Browser, type BrowserContext, type Download, type Page } from 'playwright';
 import mime from 'mime-types';
+import { resolveBrowserProxyConfig } from '@/lib/core/browserProxyConfig';
 import { looksLikeJsShell } from './links';
 import { parseContentTypeBase } from './normalize';
 import { assertSafeUrl } from './ssrf';
@@ -54,6 +55,7 @@ export class PlaywrightSession {
     if (this.context) return;
     if (this.launching) return this.launching;
     this.launching = (async () => {
+      const proxy = resolveBrowserProxyConfig();
       this.browser = await chromium.launch({
         headless: true,
         args: [
@@ -72,6 +74,11 @@ export class PlaywrightSession {
           // behavior bundled into the default launch flags).
           '--disable-blink-features=AutomationControlled',
         ],
+        // Chromium does not read HTTP(S)_PROXY itself, unlike the axios
+        // fetcher this engine is an alternative to — on a network that
+        // requires an egress proxy, that made the axios engine work while
+        // this one silently couldn't reach anything, browser-launched or not.
+        ...(proxy ? { proxy } : {}),
       });
       this.context = await this.browser.newContext({
         userAgent: this.http.userAgent ?? DEFAULT_USER_AGENT,


### PR DESCRIPTION
## Summary

Live incident (OpenShift, egress-proxy-required network): the crawler's
`axios` engine worked fine, but the interactive Browser feature and the
crawler's own `playwright` engine could not reach ANY external site — not a
blocked one, not even `example.com`. Root cause: `chromium.launch()` never
received a proxy configuration, and Chromium does not read
`HTTP_PROXY`/`HTTPS_PROXY` from the environment the way Node's own HTTP
clients (axios, undici) do. The only visible symptom was every `page.goto()`
eventually hitting Playwright's own 30-second default timeout —
`page.goto: Timeout 30000ms exceeded` — with nothing naming a proxy as the
cause. Made worse by `browserSessionService.ts`'s failure path only ever
writing the error into the session's DB row, never `logger.error`, so it
never showed up in pod stdout/OpenShift's log view either.

`stdioRunner.ts` already forwards `HTTP_PROXY`/`HTTPS_PROXY`/`NO_PROXY` to
MCP subprocesses for exactly this kind of on-prem deployment — this was the
same gap, in the two places that launch Chromium instead.

- New `resolveBrowserProxyConfig()` (`src/lib/core/browserProxyConfig.ts`)
  reads the same env vars and returns a Playwright `proxy` option.
- Wired into `browserManager.ts` (the interactive Browser feature) and the
  crawler's `playwrightFetcher.ts`.
- A session's own explicit `config.proxy` (context-level) still overrides
  this environment-derived default (launch-level) — unchanged.
- No-op for every deployment that doesn't set a proxy env var.

## Test plan

- 6 new tests over the env-var resolution logic (HTTPS_PROXY vs HTTP_PROXY
  precedence, lowercase variants, NO_PROXY bypass, no-op when unset).
- `npx tsc --noEmit` clean; `npx eslint` clean.
- Full `npx vitest run`: 5128 passed, 5 skipped, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KQq6TnVNHRNU6Wz1eQzPpD