### PR TITLE
fix(browser): domcontentloaded default, best-effort snapshot, proxy for fetch(), OpenShift cache perms

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,7 +77,17 @@ COPY --from=builder /app/mail-templates ./mail-templates
 
 
 RUN mkdir -p /app/.next/cache/images && \
-    chown -R node:node /app
+    chown -R node:node /app && \
+    # OpenShift's default restricted SCC ignores the image's USER/UID and
+    # runs the container as an arbitrary, unpredictable UID instead — but
+    # that UID is always a member of GID 0. `chown node:node` alone leaves
+    # Next's own runtime writes (ISR/data cache, on-demand image
+    # optimization writing into .next/cache/images) failing EACCES on
+    # OpenShift even though the very same image runs fine on plain Docker
+    # or Kubernetes without that SCC. Group-write + GID 0 makes it work
+    # under both.
+    chgrp -R 0 /app/.next/cache && \
+    chmod -R g=u /app/.next/cache
 
 USER node
 

--- a/src/__tests__/integration/browser-diagnostics-defaults.test.ts
+++ b/src/__tests__/integration/browser-diagnostics-defaults.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Regression tests for two defects found diagnosing a live incident where a
+ * page loaded successfully but consistently past any reasonable navigation
+ * timeout, and the failed action's result gave no hint the page had loaded
+ * at all:
+ *
+ *  - `goto`'s default `waitUntil` was Playwright's own default, `'load'`,
+ *    which waits for every last subresource (trackers, fonts, third-party
+ *    widgets) — a single slow or hanging one blocks navigation forever, even
+ *    though the DOM the caller actually wants was ready long before. Most
+ *    browser-automation tooling (crawl4ai included) defaults to
+ *    `'domcontentloaded'` for exactly this reason.
+ *  - A failed action's result carried no `ariaSnapshot`/`pageTitle`, even
+ *    when the page had rendered fine and the failure was e.g. a target that
+ *    never appeared — so the caller had no way to see what was actually on
+ *    screen when the action gave up.
+ */
+import { createServer, type Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+
+// 127.0.0.1 is private address space — set before config is read, or the
+// egress guard blocks navigation regardless of the outcome under test.
+process.env.BROWSER_BLOCK_PRIVATE_NETWORK = 'false';
+
+import { browserManager } from '@/lib/services/browser/browserManager';
+import { chromiumAvailable } from '../helpers/browserAvailability';
+
+// The image request is accepted but never answered and never closed, so
+// Chromium's `load` event (which waits for every subresource to settle)
+// never fires — the only way `goto` can return is if it stopped waiting
+// after DOMContentLoaded instead.
+const PAGE = `<!doctype html>
+<html><body>
+  <h1>Hanging subresource fixture</h1>
+  <button type="button">Does not exist target below is what we click instead</button>
+  <img src="/never-responds.png" />
+</body></html>`;
+
+let server: Server;
+let baseUrl = '';
+let openSessions: string[] = [];
+
+beforeAll(async () => {
+  server = createServer((req, res) => {
+    if (req.url === '/never-responds.png') {
+      // Deliberately never call res.end() / res.write() — the request just
+      // hangs, the way a slow third-party tracker would.
+      return;
+    }
+    res.writeHead(200, { 'content-type': 'text/html' });
+    res.end(PAGE);
+  });
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  baseUrl = `http://127.0.0.1:${(server.address() as AddressInfo).port}/`;
+}, 30_000);
+
+afterEach(async () => {
+  const keys = openSessions;
+  openSessions = [];
+  await Promise.all(keys.map((key) => browserManager.closeSession(key, 'test').catch(() => undefined)));
+});
+
+afterAll(async () => {
+  await browserManager.shutdown().catch(() => undefined);
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+});
+
+describe.skipIf(!chromiumAvailable())('goto — default waitUntil', () => {
+  it('resolves without waiting for a subresource that never finishes loading', async () => {
+    const { sessionKey } = await browserManager.openSession({
+      tenantId: 'test-tenant-diag',
+      config: { headless: true, navigationTimeoutMs: 8_000 },
+    });
+    openSessions.push(sessionKey);
+
+    const start = Date.now();
+    // No `waitUntil` — exercising the default.
+    const result = await browserManager.runAction(sessionKey, { type: 'goto', url: baseUrl });
+    const elapsedMs = Date.now() - start;
+
+    expect(result.ok).toBe(true);
+    // Playwright's 'load' default would hang for the full 8s navigation
+    // timeout on this fixture; 'domcontentloaded' returns almost instantly.
+    expect(elapsedMs).toBeLessThan(4_000);
+  }, 15_000);
+});
+
+describe.skipIf(!chromiumAvailable())('runAction — best-effort snapshot on failure', () => {
+  it('still returns pageTitle and ariaSnapshot when the action itself fails', async () => {
+    const { sessionKey } = await browserManager.openSession({
+      tenantId: 'test-tenant-diag',
+      config: { headless: true, actionTimeoutMs: 1_500, navigationTimeoutMs: 8_000 },
+    });
+    openSessions.push(sessionKey);
+    await browserManager.runAction(sessionKey, { type: 'goto', url: baseUrl });
+
+    const result = await browserManager.runAction(sessionKey, {
+      type: 'click',
+      role: 'button',
+      name: 'This button does not exist on the page',
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.errorMessage).toBeDefined();
+    expect(result.pageTitle).toBeDefined();
+    expect(result.ariaSnapshot).toContain('Hanging subresource fixture');
+  }, 15_000);
+});

--- a/src/__tests__/unit/outbound-proxy-bootstrap.test.ts
+++ b/src/__tests__/unit/outbound-proxy-bootstrap.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Regression test for a live incident: every plain `fetch()` call in this
+ * codebase (model provider contracts, CRM support handoff) never read
+ * HTTP(S)_PROXY the way Chromium already needed to be taught to
+ * (browserProxyConfig.ts) -- on a network that requires an egress proxy for
+ * internet access, those calls would fail or hang with no proxy named as
+ * the cause. `configureOutboundProxy` installs undici's env-driven dispatcher
+ * globally, once, at boot.
+ */
+import { afterEach, describe, expect, it } from 'vitest';
+import { Agent, getGlobalDispatcher, setGlobalDispatcher } from 'undici';
+import { configureOutboundProxy } from '@/lib/core/outboundProxyBootstrap';
+
+const ENV_KEYS = ['HTTPS_PROXY', 'https_proxy', 'HTTP_PROXY', 'http_proxy', 'NO_PROXY', 'no_proxy'] as const;
+const originalEnv: Record<string, string | undefined> = {};
+for (const key of ENV_KEYS) originalEnv[key] = process.env[key];
+const originalDispatcher = getGlobalDispatcher();
+
+afterEach(() => {
+  for (const key of ENV_KEYS) {
+    if (originalEnv[key] === undefined) delete process.env[key];
+    else process.env[key] = originalEnv[key];
+  }
+  setGlobalDispatcher(originalDispatcher);
+});
+
+describe('configureOutboundProxy', () => {
+  it('does nothing when no proxy variable is set — no dispatcher change for the overwhelming majority of deployments', () => {
+    for (const key of ENV_KEYS) delete process.env[key];
+    setGlobalDispatcher(new Agent());
+
+    configureOutboundProxy();
+
+    expect(getGlobalDispatcher().constructor.name).toBe('Agent');
+  });
+
+  it('installs the env-driven proxy dispatcher globally when HTTPS_PROXY is set', () => {
+    for (const key of ENV_KEYS) delete process.env[key];
+    process.env.HTTPS_PROXY = 'http://proxy.internal.example:8080';
+    setGlobalDispatcher(new Agent());
+
+    configureOutboundProxy();
+
+    expect(getGlobalDispatcher().constructor.name).toBe('EnvHttpProxyAgent');
+  });
+});

--- a/src/app/dashboard/browser/[browserId]/sessions/page.tsx
+++ b/src/app/dashboard/browser/[browserId]/sessions/page.tsx
@@ -16,6 +16,7 @@ import {
   Modal,
   Paper,
   ScrollArea,
+  Select,
   Stack,
   Switch,
   Table,
@@ -327,6 +328,7 @@ function SessionDrawer({
   const [events, setEvents] = useState<BrowserSessionEventView[]>([]);
   const [polling, setPolling] = useState(true);
   const [navigateUrl, setNavigateUrl] = useState('');
+  const [waitUntil, setWaitUntil] = useState<'domcontentloaded' | 'load' | 'networkidle'>('domcontentloaded');
   const [actionLoading, setActionLoading] = useState(false);
   const intervalRef = useRef<NodeJS.Timeout | null>(null);
 
@@ -392,7 +394,7 @@ function SessionDrawer({
       await fetch(`/api/browser/sessions/${session.sessionKey}/actions`, {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ type: 'goto', url: navigateUrl }),
+        body: JSON.stringify({ type: 'goto', url: navigateUrl, waitUntil }),
       });
       onMutated();
       const eventsRes = await fetch(`/api/browser/sessions/${session.id}/events?limit=25`, { cache: 'no-store' }).catch(() => null);
@@ -452,6 +454,17 @@ function SessionDrawer({
               value={navigateUrl}
               onChange={(e) => setNavigateUrl(e.currentTarget.value)}
               style={{ flex: 1 }}
+            />
+            <Select
+              data={[
+                { value: 'domcontentloaded', label: 'DOM ready (default)' },
+                { value: 'load', label: 'Full load' },
+                { value: 'networkidle', label: 'Network idle' },
+              ]}
+              value={waitUntil}
+              onChange={(v) => setWaitUntil((v as typeof waitUntil) ?? 'domcontentloaded')}
+              w={170}
+              size="sm"
             />
             <Button leftSection={<IconPlayerPlay size={14} />} onClick={runNavigate} loading={actionLoading}>Go</Button>
           </Group>

--- a/src/app/dashboard/browser/page.tsx
+++ b/src/app/dashboard/browser/page.tsx
@@ -82,15 +82,20 @@ export default function BrowsersListPage() {
       description: '',
       artifactBucketKey: '',
       defaultModelKey: '',
-      // Defaults mirror the server's own (`config.browser.*`), so a browser
-      // created without touching this section behaves exactly as before.
       headless: true,
       viewportWidth: 1280,
       viewportHeight: 800,
       locale: '',
       timezoneId: '',
       actionTimeoutMs: 15_000,
-      navigationTimeoutMs: 30_000,
+      // A real page behind a corporate egress proxy, or one that's just
+      // heavier than a synthetic test target, routinely needs more than 30s
+      // to navigate — and once a browser is saved with an explicit value
+      // here, it always wins over BROWSER_DEFAULT_NAVIGATION_TIMEOUT_MS (a
+      // per-browser override is supposed to win), so a low default baked in
+      // by every browser created through this form silently defeats that
+      // env var raising the deployment-wide default.
+      navigationTimeoutMs: 60_000,
       idleTimeoutMs: 300_000,
       allowList: '',
       blockList: '',

--- a/src/app/dashboard/browser/playground/page.tsx
+++ b/src/app/dashboard/browser/playground/page.tsx
@@ -192,6 +192,7 @@ export default function BrowserPlaygroundPage() {
   // ── Action composer ───────────────────────────────────────
   const [actionType, setActionType] = useState('goto');
   const [url, setUrl] = useState('');
+  const [gotoWaitUntil, setGotoWaitUntil] = useState<'domcontentloaded' | 'load' | 'networkidle'>('domcontentloaded');
   const [value, setValue] = useState('');
   const [keyName, setKeyName] = useState('Enter');
   const [waitMs, setWaitMs] = useState('1000');
@@ -285,6 +286,7 @@ export default function BrowserPlaygroundPage() {
     if (actionType === 'goto') {
       if (!url.trim()) return null;
       action.url = url.trim();
+      action.waitUntil = gotoWaitUntil;
     }
     if (actionType === 'type') action.text = value;
     if (actionType === 'select') action.labels = [value];
@@ -514,14 +516,27 @@ export default function BrowserPlaygroundPage() {
             />
 
             {actionType === 'goto' ? (
-              <TextInput
-                size="xs"
-                label="URL"
-                placeholder="https://example.com"
-                value={url}
-                onChange={(event) => setUrl(event.currentTarget.value)}
-                onKeyDown={(event) => { if (event.key === 'Enter') void run(); }}
-              />
+              <>
+                <TextInput
+                  size="xs"
+                  label="URL"
+                  placeholder="https://example.com"
+                  value={url}
+                  onChange={(event) => setUrl(event.currentTarget.value)}
+                  onKeyDown={(event) => { if (event.key === 'Enter') void run(); }}
+                />
+                <Select
+                  size="xs"
+                  label="Wait until"
+                  data={[
+                    { value: 'domcontentloaded', label: 'DOM ready (default)' },
+                    { value: 'load', label: 'Full load' },
+                    { value: 'networkidle', label: 'Network idle' },
+                  ]}
+                  value={gotoWaitUntil}
+                  onChange={(v) => setGotoWaitUntil((v as typeof gotoWaitUntil) ?? 'domcontentloaded')}
+                />
+              </>
             ) : null}
 
             {actionType === 'type' || actionType === 'select' ? (

--- a/src/lib/core/outboundProxyBootstrap.ts
+++ b/src/lib/core/outboundProxyBootstrap.ts
@@ -1,0 +1,37 @@
+/**
+ * Routes every outbound `fetch()` call (built on undici under Node 18+)
+ * through the configured corporate egress proxy, using the same
+ * HTTP(S)_PROXY / NO_PROXY environment variables already forwarded to
+ * Chromium (browserProxyConfig.ts) and MCP subprocesses (stdioRunner.ts).
+ *
+ * Model/document-processing provider calls (OpenAI, Azure, Google,
+ * Mistral), the support/CRM handoff, and any other plain `fetch()` call in
+ * this codebase never read those variables on their own -- on a network
+ * that requires an egress proxy for internet access, every one of those
+ * calls would fail or hang exactly the way Chromium did before the
+ * equivalent fix there, and Node's own DNS/connect errors rarely name a
+ * proxy as the cause.
+ *
+ * `EnvHttpProxyAgent` is undici's own env-driven dispatcher: it parses
+ * NO_PROXY with the same bypass semantics curl and most HTTP tooling use,
+ * so internal/allow-listed hosts still connect directly. A no-op when no
+ * proxy variable is set, which is the overwhelming majority of deployments
+ * -- `setGlobalDispatcher` is not called at all, so there is no behavior
+ * change and no experimental-API warning for anyone not using a proxy.
+ */
+import { setGlobalDispatcher, EnvHttpProxyAgent } from 'undici';
+import { createLogger } from './logger';
+
+const logger = createLogger('startup');
+
+export function configureOutboundProxy(): void {
+  const hasProxy =
+    process.env.HTTPS_PROXY || process.env.https_proxy
+    || process.env.HTTP_PROXY || process.env.http_proxy;
+  if (!hasProxy) return;
+
+  setGlobalDispatcher(new EnvHttpProxyAgent());
+  logger.info('Outbound fetch() routed through the configured egress proxy', {
+    bypassConfigured: Boolean(process.env.NO_PROXY || process.env.no_proxy),
+  });
+}

--- a/src/lib/services/browser/browserManager.ts
+++ b/src/lib/services/browser/browserManager.ts
@@ -294,6 +294,14 @@ class BrowserManager {
       logger.info('Launching Chromium', {
         headless: cfg.headless,
         proxied: Boolean(proxy),
+        // Host only, never the full proxy URL — a corporate proxy's URL
+        // commonly embeds basic-auth credentials (http://user:pass@host).
+        // `proxied: true` with no host next to it was a diagnostic dead end
+        // on the incident this log line was written for: no way to tell
+        // from the pod's own logs whether the configured proxy matched what
+        // the network actually required.
+        proxyHost: proxy ? safeProxyHost(proxy.server) : undefined,
+        proxyBypassConfigured: Boolean(proxy?.bypass),
         extraArgs: cfg.chromiumExtraArgs.length,
         ignoreCertificateErrors: cfg.ignoreCertificateErrors,
       });
@@ -423,7 +431,12 @@ class BrowserManager {
             blockPrivateNetwork,
           });
           if (!decision.allowed) {
-            logger.debug('Browser request blocked by egress policy', {
+            // `warn`, not `debug`: this only fires when a policy actually
+            // denies a request (default-allow otherwise emits nothing), so
+            // it's a rare, actionable diagnostic signal, not per-request
+            // noise -- and at `debug` it was invisible at the log level
+            // every production deployment actually runs at.
+            logger.warn('Browser request blocked by egress policy', {
               reason: decision.reason,
               urlHost: getSafeUrlHost(url),
             });
@@ -781,7 +794,14 @@ class BrowserManager {
             throw new Error(decision.reason ?? 'Browser navigation blocked by egress policy');
           }
           await this.activePage(live).goto(action.url, {
-            waitUntil: action.waitUntil ?? 'load',
+            // Playwright's own default. 'load' waits for every last
+            // subresource on the page -- trackers, fonts, third-party
+            // widgets -- which routinely pushes a heavy real-world page (in
+            // particular one behind a corporate egress proxy) past any
+            // reasonable navigation timeout on content that finished
+            // rendering long before. 'domcontentloaded' is what crawl4ai and
+            // most browser-automation tooling default to for the same reason.
+            waitUntil: action.waitUntil ?? 'domcontentloaded',
             timeout: action.timeout,
           });
           break;
@@ -925,9 +945,17 @@ class BrowserManager {
         tabs,
       };
     } catch (err) {
+      // A `goto` that times out (a slow network, a heavy corporate-proxied
+      // page) often leaves a partially- or fully-rendered page behind, not a
+      // blank one -- capture it best-effort instead of returning nothing, so
+      // "the action failed" doesn't also mean "the caller has no idea what
+      // the page looked like when it did."
+      const ariaSnapshot = await this.captureAriaSnapshot(live).catch(() => undefined);
       return {
         ok: false,
         url: this.activePage(live).url(),
+        pageTitle: await this.activePage(live).title().catch(() => undefined),
+        ariaSnapshot,
         targetStrategy: strategy,
         errorMessage: err instanceof Error ? err.message : String(err),
       };
@@ -1398,6 +1426,16 @@ async function evaluateBrowserRequestAccess(
 function getSafeUrlHost(rawUrl: string): string | undefined {
   try {
     return normalizeHost(new URL(rawUrl).hostname);
+  } catch {
+    return undefined;
+  }
+}
+
+/** `host:port`, stripped of scheme and any embedded basic-auth credentials — safe to log. */
+function safeProxyHost(rawUrl: string): string | undefined {
+  try {
+    const parsed = new URL(rawUrl);
+    return parsed.port ? `${parsed.hostname}:${parsed.port}` : parsed.hostname;
   } catch {
     return undefined;
   }

--- a/src/lib/services/browser/browserSessionService.ts
+++ b/src/lib/services/browser/browserSessionService.ts
@@ -257,6 +257,10 @@ export async function createBrowserSession(
     const refreshed = await db.findBrowserSessionById(sessionId);
     return serializeSession(refreshed ?? created);
   } catch (err) {
+    // This used to be persisted only to the DB row, never to the pod's own
+    // logs -- diagnosing a live incident meant querying Mongo to find out a
+    // session failed to open at all, with nothing in `oc logs` naming why.
+    logger.error('Browser session failed to open', { error: err, sessionKey, tenantId: ctx.tenantId });
     await db.updateBrowserSession(sessionId, {
       status: 'errored',
       errorMessage: err instanceof Error ? err.message : String(err),

--- a/src/server/bootstrap.ts
+++ b/src/server/bootstrap.ts
@@ -1,5 +1,6 @@
 import { getConfig, validateConfig } from '@/lib/core/config';
 import { createLogger } from '@/lib/core/logger';
+import { configureOutboundProxy } from '@/lib/core/outboundProxyBootstrap';
 import { initLifecycle, registerShutdownHandler } from '@/lib/core/lifecycle';
 import { getCache, destroyCache } from '@/lib/core/cache';
 import { runtimePool } from '@/lib/core/runtimePool';
@@ -96,6 +97,9 @@ export function isApplicationReady(): boolean {
 
 async function runBootstrap(): Promise<void> {
   const cfg = getConfig();
+  // As early as possible, and unconditionally before any provider/CRM call
+  // has a chance to fire: those all use the plain `fetch()` this configures.
+  configureOutboundProxy();
   const errors = validateConfig(cfg);
 
   if (errors.length > 0) {


### PR DESCRIPTION
## Summary
Bundle of fixes found diagnosing a live incident (browser navigation consistently timing out on a network requiring an egress proxy, while the page had in fact loaded successfully):

- `goto`'s default `waitUntil`: `'load'` → `'domcontentloaded'` (matches crawl4ai and most browser-automation tooling) — selectable per-call and from the dashboard's navigate/playground UI
- Failed actions now capture `ariaSnapshot`/`pageTitle` best-effort too, not just on success
- Dashboard's Browser create form no longer silently defeats `BROWSER_DEFAULT_NAVIGATION_TIMEOUT_MS` with a hardcoded 30s baked into every saved browser (raised to 60s)
- `configureOutboundProxy()`: every plain `fetch()` call (OpenAI/Azure/Google/Mistral provider contracts, CRM handoff) now honors `HTTP(S)_PROXY`/`NO_PROXY` via undici's `EnvHttpProxyAgent`, installed globally at boot — no-op when unset
- Logging gaps closed: `createBrowserSession` failures are now logged (previously DB-only); egress-block log `debug` → `warn`; Chromium launch log now includes the proxy host (credential-safe)
- OpenShift restricted-SCC arbitrary-UID fix for `.next/cache` (GID 0 group-write) — was causing `EACCES` on Next's own runtime image optimization

## Test plan
- [x] New integration tests: default `waitUntil` doesn't hang on a never-finishing subresource; failed action still returns snapshot/title — both regression-proven (revert → red)
- [x] New unit tests for `configureOutboundProxy` (no-op without proxy env, installs dispatcher with it)
- [x] `tsc --noEmit` clean, `next build` clean, eslint clean (pre-existing unrelated warnings only)
- [x] Full suite green: 331 files / 5141 tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KQq6TnVNHRNU6Wz1eQzPpD