### PR TITLE
docs(release): keep Community tags immutable

### DIFF
--- a/docs/guide/releasing.md
+++ b/docs/guide/releasing.md
@@ -29,6 +29,9 @@ The community build is tag-driven.
 - Run the normal validation set for the release candidate.
 - Create and push a tag in the format `vX.Y.Z-community`.
 - The community build workflow publishes from that tag.
+- Once pushed, a release tag is immutable. If its tagged workflow cannot be
+  recovered from that revision, merge the fix and advance to the next patch
+  version.
 
 Current trigger: `.github/workflows/build-community.yml` listens only for `vX.Y.Z-community` tags.
 
@@ -47,6 +50,8 @@ The public contract to remember is simple: enterprise SaaS must follow a release
 - Do not treat a release branch or PR as the release itself.
 - Do not assume enterprise SaaS will include community changes that only exist in a branch.
 - Do not cut the SaaS release first when it depends on community changes that are not tagged yet.
+- Do not delete, move, or reuse a failed release tag to pick up newer workflow
+  code.
 
 ## Minimal Checklist
 


### PR DESCRIPTION
## Summary
- document that pushed Community release tags are immutable
- require patch-forward recovery when tagged workflow code cannot be recovered
- explicitly prohibit deleting, moving, or reusing failed release tags

## Scope
Documentation only. No Community runtime, package version, build workflow, registry, deployment, or existing tag changes.

## Release purpose
After merge, this provides a new Community source commit that can be released as `v1.2.65-community`. The tag must be created through the normal release flow only after Console EE PR #166 is merged; `v1.2.64-community` and `v1.2.64-image` remain untouched.

## Validation
- Prettier check passed for `docs/guide/releasing.md`
- editor diagnostics and `git diff --check` passed
- full docs build is currently blocked by the pre-existing VitePress expression error at `docs/api/browser.md:104`, outside this PR