### PR TITLE
feat(browser): operator escape hatches for extra Chromium args + TLS bypass

### DIFF
--- a/src/__tests__/unit/browser-launch-escape-hatches.test.ts
+++ b/src/__tests__/unit/browser-launch-escape-hatches.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Regression test for the operator-controlled Chromium launch escape hatches
+ * added alongside the HTTP(S)_PROXY forwarding fix: a live incident where a
+ * network required both an egress proxy AND (suspected) a TLS-inspecting
+ * corporate proxy that Chromium has no independent way to trust, on a
+ * deployment with very limited room for iterative deploy/diagnose cycles.
+ * BROWSER_CHROMIUM_EXTRA_ARGS and BROWSER_IGNORE_CERTIFICATE_ERRORS let an
+ * operator resolve whatever their specific network needs without a code
+ * change and a new release for each one.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { getConfigSource, setConfigSource, type ConfigSource } from '@/lib/core/config';
+import { getConfig } from '@/lib/core/config';
+
+const original = getConfigSource();
+
+function sourceWith(overrides: Record<string, string>): ConfigSource {
+  return {
+    get: (key: string) => overrides[key] ?? process.env[key],
+  } as ConfigSource;
+}
+
+afterEach(() => {
+  setConfigSource(original);
+});
+
+describe('config.browser — Chromium launch escape hatches', () => {
+  it('defaults to no extra args and certificate errors NOT ignored — unchanged for every existing deployment', () => {
+    setConfigSource(sourceWith({}));
+    const cfg = getConfig().browser;
+    expect(cfg.chromiumExtraArgs).toEqual([]);
+    expect(cfg.ignoreCertificateErrors).toBe(false);
+  });
+
+  it('parses BROWSER_CHROMIUM_EXTRA_ARGS as a comma-separated list, trimmed', () => {
+    setConfigSource(sourceWith({
+      BROWSER_CHROMIUM_EXTRA_ARGS: '--proxy-bypass-list=*.internal.bank , --disable-gpu,--lang=tr',
+    }));
+    expect(getConfig().browser.chromiumExtraArgs).toEqual([
+      '--proxy-bypass-list=*.internal.bank',
+      '--disable-gpu',
+      '--lang=tr',
+    ]);
+  });
+
+  it('enables BROWSER_IGNORE_CERTIFICATE_ERRORS from a truthy value', () => {
+    setConfigSource(sourceWith({ BROWSER_IGNORE_CERTIFICATE_ERRORS: 'true' }));
+    expect(getConfig().browser.ignoreCertificateErrors).toBe(true);
+  });
+});

--- a/src/lib/core/config.ts
+++ b/src/lib/core/config.ts
@@ -233,6 +233,25 @@ export interface AppConfig {
     defaultArtifactBucketKey: string;
     /** Block localhost/private network egress from managed browser sessions. */
     blockPrivateNetwork: boolean;
+    /**
+     * Extra Chromium command-line flags, appended after the built-in
+     * `--no-sandbox`/`--disable-dev-shm-usage` set on every launch — an
+     * operator-controlled escape hatch for whatever a specific network
+     * requires (e.g. `--proxy-bypass-list=...`,
+     * `--ignore-certificate-errors-spki-list=...`) without needing a code
+     * change and a new release for each one.
+     */
+    chromiumExtraArgs: string[];
+    /**
+     * Passes `--ignore-certificate-errors` to Chromium. For networks with a
+     * TLS-inspecting corporate proxy (the browser-side equivalent of setting
+     * `NODE_EXTRA_CA_CERTS`/`NODE_TLS_REJECT_UNAUTHORIZED=0` for Node's own
+     * TLS stack, which Chromium does not read either) whose intercepting
+     * certificate Chromium has no independent way to trust. This disables
+     * certificate validation for EVERY page the managed browser navigates
+     * to — only turn it on for a network you already control end-to-end.
+     */
+    ignoreCertificateErrors: boolean;
   };
 
   outboundHttp: {
@@ -502,6 +521,8 @@ function buildConfig(source: ConfigSource): AppConfig {
       reaperIntervalMs: int(source, 'BROWSER_REAPER_INTERVAL_MS', 30 * 1000),
       defaultArtifactBucketKey: str(source, 'BROWSER_DEFAULT_ARTIFACT_BUCKET', 'browser-artifacts'),
       blockPrivateNetwork: bool(source, 'BROWSER_BLOCK_PRIVATE_NETWORK', true),
+      chromiumExtraArgs: list(source, 'BROWSER_CHROMIUM_EXTRA_ARGS', []),
+      ignoreCertificateErrors: bool(source, 'BROWSER_IGNORE_CERTIFICATE_ERRORS', false),
     },
 
     outboundHttp: {

--- a/src/lib/services/browser/browserManager.ts
+++ b/src/lib/services/browser/browserManager.ts
@@ -276,7 +276,27 @@ class BrowserManager {
 
       const cfg = getConfig().browser;
       const proxy = resolveBrowserProxyConfig();
-      logger.info('Launching Chromium', { headless: cfg.headless, proxied: Boolean(proxy) });
+      const args = [
+        '--no-sandbox',
+        '--disable-setuid-sandbox',
+        '--disable-dev-shm-usage',
+        // Operator-controlled escape hatch (BROWSER_CHROMIUM_EXTRA_ARGS) for
+        // whatever a specific network needs that isn't one of the knobs
+        // above/below — no code change or release required to add one.
+        ...cfg.chromiumExtraArgs,
+        // TLS-inspecting corporate proxies re-sign every certificate with
+        // their own CA; Chromium has no independent way to trust it the way
+        // Node's own TLS stack does via NODE_EXTRA_CA_CERTS (which Chromium
+        // also doesn't read). BROWSER_IGNORE_CERTIFICATE_ERRORS is the
+        // browser-side equivalent escape hatch — off by default.
+        ...(cfg.ignoreCertificateErrors ? ['--ignore-certificate-errors'] : []),
+      ];
+      logger.info('Launching Chromium', {
+        headless: cfg.headless,
+        proxied: Boolean(proxy),
+        extraArgs: cfg.chromiumExtraArgs.length,
+        ignoreCertificateErrors: cfg.ignoreCertificateErrors,
+      });
       return chromium.launch({
         headless: cfg.headless,
         // Chromium's own setuid/user-namespace sandbox needs privileges that
@@ -285,7 +305,7 @@ class BrowserManager {
         // Playwright's own timeout fires. --disable-dev-shm-usage works
         // around the default 64MB /dev/shm in containers, which otherwise
         // crashes the renderer. Matches the crawler's playwrightFetcher.ts.
-        args: ['--no-sandbox', '--disable-setuid-sandbox', '--disable-dev-shm-usage'],
+        args,
         // Chromium does not read HTTP(S)_PROXY itself, unlike axios/undici —
         // without this, a network that requires an egress proxy leaves every
         // browser session unable to reach anything at all (not just blocked

--- a/src/lib/services/crawler/engine/playwrightFetcher.ts
+++ b/src/lib/services/crawler/engine/playwrightFetcher.ts
@@ -8,6 +8,7 @@ import { createReadStream } from 'node:fs';
 import fs from 'node:fs/promises';
 import { chromium, type Browser, type BrowserContext, type Download, type Page } from 'playwright';
 import mime from 'mime-types';
+import { getConfig } from '@/lib/core/config';
 import { resolveBrowserProxyConfig } from '@/lib/core/browserProxyConfig';
 import { looksLikeJsShell } from './links';
 import { parseContentTypeBase } from './normalize';
@@ -56,6 +57,7 @@ export class PlaywrightSession {
     if (this.launching) return this.launching;
     this.launching = (async () => {
       const proxy = resolveBrowserProxyConfig();
+      const cfg = getConfig().browser;
       this.browser = await chromium.launch({
         headless: true,
         args: [
@@ -73,6 +75,11 @@ export class PlaywrightSession {
           // (the automation-controlled infobar / `--enable-automation`
           // behavior bundled into the default launch flags).
           '--disable-blink-features=AutomationControlled',
+          // Same operator escape hatches as the interactive Browser feature
+          // (browserManager.ts) — see BROWSER_CHROMIUM_EXTRA_ARGS /
+          // BROWSER_IGNORE_CERTIFICATE_ERRORS in config.ts.
+          ...cfg.chromiumExtraArgs,
+          ...(cfg.ignoreCertificateErrors ? ['--ignore-certificate-errors'] : []),
         ],
         // Chromium does not read HTTP(S)_PROXY itself, unlike the axios
         // fetcher this engine is an alternative to — on a network that


### PR DESCRIPTION
## Summary

Follow-up to the HTTP(S)_PROXY forwarding fix (#285), requested for a
deployment with very limited room for iterative deploy/diagnose cycles:
rather than chasing each network-specific Chromium flag with its own code
change and release, this exposes two general-purpose operator knobs.

- **`BROWSER_CHROMIUM_EXTRA_ARGS`** — comma-separated extra Chromium
  command-line flags, appended after the built-in set on every launch (both
  the interactive Browser feature and the crawler's `playwright` engine).
  Covers whatever a specific network needs next without another release.
- **`BROWSER_IGNORE_CERTIFICATE_ERRORS`** — passes `--ignore-certificate-errors`.
  For a TLS-inspecting corporate proxy that re-signs every certificate with
  its own CA — the browser-side equivalent of `NODE_EXTRA_CA_CERTS`/
  `NODE_TLS_REJECT_UNAUTHORIZED=0` for Node's own TLS stack, which Chromium
  doesn't read either. **Off by default** — disables cert validation for
  every page the managed browser navigates to when turned on, so this is an
  explicit opt-in, not a default.

Both go through `getConfig()` (typed config field, not a direct
`process.env` read in application code) and default to no-op — no behavior
change for a deployment that doesn't set either.

## Test plan

- 3 new tests: default no-op, `BROWSER_CHROMIUM_EXTRA_ARGS` CSV parsing
  (including whitespace trimming), `BROWSER_IGNORE_CERTIFICATE_ERRORS` toggle.
- `npx tsc --noEmit` clean; `npx eslint` clean.
- Full `npx vitest run`: 5131 passed, 5 skipped, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KQq6TnVNHRNU6Wz1eQzPpD