### PR TITLE
test(release): cover delayed Community compatibility handoff

### DIFF
--- a/ci/release-workflows.test.mjs
+++ b/ci/release-workflows.test.mjs
@@ -12,8 +12,15 @@ function waitForPin(pin = compat, overrides = {}) {
   const result = spawnSync('bash', ['-e', '-u', '-o', 'pipefail'], {
     input: `
       gh() { echo 'gh must not be required' >&2; return 127; }
-      sleep() { :; }
-      curl() { [[ "$HTTP_FAILURE" == 0 ]] || return 22; printf '%s' "$PIN"; }
+      sleep() { printf 'compat-poll-wait\\n'; }
+      curl() {
+        [[ "$HTTP_FAILURE" == 0 ]] || return 22
+        if [[ "$attempt" -lt "$PIN_READY_ATTEMPT" ]]; then
+          printf '%s' "$INITIAL_PIN"
+        else
+          printf '%s' "$PIN"
+        fi
+      }
       source "$SCRIPT_FILE"
     `,
     encoding: 'utf8', timeout: 30_000,
@@ -21,7 +28,8 @@ function waitForPin(pin = compat, overrides = {}) {
       ...process.env, SCRIPT_FILE: join(directory, 'wait-community-compat.sh'),
       GH_TOKEN: 'test-token', GITHUB_REPOSITORY: 'Cognipeer/console',
       CONSOLE_EE_REPOSITORY: 'Cognipeer/console-ee', COMMUNITY_TAG: compat.communityRef,
-      COMMUNITY_SHA: sha, PIN: JSON.stringify(pin), HTTP_FAILURE: '0', ...overrides,
+      COMMUNITY_SHA: sha, PIN: JSON.stringify(pin), HTTP_FAILURE: '0',
+      INITIAL_PIN: JSON.stringify(pin), PIN_READY_ATTEMPT: '1', ...overrides,
     },
   });
   assert.ifError(result.error);
@@ -31,6 +39,19 @@ function waitForPin(pin = compat, overrides = {}) {
 test('accepts an exact already-merged pin without gh or a new PR', () => {
   const result = waitForPin();
   assert.equal(result.status, 0, result.output);
+});
+
+test('waits for the exact pin to appear after compatibility sync', () => {
+  for (const initialPin of [
+    { ...compat, communityRef: 'v1.2.59-community' },
+    { ...compat, communitySha: 'c'.repeat(40) },
+  ]) {
+    const result = waitForPin(compat, {
+      INITIAL_PIN: JSON.stringify(initialPin), PIN_READY_ATTEMPT: '3',
+    });
+    assert.equal(result.status, 0, result.output);
+    assert.equal(result.output, 'compat-poll-wait\ncompat-poll-wait\n');
+  }
 });
 
 test('does not accept a moved tag, missing SHA, wrong repo or older pin', () => {


### PR DESCRIPTION
## Purpose
Provide a small, test-only Console change for the requested end-to-end managed release walkthrough. No application code, production workflow, runner, permissions, compatibility policy, or deployment configuration changes.

## Change
Extend the existing compatibility-wait regression tests with delayed REST responses. Verify that the waiter continues while the tag is old or the commit SHA is wrong, and finishes only when the exact tag and SHA appear after synchronization. All requests and waits are mocked.

## Validation
- `node --test ci/*.test.mjs`: 10 tests passed using the existing pinned yq parser.
- Editor diagnostics and `git diff --check`: clean.
- Only `ci/release-workflows.test.mjs` changed.

## End-to-End Walkthrough
1. Review and merge this PR after its checks pass. The EE neutral-CodeQL fix in https://github.com/Cognipeer/console-ee/pull/150 is already merged.
2. From CRM, create a new managed Community release at the resulting Console main commit, using the next unused version. Do not move or reuse an existing version tag.
3. Verify the Community image build, the automatically created EE compatibility PR, its checks and authorized merge, then both `communityRef` and `communitySha` on EE main.
4. Confirm the Community callback returns linked release/execution IDs and CRM marks that execution released. Only then freeze the updated EE source for the Enterprise release and its selected On-Prem/Jail targets.

## Scope
Opening this PR runs PR checks, not the full release chain. No merge, release/tag creation, registry publication, pipeline rerun or deployment has been performed as part of this request. SaaS remains explicitly blocked by the separately documented receiver-contract limitation.