### PR TITLE
fix(logger): expand a nested Error's message/stack, not just name

### DIFF
--- a/src/__tests__/unit/logger-nested-error-expansion.test.ts
+++ b/src/__tests__/unit/logger-nested-error-expansion.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Regression test for a live incident's real root cause: `logger.error('X
+ * failed', { error })` -- the dominant error-logging pattern across this
+ * codebase -- silently dropped the error's own `message` and `stack` from
+ * every JSON log line, leaving only whatever a custom Error subclass happened
+ * to assign as an enumerable own property (e.g. Playwright's TimeoutError
+ * setting `this.name`). A plain `Error`'s `message`/`stack` are non-enumerable
+ * own properties, so `JSON.stringify` drops them with no special handling --
+ * which is exactly why pod logs showed `{"name":"TimeoutError"}` and nothing
+ * else, no matter what the underlying failure actually was.
+ *
+ * Goes through the REAL pipeline (redactSecretsFormat -> winston's own
+ * errors({stack:true}) -> json()) rather than testing a helper in isolation,
+ * because the bug was specifically about what survives to the final
+ * serialized line.
+ */
+import { describe, it, expect } from 'vitest';
+import winston from 'winston';
+import { redactSecretsFormat, SENSITIVE_KEY_PATTERN } from '@/lib/core/logger';
+
+function serialize(message: string, meta: Record<string, unknown>): Record<string, unknown> {
+  const pipeline = winston.format.combine(
+    redactSecretsFormat(),
+    winston.format.errors({ stack: true }),
+    winston.format.json(),
+  );
+  const info = pipeline.transform({ level: 'error', message, ...meta }, {}) as Record<string, unknown> | false;
+  if (!info) throw new Error('format pipeline dropped the log entry');
+  return JSON.parse((info[Symbol.for('message') as unknown as string] as string) ?? JSON.stringify(info));
+}
+
+describe('logger — nested Error expansion (redactSecretsFormat)', () => {
+  it('preserves message and stack for an Error nested in metadata, not just name', () => {
+    const error = new (class extends Error {
+      constructor(message: string) {
+        super(message);
+        this.name = 'TimeoutError'; // matches Playwright's own error classes
+      }
+    })('page.screenshot: Timeout 5000ms exceeded.');
+
+    const line = serialize('Live screenshot failed', { error });
+
+    const logged = line.error as Record<string, unknown>;
+    expect(logged.name).toBe('TimeoutError');
+    expect(logged.message).toBe('page.screenshot: Timeout 5000ms exceeded.');
+    expect(typeof logged.stack).toBe('string');
+    expect((logged.stack as string).length).toBeGreaterThan(0);
+  });
+
+  it('still redacts a sensitive-named property carried on a custom Error subclass', () => {
+    const error = new (class extends Error {
+      apiKey = 'sk-should-never-appear-in-logs';
+      constructor() {
+        super('request failed');
+        this.name = 'UpstreamError';
+      }
+    })();
+
+    const line = serialize('Upstream call failed', { error });
+    const logged = line.error as Record<string, unknown>;
+    expect(logged.message).toBe('request failed');
+    expect(logged.apiKey).toBe('[REDACTED]');
+  });
+
+  it('does not affect a plain (non-Error) metadata object', () => {
+    const line = serialize('Something happened', { count: 3, ok: true });
+    expect(line.count).toBe(3);
+    expect(line.ok).toBe(true);
+  });
+});
+
+// Sanity check the pattern itself still exists, so this test would fail loudly
+// if the sensitive-key regex it exercises above is ever renamed.
+describe('SENSITIVE_KEY_PATTERN sanity', () => {
+  it('matches apiKey', () => {
+    expect(SENSITIVE_KEY_PATTERN.test('apiKey')).toBe(true);
+  });
+});

--- a/src/lib/core/logger.ts
+++ b/src/lib/core/logger.ts
@@ -58,9 +58,33 @@ function redactValue(value: unknown, depth: number, seen: WeakSet<object>): unkn
     return value.map((item) => redactValue(item, depth + 1, seen));
   }
 
-  // Preserve Error / Date / Buffer instances as-is.
-  if (value instanceof Error || value instanceof Date || Buffer.isBuffer(value)) {
+  if (value instanceof Date || Buffer.isBuffer(value)) {
     return value;
+  }
+
+  // `winston.format.errors({ stack: true })` below only expands an Error
+  // passed as the log call's own top-level message/splat -- it never looks
+  // inside a metadata property. `logger.error('X failed', { error })`, the
+  // dominant pattern across this codebase, buries the Error one level down,
+  // so it reaches here unexpanded and then hits `winston.format.json()`:
+  // `message` and `stack` are non-enumerable own properties on a plain
+  // `Error`, so a bare `JSON.stringify` drops both and keeps only whatever a
+  // custom subclass explicitly assigned as an enumerable own property (e.g.
+  // Playwright's TimeoutError setting `this.name`) -- which is exactly why
+  // these logs showed `{"name":"TimeoutError"}` and nothing else. Expand it
+  // into a plain object instead of returning it as-is, so every one of those
+  // call sites actually logs what it was written to log.
+  if (value instanceof Error) {
+    const expanded: Record<string, unknown> = {
+      name: value.name,
+      message: value.message,
+      stack: value.stack,
+    };
+    for (const [k, v] of Object.entries(value as unknown as Record<string, unknown>)) {
+      if (k === 'name' || k === 'message' || k === 'stack') continue;
+      expanded[k] = SENSITIVE_KEY_PATTERN.test(k) ? REDACTED : redactValue(v, depth + 1, seen);
+    }
+    return expanded;
   }
 
   const out: Record<string, unknown> = {};
@@ -74,7 +98,8 @@ function redactValue(value: unknown, depth: number, seen: WeakSet<object>): unkn
   return out;
 }
 
-const redactSecretsFormat = winston.format((info) => {
+/** Exported for direct testing of the actual serialization pipeline. */
+export const redactSecretsFormat = winston.format((info) => {
   for (const key of Object.keys(info)) {
     // Skip Winston's well-known structural fields.
     if (key === 'level' || key === 'message' || key === 'timestamp' || key === 'scope') continue;


### PR DESCRIPTION
## Summary

Live incident: pod logs for a repeatedly-failing operation showed only
`{"name":"TimeoutError"}` — nothing else, no matter which call was actually
failing. Root cause: `winston.format.errors({ stack: true })` only expands
an Error passed as the log call's own top-level message/splat. It never
looks inside a metadata property, and `logger.error('X failed', { error })`
— the dominant error-logging pattern across this entire codebase — buries
the Error one level down in exactly that way. A plain Error's
`message`/`stack` are non-enumerable own properties, so a bare
`JSON.stringify` (winston's `json()` formatter) drops both silently and
keeps only whatever a custom subclass happened to assign as an enumerable
own property via `this.name = ...` (which is exactly what Playwright's own
error classes, among many others, do). Every one of those log sites has
been logging next to nothing for exactly this reason.

`redactValue()` (used by `redactSecretsFormat`, upstream of winston's own
`errors()` format and `json()` in the pipeline) now expands an `Error`
instance into a plain object carrying `name`/`message`/`stack` plus any
other own enumerable properties a subclass added, redacting sensitive key
names on those extra properties the same way it already does for every
other nested object.

Exports `redactSecretsFormat` (previously module-private) so this can be
tested against the real pipeline (`redactSecretsFormat` -> winston's
`errors()` -> `json()`) rather than a helper in isolation, since the bug was
specifically about what survives to the final serialized line.

## Test plan

- 4 new tests: message/stack now present on a nested custom Error, a
  sensitive-named property on an Error subclass still redacts, plain
  non-Error metadata is unaffected, sanity check on the redaction pattern.
- Manually verified the first two fail (`TypeError: not a function`, since
  the export didn't exist) against the pre-fix code.
- Full suite: 5135 passed, 5 skipped, 0 failed; `tsc` + `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KQq6TnVNHRNU6Wz1eQzPpD