### PR TITLE
fix(vector): collapse MongoDB community vector store into main DB under single-database mode

### DIFF
--- a/src/__tests__/unit/mongo-community-vector-contract.test.ts
+++ b/src/__tests__/unit/mongo-community-vector-contract.test.ts
@@ -7,10 +7,12 @@
  * application code.
  */
 
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
 import { createRequire } from 'node:module';
+import { MongoClient } from 'mongodb';
 import { MongoCommunityVectorProviderContract } from '@/lib/providers/contracts/mongoCommunityVector.contract';
 import type { VectorProviderRuntime } from '@/lib/providers/domains/vector';
+import { getConfigSource, setConfigSource, type ConfigSource } from '@/lib/core/config';
 
 const MONGO_AVAILABLE: boolean = (() => {
   try {
@@ -141,6 +143,84 @@ describe.runIf(MONGO_AVAILABLE)('MongoCommunityVectorProviderContract', () => {
       const result = await runtime.queryVectors(handle, { vector: [1, 0, 0], topK: 10 });
       expect(result.matches.map((m) => m.id)).not.toContain('v1');
       expect(result.matches).toHaveLength(3);
+    });
+  });
+
+  // ── On-prem single-database mode ────────────────────────────────────
+
+  describe('MONGODB_SINGLE_DATABASE mode', () => {
+    const originalSource = getConfigSource();
+
+    afterEach(() => {
+      setConfigSource(originalSource);
+    });
+
+    it('reuses the app main database (as its own collections) when the store reuses the app connection with no explicit database setting', async () => {
+      setConfigSource({
+        name: 'test-single-db',
+        get: (key: string) => {
+          const overrides: Record<string, string> = {
+            DB_PROVIDER: 'mongodb',
+            MONGODB_URI: server.getUri(),
+            MONGODB_SINGLE_DATABASE: 'true',
+            MAIN_DB_NAME: 'single_db_test_main',
+          };
+          return overrides[key];
+        },
+      } as ConfigSource);
+
+      // No `uri` credential (reuses the app connection) and no `database`
+      // setting — must collapse into the app's single main database instead
+      // of the dedicated `cognipeer_vectors` database.
+      await MongoCommunityVectorProviderContract.createRuntime({
+        tenantId: 'single_db_tenant',
+        providerKey: PROVIDER_KEY,
+        credentials: {},
+        settings: {},
+      });
+
+      const client = new MongoClient(server.getUri());
+      await client.connect();
+      try {
+        const mainDbCollections = await client.db('single_db_test_main').listCollections().toArray();
+        expect(mainDbCollections.some((c) => c.name.includes('single_db_tenant'))).toBe(true);
+
+        const dedicatedDbCollections = await client.db('cognipeer_vectors').listCollections().toArray();
+        expect(dedicatedDbCollections.some((c) => c.name.includes('single_db_tenant'))).toBe(false);
+      } finally {
+        await client.close();
+      }
+    });
+
+    it('still honors an explicit database setting even in single-database mode', async () => {
+      setConfigSource({
+        name: 'test-single-db-explicit',
+        get: (key: string) => {
+          const overrides: Record<string, string> = {
+            DB_PROVIDER: 'mongodb',
+            MONGODB_URI: server.getUri(),
+            MONGODB_SINGLE_DATABASE: 'true',
+            MAIN_DB_NAME: 'single_db_test_main',
+          };
+          return overrides[key];
+        },
+      } as ConfigSource);
+
+      await MongoCommunityVectorProviderContract.createRuntime({
+        tenantId: 'single-db-tenant-explicit',
+        providerKey: PROVIDER_KEY,
+        credentials: {},
+        settings: { database: 'explicit_vectors_db' },
+      });
+
+      const client = new MongoClient(server.getUri());
+      await client.connect();
+      try {
+        const explicitDbCollections = await client.db('explicit_vectors_db').listCollections().toArray();
+        expect(explicitDbCollections.some((c) => c.name.includes('single_db_tenant_explicit'))).toBe(true);
+      } finally {
+        await client.close();
+      }
     });
   });
 

--- a/src/lib/providers/contracts/mongoCommunityVector.contract.ts
+++ b/src/lib/providers/contracts/mongoCommunityVector.contract.ts
@@ -132,8 +132,9 @@ function buildCollectionNames(
   settings: MongoCommunityVectorSettings,
   tenantId: string,
   providerKey: string,
+  defaultDbName: string,
 ): { dbName: string; indexesCollection: string; entriesCollection: string } {
-  const dbName = settings.database?.trim() || 'cognipeer_vectors';
+  const dbName = settings.database?.trim() || defaultDbName;
   const prefix = settings.collectionPrefix?.trim() || 'vec';
   const safeTenant = tenantId.replace(/[^a-zA-Z0-9_]/g, '_');
   const safeProvider = providerKey.replace(/[^a-zA-Z0-9_]/g, '_');
@@ -188,7 +189,8 @@ export const MongoCommunityVectorProviderContract: ProviderContract<
             type: 'text',
             required: false,
             placeholder: 'cognipeer_vectors',
-            description: 'Optional. Defaults to a dedicated "cognipeer_vectors" database.',
+            description:
+              'Optional. Defaults to a dedicated "cognipeer_vectors" database, or the app\'s own main database when MONGODB_SINGLE_DATABASE is on.',
             scope: 'settings',
           },
           {
@@ -222,10 +224,29 @@ export const MongoCommunityVectorProviderContract: ProviderContract<
 
   async createRuntime({ tenantId, providerKey, credentials, settings, logger }) {
     const uri = resolveUri(credentials);
+
+    // On-prem `MONGODB_SINGLE_DATABASE` mode collapses the app's own
+    // main+tenant collections into one physical database (see
+    // MongoDBProviderBase.singleDatabase) so on-prem installs don't have to
+    // provision/back up a second database. Mirror that here when this store
+    // is reusing the app's own connection (no explicit `uri` credential) and
+    // the operator hasn't explicitly named a database: keep vectors as their
+    // own tenant+provider-scoped collections (buildCollectionNames already
+    // guarantees no name collision with the app's `vector_*` collections)
+    // inside that same database instead of a dedicated `cognipeer_vectors`
+    // one — one physical database, as intended.
+    const usingAppConnection = !credentials?.uri?.trim();
+    const cfg = getConfig();
+    const defaultDbName =
+      usingAppConnection && cfg.database.provider === 'mongodb' && cfg.database.singleDatabase
+        ? cfg.database.mainDbName
+        : 'cognipeer_vectors';
+
     const { dbName, indexesCollection, entriesCollection } = buildCollectionNames(
       settings,
       tenantId,
       providerKey,
+      defaultDbName,
     );
 
     const client = new MongoClient(uri);


### PR DESCRIPTION
## Summary
- `MongoCommunityVectorProviderContract` (the brute-force "local vector" store used on non-Atlas MongoDB) always opened a separate `cognipeer_vectors` database, even under `MONGODB_SINGLE_DATABASE=true` — defeating the point of single-database on-prem deployments (avoid a second database to provision/back up).
- Now, when the store reuses the app's own connection (no explicit `uri` credential) and no explicit `database` setting is given, it defaults to the app's main database and stores vectors as its own tenant+provider-scoped collections there. Collisions with the app's built-in `vector_*` collections aren't possible since names follow a distinct `vec_..._{tenant}__{provider}` pattern. An explicit `database` setting still overrides.

## Test plan
- [x] `npx vitest run src/__tests__/unit/mongo-community-vector-contract.test.ts` — 17/17 pass (2 new cases covering single-DB default + explicit override)
- [x] `npx tsc --noEmit` clean on the touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017C4kRtyezjkSLyNktm8UNH