### PR TITLE
fix(browser): preserve tenant scope across background flows

### DIFF
--- a/src/__tests__/api/browser-dashboard-actions.test.ts
+++ b/src/__tests__/api/browser-dashboard-actions.test.ts
@@ -1,0 +1,128 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const browserMocks = vi.hoisted(() => ({
+  captureLiveScreenshot: vi.fn(),
+  captureScreenshot: vi.fn(),
+  captureSnapshot: vi.fn(),
+  clearBrowserStorageState: vi.fn(),
+  closeBrowserSession: vi.fn(),
+  createBrowser: vi.fn(),
+  createBrowserFlow: vi.fn(),
+  createBrowserSession: vi.fn(),
+  deleteBrowser: vi.fn(),
+  deleteBrowserFlow: vi.fn(),
+  deleteBrowserSession: vi.fn(),
+  describeSessionElement: vi.fn(),
+  exportSessionPdf: vi.fn(),
+  exportSessionStorageState: vi.fn(),
+  extractFromBrowser: vi.fn(),
+  getBrowser: vi.fn(),
+  getBrowserFlow: vi.fn(),
+  getBrowserFlowRun: vi.fn(),
+  getBrowserSession: vi.fn(),
+  listBrowserFlowRuns: vi.fn(),
+  listBrowserFlows: vi.fn(),
+  listBrowserSessionEvents: vi.fn(),
+  listBrowserSessions: vi.fn(),
+  listBrowsers: vi.fn(),
+  readSessionObservations: vi.fn(),
+  recordBrowserFlow: vi.fn(),
+  runBrowserAction: vi.fn(),
+  runBrowserFlow: vi.fn(),
+  runBrowserFlowSteps: vi.fn(),
+  searchPageText: vi.fn(),
+  setBrowserStorageState: vi.fn(),
+  startBrowserFlowRun: vi.fn(),
+  updateBrowser: vi.fn(),
+  updateBrowserFlow: vi.fn(),
+}));
+
+vi.mock('@/lib/services/browser', () => browserMocks);
+vi.mock('@/lib/database', () => ({ getDatabase: vi.fn() }));
+vi.mock('@/lib/services/projects/projectContext', () => ({
+  resolveProjectContext: vi.fn(),
+  ProjectContextError: class ProjectContextError extends Error {
+    status: number;
+    constructor(message: string, status = 400) {
+      super(message);
+      this.status = status;
+    }
+  },
+}));
+
+import { getDatabase } from '@/lib/database';
+import { resolveProjectContext } from '@/lib/services/projects/projectContext';
+import { browserApiPlugin } from '@/server/api/plugins/browser';
+import { createMockDb } from '../helpers/db.mock';
+import { createFastifyApiTestApp, parseJsonBody } from '../helpers/fastify-api';
+
+const HEADERS = {
+  'content-type': 'application/json',
+  'x-license-type': 'ENTERPRISE',
+  'x-tenant-db-name': 'tenant_acme',
+  'x-tenant-id': 'tenant-1',
+  'x-tenant-slug': 'acme',
+  'x-user-id': 'user-1',
+  'x-user-role': 'owner',
+};
+const SCOPE = { tenantDbName: 'tenant_acme', tenantId: 'tenant-1', projectId: 'project-1' };
+
+describe('dashboard browser action routes', () => {
+  let app: Awaited<ReturnType<typeof createFastifyApiTestApp>>;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    (resolveProjectContext as ReturnType<typeof vi.fn>).mockResolvedValue({
+      projectId: 'project-1',
+      project: { _id: 'project-1' },
+      user: { _id: 'user-1', role: 'owner', projectIds: ['project-1'] },
+    });
+    const db = createMockDb();
+    db.findUserById.mockResolvedValue({
+      _id: 'user-1', email: 'owner@example.com', role: 'owner', tenantId: 'tenant-1',
+    } as never);
+    (getDatabase as ReturnType<typeof vi.fn>).mockResolvedValue(db);
+    app = await createFastifyApiTestApp(browserApiPlugin);
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('POST /api/browser/sessions/:sessionKey/describe resolves a durable target', async () => {
+    browserMocks.describeSessionElement.mockResolvedValue({ role: 'button', name: 'Submit' });
+    const response = await app.inject({
+      method: 'POST', url: '/api/browser/sessions/session-1/describe', headers: HEADERS,
+      payload: { ref: 'e7' },
+    });
+    expect(response.statusCode).toBe(200);
+    expect(parseJsonBody(response.body)).toEqual({ role: 'button', name: 'Submit' });
+    expect(browserMocks.describeSessionElement).toHaveBeenCalledWith(SCOPE, 'session-1', 'e7');
+  });
+
+  it('POST /api/browser/flows/:idOrKey/run/start returns the background run', async () => {
+    browserMocks.startBrowserFlowRun.mockResolvedValue({ id: 'run-1', status: 'running' });
+    const response = await app.inject({
+      method: 'POST', url: '/api/browser/flows/flow-1/run/start', headers: HEADERS,
+      payload: { inputs: { account: 'ACME' } },
+    });
+    expect(response.statusCode).toBe(202);
+    expect(parseJsonBody(response.body)).toEqual({ run: { id: 'run-1', status: 'running' } });
+    expect(browserMocks.startBrowserFlowRun).toHaveBeenCalledWith(SCOPE, 'flow-1', {
+      inputs: { account: 'ACME' }, trigger: 'manual', createdBy: 'user-1',
+    });
+  });
+
+  it('POST /api/browser/flows/:idOrKey/steps/run replays only the requested slice', async () => {
+    browserMocks.runBrowserFlowSteps.mockResolvedValue({ stepResults: [{ status: 'succeeded' }] });
+    const response = await app.inject({
+      method: 'POST', url: '/api/browser/flows/flow-1/steps/run', headers: HEADERS,
+      payload: { sessionKey: 'session-1', from: 1, to: 2, inputs: { account: 'ACME' } },
+    });
+    expect(response.statusCode).toBe(200);
+    expect(parseJsonBody(response.body)).toEqual({ stepResults: [{ status: 'succeeded' }] });
+    expect(browserMocks.runBrowserFlowSteps).toHaveBeenCalledWith(SCOPE, 'flow-1', {
+      sessionKey: 'session-1', from: 1, to: 2, inputs: { account: 'ACME' }, createdBy: 'user-1',
+    });
+  });
+});

--- a/src/lib/services/browser/browserFlowService.ts
+++ b/src/lib/services/browser/browserFlowService.ts
@@ -139,32 +139,33 @@ export async function createBrowserFlow(
   ctx: FlowContext,
   input: CreateBrowserFlowInput,
 ): Promise<BrowserFlowView> {
-  const db = await withTenantDb(ctx.tenantDbName);
-  const browser = await resolveBrowser(ctx, input.browserId);
-  if (!browser) {
-    throw new Error(`Browser not found: ${input.browserId}`);
-  }
+  return runWithTenantScope(ctx.tenantDbName, async (db) => {
+    const browser = await resolveBrowser(ctx, input.browserId);
+    if (!browser) {
+      throw new Error(`Browser not found: ${input.browserId}`);
+    }
 
-  const key = await generateUniqueFlowKey(db, ctx.tenantId, input.key ?? input.name, ctx.projectId);
-  const created = await db.createBrowserFlow({
-    tenantId: ctx.tenantId,
-    projectId: ctx.projectId,
-    key,
-    name: input.name,
-    description: input.description,
-    status: input.status ?? 'draft',
-    browserId: String(browser._id ?? ''),
-    inputs: input.inputs,
-    outputs: input.outputs,
-    steps: normalizeSteps(input.steps ?? []),
-    sessionConfig: input.sessionConfig,
-    recordedFromSessionId: input.recordedFromSessionId,
-    version: 1,
-    metadata: input.metadata,
-    createdBy: input.createdBy,
+    const key = await generateUniqueFlowKey(db, ctx.tenantId, input.key ?? input.name, ctx.projectId);
+    const created = await db.createBrowserFlow({
+      tenantId: ctx.tenantId,
+      projectId: ctx.projectId,
+      key,
+      name: input.name,
+      description: input.description,
+      status: input.status ?? 'draft',
+      browserId: String(browser._id ?? ''),
+      inputs: input.inputs,
+      outputs: input.outputs,
+      steps: normalizeSteps(input.steps ?? []),
+      sessionConfig: input.sessionConfig,
+      recordedFromSessionId: input.recordedFromSessionId,
+      version: 1,
+      metadata: input.metadata,
+      createdBy: input.createdBy,
+    });
+    logger.info('Browser flow created', { flowId: created._id, key, steps: created.steps.length });
+    return serializeFlow(created);
   });
-  logger.info('Browser flow created', { flowId: created._id, key, steps: created.steps.length });
-  return serializeFlow(created);
 }
 
 export async function updateBrowserFlow(
@@ -261,8 +262,9 @@ export async function getBrowserFlowRun(
 async function resolveFlowRecord(
   ctx: FlowContext,
   idOrKey: string,
+  scopedDb?: DatabaseProvider,
 ): Promise<IBrowserFlow | null> {
-  const db = await withTenantDb(ctx.tenantDbName);
+  const db = scopedDb ?? await withTenantDb(ctx.tenantDbName);
   const record =
     (await db.findBrowserFlowById(idOrKey).catch(() => null))
     ?? (await db.findBrowserFlowByKey(ctx.tenantId, idOrKey, ctx.projectId));
@@ -529,7 +531,7 @@ async function prepareFlowRun(
   idOrKey: string,
   input: RunBrowserFlowInput,
 ): Promise<FlowRunSetup> {
-  const flow = await resolveFlowRecord(ctx, idOrKey);
+  const flow = await resolveFlowRecord(ctx, idOrKey, db);
   if (!flow) throw new Error(`Browser flow not found: ${idOrKey}`);
   if (flow.status === 'disabled') throw new Error(`Browser flow ${flow.key} is disabled`);
   if (!flow.steps.length) throw new Error(`Browser flow ${flow.key} has no steps`);
@@ -685,9 +687,10 @@ export async function runBrowserFlow(
   idOrKey: string,
   input: RunBrowserFlowInput,
 ): Promise<BrowserFlowRunView> {
-  const db = await withTenantDb(ctx.tenantDbName);
-  const setup = await prepareFlowRun(db, ctx, idOrKey, input);
-  return executeFlowRun(db, ctx, setup, input);
+  return runWithTenantScope(ctx.tenantDbName, async (db) => {
+    const setup = await prepareFlowRun(db, ctx, idOrKey, input);
+    return executeFlowRun(db, ctx, setup, input);
+  });
 }
 
 /**
@@ -709,8 +712,9 @@ export async function startBrowserFlowRun(
   idOrKey: string,
   input: RunBrowserFlowInput,
 ): Promise<BrowserFlowRunView> {
-  const db = await withTenantDb(ctx.tenantDbName);
-  const setup = await prepareFlowRun(db, ctx, idOrKey, input);
+  const setup = await runWithTenantScope(ctx.tenantDbName, (db) => (
+    prepareFlowRun(db, ctx, idOrKey, input)
+  ));
   const requestContext = captureRequestContext();
 
   void runWithRequestContext(requestContext ?? {}, () => (

--- a/src/lib/services/browser/browserProfileService.ts
+++ b/src/lib/services/browser/browserProfileService.ts
@@ -6,7 +6,7 @@ import slugify from 'slugify';
 import { z } from 'zod';
 import { createLogger } from '@/lib/core/logger';
 import { decryptObject, encryptObject } from '@/lib/utils/crypto';
-import { getDatabase, type DatabaseProvider } from '@/lib/database';
+import { getDatabase, runWithTenantScope, type DatabaseProvider } from '@/lib/database';
 import type { IBrowser } from '@/lib/database';
 import type { BrowserView, CreateBrowserInput, UpdateBrowserInput } from './types';
 import { matchesProjectScope } from './internals';
@@ -70,24 +70,25 @@ export async function createBrowser(
   ctx: BrowserCtx,
   input: CreateBrowserInput,
 ): Promise<BrowserView> {
-  const db = await withTenantDb(ctx.tenantDbName);
-  const key = await generateUniqueBrowserKey(db, ctx.tenantId, input.key ?? input.name, ctx.projectId);
-  const created = await db.createBrowser({
-    tenantId: ctx.tenantId,
-    projectId: ctx.projectId,
-    key,
-    name: input.name,
-    description: input.description,
-    status: input.status ?? 'active',
-    artifactBucketKey: input.artifactBucketKey,
-    defaultSessionConfig: input.defaultSessionConfig,
-    defaultModelKey: input.defaultModelKey,
-    defaultRunOptions: input.defaultRunOptions,
-    metadata: input.metadata,
-    createdBy: input.createdBy,
+  return runWithTenantScope(ctx.tenantDbName, async (db) => {
+    const key = await generateUniqueBrowserKey(db, ctx.tenantId, input.key ?? input.name, ctx.projectId);
+    const created = await db.createBrowser({
+      tenantId: ctx.tenantId,
+      projectId: ctx.projectId,
+      key,
+      name: input.name,
+      description: input.description,
+      status: input.status ?? 'active',
+      artifactBucketKey: input.artifactBucketKey,
+      defaultSessionConfig: input.defaultSessionConfig,
+      defaultModelKey: input.defaultModelKey,
+      defaultRunOptions: input.defaultRunOptions,
+      metadata: input.metadata,
+      createdBy: input.createdBy,
+    });
+    logger.info('Browser created', { browserId: created._id, key });
+    return serializeBrowser(created);
   });
-  logger.info('Browser created', { browserId: created._id, key });
-  return serializeBrowser(created);
 }
 
 export async function listBrowsers(


### PR DESCRIPTION
## Cause
Console CI runs [34148044715](https://github.com/Cognipeer/console/actions/runs/34148044715) and [34148123347](https://github.com/Cognipeer/console/actions/runs/34148123347) failed in the same browser integration test with `Browser flow not found: tenant-2-flow`. The failure predates the release handoff test PR and began with the browser background-run feature.

Browser creation and flow setup used bare `switchToTenant` calls. Under an inherited AsyncLocalStorage tenant context, tenant-2 records could be written through tenant-1's database handle, then correctly scoped tenant-2 reads could not find them.

## Changes
- Keep browser creation, flow creation, synchronous flow execution and background-run preparation inside `runWithTenantScope` for their full async operation.
- Reuse the already scoped database when resolving a flow during run preparation.
- Add actual Fastify handler tests for dashboard element description, background flow start and authoring step replay. This also closes the three new endpoint coverage gaps without adding baseline exceptions.

## Validation
- Browser flow integration with real temporary Chromium: 24/24 passed, including the formerly failing concurrent tenant test.
- Full Vitest suite: 333 files passed, one skipped; 5,159 tests passed, five skipped.
- Dashboard browser route tests: 3/3 passed.
- Endpoint authorization coverage gate: passed with no new uncovered routes.
- Full no-emit TypeScript check, scoped ESLint (zero errors; two existing `_enc` warnings), production Next build and `git diff --check`: passed.

No release, tag, registry operation or deployment was triggered.